### PR TITLE
609 Update active dataset view

### DIFF
--- a/app/react-client-app/src/views/DatasetTbl.jsx
+++ b/app/react-client-app/src/views/DatasetTbl.jsx
@@ -169,8 +169,15 @@ const DatasetTbl = (props) => {
             <Flex>
                 <PageHeading text={title} />
                 <Spacer />
-                <Button variant="blue" mr="10px" onClick={goToActive}>Active Datasets</Button>
-                <Button variant="blue" onClick={goToArchived}>Archived Datasets</Button>
+                {title === "Active Datasets" ? (
+                    <Button variant="blue" onClick={goToArchived}>
+                        Archived Datasets
+                     </Button>
+                ) : (
+                    <Button variant="blue" mr="10px" onClick={goToActive}>
+                        Active Datasets
+                    </Button>
+                )}
             </Flex>
             <Center>
                 <Pagination

--- a/app/react-client-app/src/views/DatasetTbl.jsx
+++ b/app/react-client-app/src/views/DatasetTbl.jsx
@@ -169,15 +169,12 @@ const DatasetTbl = (props) => {
             <Flex>
                 <PageHeading text={title} />
                 <Spacer />
-                {title === "Active Datasets" ? (
-                    <Button variant="blue" onClick={goToArchived}>
-                        Archived Datasets
-                     </Button>
-                ) : (
-                    <Button variant="blue" mr="10px" onClick={goToActive}>
-                        Active Datasets
-                    </Button>
-                )}
+                <Button disabled={title === "Active Datasets"} variant="blue" mr="10px" onClick={goToActive}>
+                    Active Datasets
+                </Button>
+                <Button disabled={title === "Archived Datasets"} variant="blue" onClick={goToArchived}>
+                    Archived Datasets
+                 </Button>
             </Flex>
             <Center>
                 <Pagination


### PR DESCRIPTION
# Changes

This PR fixes which button should be active on the dataset view page depending on if it is active or archived datasets. Resolves #609

<img width="1393" alt="Screenshot 2024-02-28 at 15 28 20" src="https://github.com/Health-Informatics-UoN/CaRROT-Mapper/assets/94780632/8c2676d3-9348-4a4e-b2be-cd6312abf18b">

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.