### PR TITLE
Fix magic numbers

### DIFF
--- a/app/api/mapping/serializers.py
+++ b/app/api/mapping/serializers.py
@@ -1,43 +1,35 @@
-from rest_framework import serializers
-from rest_framework.exceptions import PermissionDenied, NotFound
-from drf_dynamic_fields import DynamicFieldsMixin
-from django.contrib.auth.models import User
 from data.models import (
     Concept,
-    Vocabulary,
-    ConceptRelationship,
     ConceptAncestor,
     ConceptClass,
+    ConceptRelationship,
     ConceptSynonym,
     Domain,
     DrugStrength,
+    Vocabulary,
 )
+from django.contrib.auth.models import User
+from drf_dynamic_fields import DynamicFieldsMixin
 from mapping.models import (
-    ScanReportField,
-    ScanReportValue,
-    ScanReport,
-    ScanReportTable,
-    ScanReportConcept,
     ClassificationSystem,
     DataDictionary,
     DataPartner,
+    Dataset,
+    MappingRule,
     OmopField,
     OmopTable,
-    MappingRule,
-    Dataset,
     Project,
+    ScanReport,
+    ScanReportConcept,
+    ScanReportField,
+    ScanReportTable,
+    ScanReportValue,
 )
+from rest_framework import serializers
+from rest_framework.exceptions import NotFound, PermissionDenied
 
-from .services_rules import (
-    analyse_concepts,
-    get_mapping_rules_json,
-)
-
-from .permissions import (
-    has_editorship,
-    is_admin,
-    is_az_function_user,
-)
+from .permissions import has_editorship, is_admin, is_az_function_user
+from .services_rules import analyse_concepts, get_mapping_rules_json
 
 
 class DataPartnerSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
@@ -132,7 +124,7 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
                 is_admin(self.instance, request) or is_az_function_user(request.user)
             ):
                 raise serializers.ValidationError(
-                    """You must be the author of the scan report or an admin of the parent dataset 
+                    """You must be the author of the scan report or an admin of the parent dataset
                     to change this field."""
                 )
         return author
@@ -143,7 +135,7 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
                 is_admin(self.instance, request) or is_az_function_user(request.user)
             ):
                 raise serializers.ValidationError(
-                    """You must be the author of the scan report or an admin of the parent dataset 
+                    """You must be the author of the scan report or an admin of the parent dataset
                     to change this field."""
                 )
         return viewers
@@ -154,7 +146,7 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
                 is_admin(self.instance, request) or is_az_function_user(request.user)
             ):
                 raise serializers.ValidationError(
-                    """You must be the author of the scan report or an admin of the parent dataset 
+                    """You must be the author of the scan report or an admin of the parent dataset
                     to change this field."""
                 )
         return editors
@@ -425,3 +417,18 @@ class GetRulesAnalysis(DynamicFieldsMixin, serializers.ModelSerializer):
     def to_representation(self, scan_report):
         analysis = analyse_concepts(scan_report.id)
         return analysis
+
+
+class ContentTypeSerializer(serializers.Serializer):
+    """
+    Serializes the content type name.
+
+    Args:
+        self: The instance of the class.
+
+    Attributes:
+        type_name: The serialized content type name.
+
+    """
+
+    type_name = serializers.CharField(max_length=100)

--- a/app/api/mapping/urls.py
+++ b/app/api/mapping/urls.py
@@ -136,6 +136,7 @@ routers.register(
 routers.register(r"analyse", views.AnalyseRules, basename="getanalysis")
 
 urlpatterns = [
+    path(r"api/contenttypeid", views.GetContentTypeID.as_view(), name="contenttypeid"),
     path(
         r"api/countprojects/<int:dataset>",
         views.CountProjects.as_view(),

--- a/app/api/mapping/views.py
+++ b/app/api/mapping/views.py
@@ -763,20 +763,19 @@ class ScanReportActiveConceptFilterViewSet(viewsets.ModelViewSet):
 
     serializer_class = ScanReportConceptSerializer
     filter_backends = [DjangoFilterBackend]
-    # filterset_fields = ["content_type"]
 
     def get_queryset(self):
         if self.request.user.username != os.getenv("AZ_FUNCTION_USER"):
             raise PermissionDenied(
                 "You do not have permission to access this resource."
             )
-        # TODO: This is a problem.
+
         content_type_str = self.request.GET["content_type"]
         content_type = ContentType.objects.get(model=content_type_str)
 
         if content_type_str == "scanreportfield":
             # ScanReportField
-            # we have SRCs with content_type 15, grab all SRFields in active SRs,
+            # we have SRCs of content_type "field", grab all SRFields in active SRs,
             # and then filter ScanReportConcepts by those object_ids
             field_ids = ScanReportField.objects.filter(
                 scan_report_table__scan_report__hidden=False,
@@ -788,7 +787,7 @@ class ScanReportActiveConceptFilterViewSet(viewsets.ModelViewSet):
             )
         elif content_type_str == "scanreportvalue":
             # ScanReportValue
-            # we have SRCs with content_type 17, grab all SRValues in active SRs,
+            # we have SRCs of content_type "value", grab all SRValues in active SRs,
             # and then filter ScanReportConcepts by those object_ids
             value_ids = ScanReportValue.objects.filter(
                 scan_report_field__scan_report_table__scan_report__hidden=False,
@@ -1147,9 +1146,6 @@ class ScanReportValuePKViewSet(viewsets.ModelViewSet):
 
 
 class GetContentTypeID(APIView):
-    """
-    TODO: Add documentation
-    """
 
     def get(self, request, *args, **kwargs):
         """

--- a/app/api/mapping/views.py
+++ b/app/api/mapping/views.py
@@ -692,10 +692,15 @@ class ScanReportConceptViewSet(viewsets.ModelViewSet):
     def create(self, request, *args, **kwargs):
         body = request.data
         if not isinstance(body, list):
+            # Extract the content_type
+            content_type_str = body.pop("content_type", None)
+            content_type = ContentType.objects.get(model=content_type_str)
+            body["content_type"] = content_type.id
+
             concept = ScanReportConcept.objects.filter(
                 concept=body["concept"],
                 object_id=body["object_id"],
-                content_type=body["content_type"],
+                content_type=content_type,
             )
             if concept.count() > 0:
                 print("Can't add multiple concepts of the same id to the same object")
@@ -713,10 +718,15 @@ class ScanReportConceptViewSet(viewsets.ModelViewSet):
             # this method may be quite slow as it has to wait for each query
             filtered = []
             for item in body:
+                # Extract the content_type
+                content_type_str = item.pop("content_type", None)
+                content_type = ContentType.objects.get(model=content_type_str)
+                item["content_type"] = content_type.id
+
                 concept = ScanReportConcept.objects.filter(
                     concept=item["concept"],
                     object_id=item["object_id"],
-                    content_type=item["content_type"],
+                    content_type=content_type,
                 )
                 if concept.count() == 0:
                     filtered.append(item)

--- a/app/react-client-app/src/api/values.js
+++ b/app/react-client-app/src/api/values.js
@@ -84,6 +84,16 @@ const useDelete = async (url) => {
   });
   return response;
 };
+
+/**
+ * Gets the Content Type ID for a given contentType
+ * @param {string} contentType to fetch
+ * @returns JSON { content_type_id: id }
+ */
+const getContentTypeId = async (contentType) => {
+  return await useGet(`/contenttypeid?type_name=${contentType}`);
+};
+
 // get scan report field with given id
 const getScanReportField = async (id) => {
   const field = await useGet(`/scanreportfields/${id}/`);
@@ -118,9 +128,7 @@ const getValuesScanReportConcepts = async (
   let scanreportconcepts = [].concat.apply([], promiseResult);
 
   // Get the content_type_id for the given content_type
-  const { content_type_id } = await useGet(
-    `/contenttypeid?type_name=${contentType}`,
-  );
+  const { content_type_id } = await getContentTypeId(contentType);
 
   // only keep the scanreport concepts that are of the correct content type
   scanreportconcepts = scanreportconcepts.filter(
@@ -288,11 +296,10 @@ const saveMappingRules = async (
   });
 
   // Get the content_type_id for the scan_report_field
-  const { scan_report_field_content_type_id } = await useGet(
-    "/contenttypeid?type_name=scanreportfield",
-  );
+  const { content_type_id } = await getContentTypeId("scanreportfield");
+
   // set source field depending on content type
-  if (scan_report_concept.content_type == scan_report_field_content_type_id) {
+  if (scan_report_concept.content_type == content_type_id) {
     data.source_field = scan_report_concept.object_id;
   } else {
     data.source_field = scan_report_value.scan_report_field;
@@ -450,6 +457,7 @@ export {
   useDelete,
   getScanReportFieldValues,
   chunkIds,
+  getContentTypeId,
   getScanReportField,
   getScanReportTable,
   mapConceptToOmopField,

--- a/app/react-client-app/src/api/values.js
+++ b/app/react-client-app/src/api/values.js
@@ -1,366 +1,462 @@
-import Cookies from 'js-cookie';
-import axios from 'axios';
-const m_allowed_tables = ['person','measurement','condition_occurrence','observation','drug_exposure','procedure_occurrence','specimen']
+import Cookies from "js-cookie";
+import axios from "axios";
+const m_allowed_tables = [
+  "person",
+  "measurement",
+  "condition_occurrence",
+  "observation",
+  "drug_exposure",
+  "procedure_occurrence",
+  "specimen",
+];
 
 // function to fetch from api with authorization token
-const useGet = async (url) =>{
-    const response = await fetch(`/api${url}`, 
-    {
-        method: "GET",
-        headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-            'X-CSRFToken': Cookies.get('csrftoken'),
-        }
-    }
-    );
-    if (response.status < 200 || response.status > 300) {
-        console.log(response)
-        throw response
-    }
-    const data = await response.json();
-    return data;
-}
+const useGet = async (url) => {
+  const response = await fetch(`/api${url}`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "X-CSRFToken": Cookies.get("csrftoken"),
+    },
+  });
+  if (response.status < 200 || response.status > 300) {
+    console.log(response);
+    throw response;
+  }
+  const data = await response.json();
+  return data;
+};
 // function for post requests to api with authorization token
-const usePost = async (url,data,withApi=true) =>{
-    const response = await axios.post(withApi?`/api${url}`:url,
-    data,
-    {    
-        headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-            'X-CSRFToken': Cookies.get('csrftoken'),
-        },  
-    }
-    );
-    if (response.status < 200 || response.status > 300) {
-        console.log(response)
-        throw response
-    }
-    const res = withApi? await response.data:response;
-    return res;
-}
-const postForm = async (url,data) =>{
-    const response = await fetch(url,
-    {
-        method: "POST",
-        headers: {
-            'X-CSRFToken': Cookies.get('csrftoken'),
-        },
-        body: data
-    }
-    );
-    
-    if (response.status < 200 || response.status > 300) {
-        const json = await response.json()
-        throw json
-    }
-    return response;
-}
+const usePost = async (url, data, withApi = true) => {
+  const response = await axios.post(withApi ? `/api${url}` : url, data, {
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "X-CSRFToken": Cookies.get("csrftoken"),
+    },
+  });
+  if (response.status < 200 || response.status > 300) {
+    console.log(response);
+    throw response;
+  }
+  const res = withApi ? await response.data : response;
+  return res;
+};
+const postForm = async (url, data) => {
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "X-CSRFToken": Cookies.get("csrftoken"),
+    },
+    body: data,
+  });
+
+  if (response.status < 200 || response.status > 300) {
+    const json = await response.json();
+    throw json;
+  }
+  return response;
+};
 // function for patch requests to api with authorization token
 const usePatch = async (url, body) => {
-    const response = await fetch(`/api${url}`,
-        {
-            method: "PATCH",
-            headers: {
-                'Content-Type': 'application/json; charset=utf-8',
-                'X-CSRFToken': Cookies.get('csrftoken'),
-            },
-            body: JSON.stringify(body)
-        }
-    );
-    if (response.status < 200 || response.status > 300) {
-        console.log(response)
-        throw response
-    }
-    const res = await response.json();
-    return res;
-}
+  const response = await fetch(`/api${url}`, {
+    method: "PATCH",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "X-CSRFToken": Cookies.get("csrftoken"),
+    },
+    body: JSON.stringify(body),
+  });
+  if (response.status < 200 || response.status > 300) {
+    console.log(response);
+    throw response;
+  }
+  const res = await response.json();
+  return res;
+};
 // function for delete requests to api with authorization token
 const useDelete = async (url) => {
-    const response = await fetch(`/api${url}`, {
-        method: "DELETE", 
-        headers: {
-            'Content-Type': 'application/json; charset=utf-8',
-            'X-CSRFToken': Cookies.get('csrftoken'),
-    }
-});
-    return response;
-}
+  const response = await fetch(`/api${url}`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json; charset=utf-8",
+      "X-CSRFToken": Cookies.get("csrftoken"),
+    },
+  });
+  return response;
+};
 // get scan report field with given id
-const getScanReportField = async (id)=>{
-    const field = await useGet(`/scanreportfields/${id}/`)
-    return field
-}
+const getScanReportField = async (id) => {
+  const field = await useGet(`/scanreportfields/${id}/`);
+  return field;
+};
 // get scan report table with given id
-const getScanReportTable = async (id)=>{
-    const table = await useGet(`/scanreporttables/${id}/`)
-    return table
-}
+const getScanReportTable = async (id) => {
+  const table = await useGet(`/scanreporttables/${id}/`);
+  return table;
+};
 // get concepts for a specific scan report
 const getScanReportConcepts = async (id) => {
-    const response = await useGet(`/scanreportconceptsfilter/?object_id=${id}`)
-    return response;
-}
+  const response = await useGet(`/scanreportconceptsfilter/?object_id=${id}`);
+  return response;
+};
 // get scan report concepts for all specified values
-const getValuesScanReportConcepts = async (values,contentType,scanReportsRef={},setScanReports=()=>{}) => {
-    // create array of ids and use them to batch query for ScanReportConcepts associated to those id's
-    const valueIds = chunkIds(values.map(value => value.id))
-    const valuePromises = []
-    for (let i = 0; i < valueIds.length; i++) {
-        valuePromises.push(useGet(`/scanreportconceptsfilter/?object_id__in=${valueIds[i].join()}`))
-    }
-    const promiseResult = await Promise.all(valuePromises)
-    let scanreportconcepts = [].concat.apply([], promiseResult)
-    // only keep the scanreport concepts that are of the correct content type
-    scanreportconcepts = scanreportconcepts.filter(concept=>concept.content_type==contentType)
-    // if there are no scanreport concepts to map, return
-    if (scanreportconcepts.length == 0) {
-        values = values.map(element => ({ ...element, conceptsLoaded: true, concepts: [] }))
-        scanReportsRef.current = values
-        return values
-    }
-    // create a list of unique omop concept id's from scanreportconcepts.  and use them to make a batch call to the api
-    const conceptIdsObject = {}
-    // TODO: dedent this
-    // conceptIdsObject will be a map from concept to object_id for each element in scanreportconcepts
-        scanreportconcepts.map(value => {
-            if (value.concept) {
-                if (conceptIdsObject[value.concept]) {
-                    conceptIdsObject[value.concept].push(value.object_id)
-                }
-                else {
-                    conceptIdsObject[value.concept] = [value.object_id]
-                }
-            }
-        })
-        // indicate that concepts are loaded for all values that have no concepts to be mapped to them
-        values = values.map((scanReport) => Object.values(conceptIdsObject).find(arr => arr.includes(scanReport.id)) ?
-                            scanReport : { ...scanReport, conceptsLoaded: true })
-        scanReportsRef.current = values
-        setScanReports(scanReportsRef.current)
+const getValuesScanReportConcepts = async (
+  values,
+  contentType,
+  scanReportsRef = {},
+  setScanReports = () => {},
+) => {
+  // create array of ids and use them to batch query for ScanReportConcepts associated to those id's
+  const valueIds = chunkIds(values.map((value) => value.id));
+  const valuePromises = [];
+  for (let i = 0; i < valueIds.length; i++) {
+    valuePromises.push(
+      useGet(`/scanreportconceptsfilter/?object_id__in=${valueIds[i].join()}`),
+    );
+  }
+  const promiseResult = await Promise.all(valuePromises);
+  let scanreportconcepts = [].concat.apply([], promiseResult);
 
-        // This is chunking the .concepts from the values.
-        const conceptIds = chunkIds(Object.keys(conceptIdsObject))
-        // make batch call with unique concept ids. Get all Concepts with the given concept_ids, and save to omopConcepts.
-        const conceptPromises = []
-        for (let i = 0; i < conceptIds.length; i++) {
-            conceptPromises.push(useGet(`/omop/conceptsfilter/?concept_id__in=${conceptIds[i].join()}`))
-        }
-        const conceptPromiseResults = await Promise.all(conceptPromises)
-        const omopConcepts = [].concat.apply([], conceptPromiseResults)
+  // Get the content_type_id for the given content_type
+  const { content_type_id } = await useGet(
+    `/contenttypeid?type_name=${contentType}`,
+  );
 
-        scanreportconcepts = scanreportconcepts.map(element => ({ ...element, concept: omopConcepts.find(con => con.concept_id == element.concept) }))
-        // map each scanreport concept to it's value
-        values = values.map(element => ({ ...element, conceptsLoaded: true, concepts: scanreportconcepts.filter(concept => concept.object_id == element.id) }))
-        scanReportsRef.current = values
-        setScanReports(scanReportsRef.current)
-        return values
-}
+  // only keep the scanreport concepts that are of the correct content type
+  scanreportconcepts = scanreportconcepts.filter(
+    (concept) => concept.content_type == content_type_id,
+  );
+  // if there are no scanreport concepts to map, return
+  if (scanreportconcepts.length == 0) {
+    values = values.map((element) => ({
+      ...element,
+      conceptsLoaded: true,
+      concepts: [],
+    }));
+    scanReportsRef.current = values;
+    return values;
+  }
+  // create a list of unique omop concept id's from scanreportconcepts.  and use them to make a batch call to the api
+  const conceptIdsObject = {};
+  // TODO: dedent this
+  // conceptIdsObject will be a map from concept to object_id for each element in scanreportconcepts
+  scanreportconcepts.map((value) => {
+    if (value.concept) {
+      if (conceptIdsObject[value.concept]) {
+        conceptIdsObject[value.concept].push(value.object_id);
+      } else {
+        conceptIdsObject[value.concept] = [value.object_id];
+      }
+    }
+  });
+  // indicate that concepts are loaded for all values that have no concepts to be mapped to them
+  values = values.map((scanReport) =>
+    Object.values(conceptIdsObject).find((arr) => arr.includes(scanReport.id))
+      ? scanReport
+      : { ...scanReport, conceptsLoaded: true },
+  );
+  scanReportsRef.current = values;
+  setScanReports(scanReportsRef.current);
+
+  // This is chunking the .concepts from the values.
+  const conceptIds = chunkIds(Object.keys(conceptIdsObject));
+  // make batch call with unique concept ids. Get all Concepts with the given concept_ids, and save to omopConcepts.
+  const conceptPromises = [];
+  for (let i = 0; i < conceptIds.length; i++) {
+    conceptPromises.push(
+      useGet(`/omop/conceptsfilter/?concept_id__in=${conceptIds[i].join()}`),
+    );
+  }
+  const conceptPromiseResults = await Promise.all(conceptPromises);
+  const omopConcepts = [].concat.apply([], conceptPromiseResults);
+
+  scanreportconcepts = scanreportconcepts.map((element) => ({
+    ...element,
+    concept: omopConcepts.find((con) => con.concept_id == element.concept),
+  }));
+  // map each scanreport concept to it's value
+  values = values.map((element) => ({
+    ...element,
+    conceptsLoaded: true,
+    concepts: scanreportconcepts.filter(
+      (concept) => concept.object_id == element.id,
+    ),
+  }));
+  scanReportsRef.current = values;
+  setScanReports(scanReportsRef.current);
+  return values;
+};
 
 // get scan report values for a specific field id
-const getScanReports = async (valueId, setScanReports, scanReportsRef, setLoadingMessage, setError) => {
-    // query endpoint for field values
-    let values = await useGet(`/scanreportvalues/?scan_report_field=${valueId}`)
-    if (!Array.isArray(values)) {
-        setError(true)
-        return
-    }
-    // if there are values for this table then sort them and get any concepts associated to them
-    if (values.length > 0) {
-        values = values.sort((a, b) => (a.id > b.id) ? 1 : ((b.id > a.id) ? -1 : 0))
-        values = values.map(scanReport => ({ ...scanReport, concepts: [], conceptsLoaded: false }))
-        scanReportsRef.current = values
-        setScanReports(scanReportsRef.current)
-        values = await getValuesScanReportConcepts(values,17,scanReportsRef,setScanReports)
-        setScanReports(scanReportsRef.current)
-        return values
-    }
-    else {
-        // return if there are no scan reports
-        scanReportsRef.current = [undefined]
-        setScanReports([undefined])
-    }
-}
+const getScanReports = async (
+  valueId,
+  setScanReports,
+  scanReportsRef,
+  setLoadingMessage,
+  setError,
+) => {
+  // query endpoint for field values
+  let values = await useGet(`/scanreportvalues/?scan_report_field=${valueId}`);
+  if (!Array.isArray(values)) {
+    setError(true);
+    return;
+  }
+  // if there are values for this table then sort them and get any concepts associated to them
+  if (values.length > 0) {
+    values = values.sort((a, b) => (a.id > b.id ? 1 : b.id > a.id ? -1 : 0));
+    values = values.map((scanReport) => ({
+      ...scanReport,
+      concepts: [],
+      conceptsLoaded: false,
+    }));
+    scanReportsRef.current = values;
+    setScanReports(scanReportsRef.current);
+    values = await getValuesScanReportConcepts(
+      values,
+      "scanreportvalue",
+      scanReportsRef,
+      setScanReports,
+    );
+    setScanReports(scanReportsRef.current);
+    return values;
+  } else {
+    // return if there are no scan reports
+    scanReportsRef.current = [undefined];
+    setScanReports([undefined]);
+  }
+};
 
 // function to save mapping rules copying python implementation
-const saveMappingRules = async (scan_report_concept,scan_report_value,table) => {
-    const domain = scan_report_concept.concept.domain_id.toLowerCase()
-    const fields = await useGet(`/omopfields/`)
-    const cachedOmopFunction = mapConceptToOmopField()
-    const m_date_field_mapper = {
-        'person': ['birth_datetime'],
-        'condition_occurrence': ['condition_start_datetime','condition_end_datetime'],
-        'measurement': ['measurement_datetime'],
-        'observation': ['observation_datetime'],
-        'drug_exposure': ['drug_exposure_start_datetime','drug_exposure_end_datetime'],
-        'procedure_occurrence': ['procedure_datetime'],
-        'specimen': ['specimen_datetime']
-        }
-    const destination_field = await cachedOmopFunction(fields,domain+"_source_concept_id")
-    // if a destination field can't be found for concept domain, return error
-    if(destination_field == undefined){
-        throw 'Could not find a destination field for this concept'
-    }
-    // create a list to populate with requests for each structural mapping rule to be created
-    const promises = []
-    // data object to be passed to post request to create mapping rule
-    const data = 
-    {
-        scan_report:table.scan_report,
-        concept: scan_report_concept.id, 
-        approved: true,
-        creation_type: "M",
-    }
-    // create mapping rule for the following
-    //person_id
-    data.omop_field = fields.filter(field=> field.field == "person_id" && field.table==destination_field.table)[0].id
-    data.source_field = table.person_id
-    promises.push(usePost(`/mappingrules/`,data))
-    //date_event
-    data.source_field = table.date_event
-    const omopTable = await useGet(`/omoptables/${destination_field.table}/`)
-    const date_omop_fields = m_date_field_mapper[omopTable.table]
-    date_omop_fields.forEach(element => {
-        data.omop_field = fields.filter(field=> field.field == element && field.table==destination_field.table)[0].id
-        promises.push(usePost(`/mappingrules/`,data))
-    })
-    // set source field depending on content type
-    if(scan_report_concept.content_type==15){
-        data.source_field = scan_report_concept.object_id 
-    }
-    else{
-        data.source_field = scan_report_value.scan_report_field
-    }
-    //_source_concept_id
-    data.omop_field = destination_field.id
-    promises.push(usePost(`/mappingrules/`,data))
-    //_concept_id
-    let tempOmopField = await cachedOmopFunction(fields,domain+"_concept_id")
-    data.omop_field = tempOmopField.id
-    promises.push(usePost(`/mappingrules/`,data))
-    //_source_value
-    tempOmopField = await cachedOmopFunction(fields,domain+"_source_value")
-    data.omop_field = tempOmopField.id
-    promises.push(usePost(`/mappingrules/`,data))
-    //measurement
-    if(domain == 'measurement'){
-        tempOmopField = await cachedOmopFunction(fields,"value_as_number","measurement")
-        data.omop_field = tempOmopField.id
-        promises.push(usePost(`/mappingrules/`,data))
-    }  
-    // when all requests have finished, return
-    const values = await Promise.all(promises)
-    return values
-}
+const saveMappingRules = async (
+  scan_report_concept,
+  scan_report_value,
+  table,
+) => {
+  const domain = scan_report_concept.concept.domain_id.toLowerCase();
+  const fields = await useGet(`/omopfields/`);
+  const cachedOmopFunction = mapConceptToOmopField();
+  const m_date_field_mapper = {
+    person: ["birth_datetime"],
+    condition_occurrence: [
+      "condition_start_datetime",
+      "condition_end_datetime",
+    ],
+    measurement: ["measurement_datetime"],
+    observation: ["observation_datetime"],
+    drug_exposure: [
+      "drug_exposure_start_datetime",
+      "drug_exposure_end_datetime",
+    ],
+    procedure_occurrence: ["procedure_datetime"],
+    specimen: ["specimen_datetime"],
+  };
+  const destination_field = await cachedOmopFunction(
+    fields,
+    domain + "_source_concept_id",
+  );
+  // if a destination field can't be found for concept domain, return error
+  if (destination_field == undefined) {
+    throw "Could not find a destination field for this concept";
+  }
+  // create a list to populate with requests for each structural mapping rule to be created
+  const promises = [];
+  // data object to be passed to post request to create mapping rule
+  const data = {
+    scan_report: table.scan_report,
+    concept: scan_report_concept.id,
+    approved: true,
+    creation_type: "M",
+  };
+  // create mapping rule for the following
+  //person_id
+  data.omop_field = fields.filter(
+    (field) =>
+      field.field == "person_id" && field.table == destination_field.table,
+  )[0].id;
+  data.source_field = table.person_id;
+  promises.push(usePost(`/mappingrules/`, data));
+  //date_event
+  data.source_field = table.date_event;
+  const omopTable = await useGet(`/omoptables/${destination_field.table}/`);
+  const date_omop_fields = m_date_field_mapper[omopTable.table];
+  date_omop_fields.forEach((element) => {
+    data.omop_field = fields.filter(
+      (field) =>
+        field.field == element && field.table == destination_field.table,
+    )[0].id;
+    promises.push(usePost(`/mappingrules/`, data));
+  });
+
+  // Get the content_type_id for the scan_report_field
+  const { scan_report_field_content_type_id } = await useGet(
+    "/contenttypeid?type_name=scanreportfield",
+  );
+  // set source field depending on content type
+  if (scan_report_concept.content_type == scan_report_field_content_type_id) {
+    data.source_field = scan_report_concept.object_id;
+  } else {
+    data.source_field = scan_report_value.scan_report_field;
+  }
+  //_source_concept_id
+  data.omop_field = destination_field.id;
+  promises.push(usePost(`/mappingrules/`, data));
+  //_concept_id
+  let tempOmopField = await cachedOmopFunction(fields, domain + "_concept_id");
+  data.omop_field = tempOmopField.id;
+  promises.push(usePost(`/mappingrules/`, data));
+  //_source_value
+  tempOmopField = await cachedOmopFunction(fields, domain + "_source_value");
+  data.omop_field = tempOmopField.id;
+  promises.push(usePost(`/mappingrules/`, data));
+  //measurement
+  if (domain == "measurement") {
+    tempOmopField = await cachedOmopFunction(
+      fields,
+      "value_as_number",
+      "measurement",
+    );
+    data.omop_field = tempOmopField.id;
+    promises.push(usePost(`/mappingrules/`, data));
+  }
+  // when all requests have finished, return
+  const values = await Promise.all(promises);
+  return values;
+};
 //function to map concept domain to an omop field
-const mapConceptToOmopField = () =>{
-    // cached values
-    let omopTables = null
-    
-    // mapping function which is returned by this function
-    return async (fields,domain,table) =>{
-        //if omop table is not specified
-        if(!table){
-            // get omop fields that match specified domain
-            const mappedFields = fields.filter(field=> field.field == domain)
-            if(mappedFields.length<2){
-                return mappedFields[0]
-            }
-            // if there are more than 1 fields that match the domain
-            // if omopTables hasn't previously been retrieved retreive it, otherwise, use cached version
-            if(!omopTables){
-                omopTables = await useGet(`/omoptables/`)
-            } 
-            // find correct field to return
-            let mappedTables = mappedFields.map(field=> (
-                {
-                table:omopTables.find(t=>t.id == field.table),
-                field:field
-                }))
-            mappedTables = mappedTables.map(val=>({...val,isAllowed:m_allowed_tables.includes(val.table.table)})) 
-            return mappedTables.find(val=> val.isAllowed==true).field
-        }
-        if(!omopTables){
-            omopTables = await useGet(`/omoptables/`)
-        } 
-        // find omop field with specified table and domain
-        let mappedTable = omopTables.find(t=>t.table == table)
-        const mappedField = fields.find(f=> f.table == mappedTable.id && f.field==domain)
-        return mappedField
+const mapConceptToOmopField = () => {
+  // cached values
+  let omopTables = null;
+
+  // mapping function which is returned by this function
+  return async (fields, domain, table) => {
+    //if omop table is not specified
+    if (!table) {
+      // get omop fields that match specified domain
+      const mappedFields = fields.filter((field) => field.field == domain);
+      if (mappedFields.length < 2) {
+        return mappedFields[0];
+      }
+      // if there are more than 1 fields that match the domain
+      // if omopTables hasn't previously been retrieved retreive it, otherwise, use cached version
+      if (!omopTables) {
+        omopTables = await useGet(`/omoptables/`);
+      }
+      // find correct field to return
+      let mappedTables = mappedFields.map((field) => ({
+        table: omopTables.find((t) => t.id == field.table),
+        field: field,
+      }));
+      mappedTables = mappedTables.map((val) => ({
+        ...val,
+        isAllowed: m_allowed_tables.includes(val.table.table),
+      }));
+      return mappedTables.find((val) => val.isAllowed == true).field;
     }
-}
+    if (!omopTables) {
+      omopTables = await useGet(`/omoptables/`);
+    }
+    // find omop field with specified table and domain
+    let mappedTable = omopTables.find((t) => t.table == table);
+    const mappedField = fields.find(
+      (f) => f.table == mappedTable.id && f.field == domain,
+    );
+    return mappedField;
+  };
+};
 
 // function to turn list of ids into a set of sublists of id's who's total length does not exceed a limit
 const chunkIds = (list) => {
-    const chunkedList = [[]]
+  const chunkedList = [[]];
 
-    let maxChars = 2000
-    let currentChars = 80
-    list.map(async (value, index) => {
-        const digits = value.toString().length
-        if (currentChars + digits > maxChars - 20) {
-            currentChars = 80 + digits
-            chunkedList.push([])
-            chunkedList[chunkedList.length - 1].push(value)
-        }
-        else {
-            currentChars = currentChars + digits
-            chunkedList[chunkedList.length - 1].push(value)
-        }
-    })
-    if(chunkedList[0].length == 0){
-        return []
+  let maxChars = 2000;
+  let currentChars = 80;
+  list.map(async (value, index) => {
+    const digits = value.toString().length;
+    if (currentChars + digits > maxChars - 20) {
+      currentChars = 80 + digits;
+      chunkedList.push([]);
+      chunkedList[chunkedList.length - 1].push(value);
+    } else {
+      currentChars = currentChars + digits;
+      chunkedList[chunkedList.length - 1].push(value);
     }
-    return chunkedList
-}
+  });
+  if (chunkedList[0].length == 0) {
+    return [];
+  }
+  return chunkedList;
+};
 // get field values for a given table id and map any scanreport concepts that are associated
 const getScanReportFieldValues = async (valueId, valuesRef) => {
-    let response = await useGet(`/scanreportfields/?scan_report_table=${valueId}`)
-    response = response.sort((a, b) => (a.id > b.id) ? 1 : ((b.id > a.id) ? -1 : 0))
-    if (response.length == 0) {
-        return []
-    }
-    response = await getValuesScanReportConcepts(response,15,valuesRef)
-    return response
-}
+  let response = await useGet(
+    `/scanreportfields/?scan_report_table=${valueId}`,
+  );
+  response = response.sort((a, b) => (a.id > b.id ? 1 : b.id > a.id ? -1 : 0));
+  if (response.length == 0) {
+    return [];
+  }
+  response = await getValuesScanReportConcepts(
+    response,
+    "scanreportfield",
+    valuesRef,
+  );
+  return response;
+};
 
-const getScanReportTableRows = async (id) =>{
-    // get table rows
-    let table = await useGet(`/scanreporttables/?scan_report=${id}`)
-    // if table is empty then return
-    if(table.length==0){
-        return []
+const getScanReportTableRows = async (id) => {
+  // get table rows
+  let table = await useGet(`/scanreporttables/?scan_report=${id}`);
+  // if table is empty then return
+  if (table.length == 0) {
+    return [];
+  }
+  // sort table
+  table = table.sort((a, b) => (a.id > b.id ? 1 : b.id > a.id ? -1 : 0));
+  // get ids of scanroport fields that need to be retrieved and do a batch call
+  const fieldIdsObject = {};
+  table.map((element) => {
+    if (element.person_id) {
+      fieldIdsObject[element.person_id] = true;
     }
-    // sort table
-    table = table.sort((a,b) => (a.id > b.id) ? 1 : ((b.id > a.id) ? -1 :0))
-    // get ids of scanroport fields that need to be retrieved and do a batch call
-    const fieldIdsObject = {}
-    table.map(element=>{   
-        if(element.person_id){
-            fieldIdsObject[element.person_id] = true
-        }
-        if(element.date_event){
-            fieldIdsObject[element.date_event] = true
-        }
-                    
-    })
-    if(Object.keys(fieldIdsObject).length == 0){
-        return table
+    if (element.date_event) {
+      fieldIdsObject[element.date_event] = true;
     }
-    const fieldIds = chunkIds(Object.keys(fieldIdsObject))
-    const promises = []
-    // send API request for every sublist
-    for (let i = 0; i < fieldIds.length; i++) {
-        promises.push(useGet(`/scanreportfields/?id__in=${fieldIds[i].join()}&fields=id,name`))
-    }
-    const promiseResult = await Promise.all(promises)
-    const fields = [].concat.apply([], promiseResult)
-    table = table.map(value=>({...value,person_id:fields.find(field=>field.id==value.person_id),date_event:fields.find(field=>field.id==value.date_event)}))
-    return table
-}
+  });
+  if (Object.keys(fieldIdsObject).length == 0) {
+    return table;
+  }
+  const fieldIds = chunkIds(Object.keys(fieldIdsObject));
+  const promises = [];
+  // send API request for every sublist
+  for (let i = 0; i < fieldIds.length; i++) {
+    promises.push(
+      useGet(`/scanreportfields/?id__in=${fieldIds[i].join()}&fields=id,name`),
+    );
+  }
+  const promiseResult = await Promise.all(promises);
+  const fields = [].concat.apply([], promiseResult);
+  table = table.map((value) => ({
+    ...value,
+    person_id: fields.find((field) => field.id == value.person_id),
+    date_event: fields.find((field) => field.id == value.date_event),
+  }));
+  return table;
+};
 
-
-
-export { saveMappingRules,useGet,usePost,useDelete,getScanReportFieldValues,chunkIds,
-     getScanReportField,getScanReportTable,mapConceptToOmopField,m_allowed_tables,
-     getScanReportConcepts,getScanReports,getScanReportTableRows,usePatch,postForm
-     }
+export {
+  saveMappingRules,
+  useGet,
+  usePost,
+  useDelete,
+  getScanReportFieldValues,
+  chunkIds,
+  getScanReportField,
+  getScanReportTable,
+  mapConceptToOmopField,
+  m_allowed_tables,
+  getScanReportConcepts,
+  getScanReports,
+  getScanReportTableRows,
+  usePatch,
+  postForm,
+};

--- a/app/react-client-app/src/components/AnalysisTbl.jsx
+++ b/app/react-client-app/src/components/AnalysisTbl.jsx
@@ -1,80 +1,185 @@
-import React from 'react'
-import {
-    Flex,
-    Link,
-    Grid,
-    Text,
-    GridItem,
-} from "@chakra-ui/react"
+import React, { useState, useEffect } from "react";
+import { Flex, Link, Grid, Text, GridItem } from "@chakra-ui/react";
+import { getContentTypeId } from "../api/values";
 const truncate = (str) => {
-    return str.length > 20 ? str.substring(0, 20) + "..." : str;
-}
+  return str.length > 20 ? str.substring(0, 20) + "..." : str;
+};
 function AnalysisTbl({ data }) {
+  const [contentTypeId, setContentTypeId] = useState(null);
 
-    return (
-        <Grid templateColumns="repeat(4, 1fr)" gap={6} >
+  useEffect(() => {
+    const fetchContentTypeId = async () => {
+      const { content_type_id } = await getContentTypeId("scanreportfield");
+      setContentTypeId(content_type_id);
+    };
 
-            <Text fontWeight={"bold"}>Concept ID</Text>
-            <Text fontWeight={"bold"}>
-                <span style={{ color: "#475da7" }}>Ancestors</span> /
-                <span style={{ color: "#3db28c" }}> Descendants</span>
-            </Text>
-            <Text fontWeight={"bold"} textAlignVertical={"center"} textAlign={"center"}>Min/Max Separation</Text>
-            <Text fontWeight={"bold"}>Source</Text>
+    fetchContentTypeId();
+  }, []);
 
+  if (!contentTypeId) {
+    return <div>Loading...</div>;
+  }
 
-            {
-                (data).length > 0 ?
-                    data.map((item, index) =>
-                        <GridItem colSpan={4} w={"100%"} bg={index % 2 == 0 ? 'greyBasic.100' : 'greyBasic.500'} >
-                            <Grid templateColumns="repeat(4, 1fr)">
-                                <Text>{item.rule_id} - {item.rule_name}</Text>
-                                <GridItem colSpan={3} >
-                                    {item.anc_desc.map((element) =>
-                                        <Grid templateColumns="repeat(3, 1fr)">
-                                            {element.ancestors.map(ancestor =>
-                                                <>
-                                                    <Text style={{ color: "#475da7" }}> {ancestor.a_id} - {ancestor.a_name} (A)</Text>
-                                                    <Text style={{ color: "#475da7", textAlignVertical: "center", textAlign: "center" }}> {ancestor.level} </Text>
-                                                    <div style={{ alignSelf: 'flex-start' }}>
-                                                        {ancestor.source.map(source_id => {
+  return (
+    <Grid templateColumns="repeat(4, 1fr)" gap={6}>
+      <Text fontWeight={"bold"}>Concept ID</Text>
+      <Text fontWeight={"bold"}>
+        <span style={{ color: "#475da7" }}>Ancestors</span> /
+        <span style={{ color: "#3db28c" }}> Descendants</span>
+      </Text>
+      <Text
+        fontWeight={"bold"}
+        textAlignVertical={"center"}
+        textAlign={"center"}
+      >
+        Min/Max Separation
+      </Text>
+      <Text fontWeight={"bold"}>Source</Text>
 
-                                                            if (source_id.concept__content_type == 15)
-                                                                return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={`/scanreports/${source_id.source_field__scan_report_table__scan_report}/tables/${source_id.source_field__scan_report_table__id}/`}> {truncate(source_id.source_field__name)} </Link> </Text>
-                                                            return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}> <Link style={{ color: "#0000FF" }} href={`/scanreports/${source_id.source_field__scan_report_table__scan_report}/tables/${source_id.source_field__scan_report_table__id}/fields/${source_id.source_field__id}/`} > {truncate(source_id.source_field__name)} </Link></Text>
-                                                        })}
-                                                    </div>
+      {data.length > 0 ? (
+        data.map((item, index) => (
+          <GridItem
+            colSpan={4}
+            w={"100%"}
+            bg={index % 2 == 0 ? "greyBasic.100" : "greyBasic.500"}
+          >
+            <Grid templateColumns="repeat(4, 1fr)">
+              <Text>
+                {item.rule_id} - {item.rule_name}
+              </Text>
+              <GridItem colSpan={3}>
+                {item.anc_desc.map((element) => (
+                  <Grid templateColumns="repeat(3, 1fr)">
+                    {element.ancestors.map((ancestor) => (
+                      <>
+                        <Text style={{ color: "#475da7" }}>
+                          {" "}
+                          {ancestor.a_id} - {ancestor.a_name} (A)
+                        </Text>
+                        <Text
+                          style={{
+                            color: "#475da7",
+                            textAlignVertical: "center",
+                            textAlign: "center",
+                          }}
+                        >
+                          {" "}
+                          {ancestor.level}{" "}
+                        </Text>
+                        <div style={{ alignSelf: "flex-start" }}>
+                          {ancestor.source.map((source_id) => {
+                            if (
+                              source_id.concept__content_type == contentTypeId
+                            )
+                              return (
+                                <Text
+                                  maxWidth={"200px"}
+                                  title={source_id.source_field__name}
+                                  sx={{ m: 1 }}
+                                >
+                                  <Link
+                                    style={{ color: "#0000FF" }}
+                                    href={`/scanreports/${source_id.source_field__scan_report_table__scan_report}/tables/${source_id.source_field__scan_report_table__id}/`}
+                                  >
+                                    {" "}
+                                    {truncate(
+                                      source_id.source_field__name,
+                                    )}{" "}
+                                  </Link>{" "}
+                                </Text>
+                              );
+                            return (
+                              <Text
+                                maxWidth={"200px"}
+                                title={source_id.source_field__name}
+                                sx={{ m: 1 }}
+                              >
+                                {" "}
+                                <Link
+                                  style={{ color: "#0000FF" }}
+                                  href={`/scanreports/${source_id.source_field__scan_report_table__scan_report}/tables/${source_id.source_field__scan_report_table__id}/fields/${source_id.source_field__id}/`}
+                                >
+                                  {" "}
+                                  {truncate(source_id.source_field__name)}{" "}
+                                </Link>
+                              </Text>
+                            );
+                          })}
+                        </div>
+                      </>
+                    ))}
 
-                                                </>
-                                            )}
-
-                                            {element.descendants.map(descendant =>
-                                                <>
-                                                    <Text style={{ color: "#3db28c" }} > {descendant.d_id} - {descendant.d_name} (D)</Text>
-                                                    <div style={{ color: "#3db28c", textAlignVertical: "center", textAlign: "center" }} > {descendant.level}</div>
-                                                    <div style={{ alignSelf: 'flex-start' }}>
-                                                        {descendant.source.map(source_id => {
-
-                                                            if (source_id.concept__content_type == 15)
-                                                                return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={`/scanreports/${source_id.source_field__scan_report_table__scan_report}/tables/${source_id.source_field__scan_report_table__id}/`}> {source_id.source_field__name} </Link></Text>
-                                                            return <Text maxWidth={"200px"} title={source_id.source_field__name} sx={{ m: 1 }}><Link style={{ color: "#0000FF", }} href={`/scanreports/${source_id.source_field__scan_report_table__scan_report}/tables/${source_id.source_field__scan_report_table__id}/fields/${source_id.source_field__id}/`}> {source_id.source_field__name} </Link></Text>
-                                                        })}
-                                                    </div>
-                                                </>
-
-                                            )}
-                                        </Grid>
-                                    )}
-                                </GridItem>
-                            </Grid>
-                        </GridItem >
-                    ) :
-                    <Flex padding="30px">
-                        <Flex marginLeft="10px">No ancestors or descendants of these mappings appear in any other Scan Reports</Flex>
-                    </Flex>
-            }
-        </Grid >
-    )
+                    {element.descendants.map((descendant) => (
+                      <>
+                        <Text style={{ color: "#3db28c" }}>
+                          {" "}
+                          {descendant.d_id} - {descendant.d_name} (D)
+                        </Text>
+                        <div
+                          style={{
+                            color: "#3db28c",
+                            textAlignVertical: "center",
+                            textAlign: "center",
+                          }}
+                        >
+                          {" "}
+                          {descendant.level}
+                        </div>
+                        <div style={{ alignSelf: "flex-start" }}>
+                          {descendant.source.map((source_id) => {
+                            if (
+                              source_id.concept__content_type == contentTypeId
+                            )
+                              return (
+                                <Text
+                                  maxWidth={"200px"}
+                                  title={source_id.source_field__name}
+                                  sx={{ m: 1 }}
+                                >
+                                  <Link
+                                    style={{ color: "#0000FF" }}
+                                    href={`/scanreports/${source_id.source_field__scan_report_table__scan_report}/tables/${source_id.source_field__scan_report_table__id}/`}
+                                  >
+                                    {" "}
+                                    {source_id.source_field__name}{" "}
+                                  </Link>
+                                </Text>
+                              );
+                            return (
+                              <Text
+                                maxWidth={"200px"}
+                                title={source_id.source_field__name}
+                                sx={{ m: 1 }}
+                              >
+                                <Link
+                                  style={{ color: "#0000FF" }}
+                                  href={`/scanreports/${source_id.source_field__scan_report_table__scan_report}/tables/${source_id.source_field__scan_report_table__id}/fields/${source_id.source_field__id}/`}
+                                >
+                                  {" "}
+                                  {source_id.source_field__name}{" "}
+                                </Link>
+                              </Text>
+                            );
+                          })}
+                        </div>
+                      </>
+                    ))}
+                  </Grid>
+                ))}
+              </GridItem>
+            </Grid>
+          </GridItem>
+        ))
+      ) : (
+        <Flex padding="30px">
+          <Flex marginLeft="10px">
+            No ancestors or descendants of these mappings appear in any other
+            Scan Reports
+          </Flex>
+        </Flex>
+      )}
+    </Grid>
+  );
 }
 
 export default AnalysisTbl;

--- a/app/react-client-app/src/components/FieldsTbl.jsx
+++ b/app/react-client-app/src/components/FieldsTbl.jsx
@@ -1,226 +1,311 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef } from "react";
 import {
-    Button,
-    Table,
-    Thead,
-    Tbody,
-    Tr,
-    Th,
-    Td,
-    TableCaption,
-    Text,
-    HStack,
-    VStack,
-    Flex,
-    Spinner,
-    ScaleFade,
-    Input,
-    Link,
-    useDisclosure,
+  Button,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableCaption,
+  Text,
+  HStack,
+  VStack,
+  Flex,
+  Spinner,
+  ScaleFade,
+  Input,
+  Link,
+  useDisclosure,
+} from "@chakra-ui/react";
 
-} from "@chakra-ui/react"
-
-import { Formik, Form, } from 'formik'
-import { getScanReportTable, getScanReportFieldValues, useGet } from '../api/values'
-import ConceptTag from './ConceptTag'
-import ToastAlert from './ToastAlert'
-import PageHeading from './PageHeading'
-import CCBreadcrumbBar from './CCBreadcrumbBar'
-import Error404 from '../views/Error404'
+import { Formik, Form } from "formik";
+import {
+  getScanReportTable,
+  getScanReportFieldValues,
+  useGet,
+} from "../api/values";
+import ConceptTag from "./ConceptTag";
+import ToastAlert from "./ToastAlert";
+import PageHeading from "./PageHeading";
+import CCBreadcrumbBar from "./CCBreadcrumbBar";
+import Error404 from "../views/Error404";
 
 const FieldsTbl = (props) => {
-    // get the value to use to query the fields endpoint from the page url
-    const pathArray = window.location.pathname.split("/")
-    const scanReportId = pathArray[pathArray.length - 4]
-    // const scanReportTableId = pathArray[pathArray.length - 1]
-    // const scanReportTableId = window.pk ? window.pk : parseInt(new URLSearchParams(window.location.search).get("search"))
-    const scanReportTableId = parseInt(new URLSearchParams(window.location.search).get("search")) ?
-        parseInt(new URLSearchParams(window.location.search).get("search")) : pathArray[pathArray.length - 2]
-    const [alert, setAlert] = useState({ hidden: true, title: '', description: '', status: 'error' });
-    const { isOpen, onOpen, onClose } = useDisclosure()
-    const [values, setValues] = useState([]);
-    const [error, setError] = useState(undefined);
-    const [loading, setLoading] = useState(true);
-    const [loadingMessage, setLoadingMessage] = useState("");
-    const valuesRef = useRef([]);
-    const scanReportTable = useRef([]);
-    const scanReportName = useRef([]);
-    const [mappingButtonDisabled, setMappingButtonDisabled] = useState(true);
+  // get the value to use to query the fields endpoint from the page url
+  const pathArray = window.location.pathname.split("/");
+  const scanReportId = pathArray[pathArray.length - 4];
+  // const scanReportTableId = pathArray[pathArray.length - 1]
+  // const scanReportTableId = window.pk ? window.pk : parseInt(new URLSearchParams(window.location.search).get("search"))
+  const scanReportTableId = parseInt(
+    new URLSearchParams(window.location.search).get("search"),
+  )
+    ? parseInt(new URLSearchParams(window.location.search).get("search"))
+    : pathArray[pathArray.length - 2];
+  const [alert, setAlert] = useState({
+    hidden: true,
+    title: "",
+    description: "",
+    status: "error",
+  });
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [values, setValues] = useState([]);
+  const [error, setError] = useState(undefined);
+  const [loading, setLoading] = useState(true);
+  const [loadingMessage, setLoadingMessage] = useState("");
+  const valuesRef = useRef([]);
+  const scanReportTable = useRef([]);
+  const scanReportName = useRef([]);
+  const [mappingButtonDisabled, setMappingButtonDisabled] = useState(true);
 
-    useEffect(() => {
-        props.setTitle(null)
-        // run on initial render
-        // Check if user can see SR table
-        useGet(`/scanreporttables/${scanReportTableId}/`).then(
-            res => {
-                // get field table values for specified id
-                getScanReportFieldValues(scanReportTableId, valuesRef).then(val => {
-                    setValues(val)
-                    setLoading(false)
-                })
-                // get scan report table data to use for checking person id and date event
-                getScanReportTable(scanReportTableId).then(table => {
-                    scanReportTable.current = table
-                    setMappingButtonDisabled(false)
-                })
-                useGet(`/scanreports/${scanReportId}/`).then(sr => scanReportName.current = sr.dataset)
-            }
-        ).catch(
-            err => {
-                // If user can't see SR table, show an error message
-                setError(true)
-                setLoading(false)
-            }
-        )
-    }, []);
+  useEffect(() => {
+    props.setTitle(null);
+    // run on initial render
+    // Check if user can see SR table
+    useGet(`/scanreporttables/${scanReportTableId}/`)
+      .then((res) => {
+        // get field table values for specified id
+        getScanReportFieldValues(scanReportTableId, valuesRef).then((val) => {
+          setValues(val);
+          setLoading(false);
+        });
+        // get scan report table data to use for checking person id and date event
+        getScanReportTable(scanReportTableId).then((table) => {
+          scanReportTable.current = table;
+          setMappingButtonDisabled(false);
+        });
+        useGet(`/scanreports/${scanReportId}/`).then(
+          (sr) => (scanReportName.current = sr.dataset),
+        );
+      })
+      .catch((err) => {
+        // If user can't see SR table, show an error message
+        setError(true);
+        setLoading(false);
+      });
+  }, []);
 
-    // called to submit a concept to be added. Calls handle submit function from app.js
-    const handleSubmit = (id, concept) => {
-        props.handleSubmit(id, concept, valuesRef, setValues, setAlert, onOpen, scanReportTable.current, 15)
-    }
+  // called to submit a concept to be added. Calls handle submit function from app.js
+  const handleSubmit = (id, concept) => {
+    props.handleSubmit(
+      id,
+      concept,
+      valuesRef,
+      setValues,
+      setAlert,
+      onOpen,
+      scanReportTable.current,
+      "scanreportfield",
+    );
+  };
 
-    // called to delete a concept. Calls handle delete function from app.js
-    const handleDelete = (id, conceptId) => {
-        props.handleDelete(id, conceptId, valuesRef, setValues, setAlert, onOpen)
-    }
+  // called to delete a concept. Calls handle delete function from app.js
+  const handleDelete = (id, conceptId) => {
+    props.handleDelete(id, conceptId, valuesRef, setValues, setAlert, onOpen);
+  };
 
-    if (error) {
-        //Render Error State
-        return <Error404 setTitle={props.setTitle} />
-    }
+  if (error) {
+    //Render Error State
+    return <Error404 setTitle={props.setTitle} />;
+  }
 
-    if (loading) {
-        //Render Loading State
-        return (
-            <Flex padding="30px">
-                <Spinner />
-                <Flex marginLeft="10px">Loading Fields {loadingMessage}</Flex>
-            </Flex>
-        )
-    }
-    if (values.length < 1) {
-        //Render Empty List State
-        return (
-            <Flex padding="30px">
-                <Flex marginLeft="10px">No Fields Found</Flex>
-            </Flex>
-        )
-    }
-    else {
-        return (
-            <div>
-                <CCBreadcrumbBar>
-                    <Link href={"/"}>Home</Link>
-                    <Link href={"/scanreports/"}>Scan Reports</Link>
-                    <Link href={`/scanreports/${scanReportTable.current.scan_report}/`}>{scanReportName.current}</Link>
-                    <Link href={`/scanreports/${scanReportTable.current.scan_report}/tables/${scanReportTableId}/`}>{scanReportTable.current.name}</Link>
-                </CCBreadcrumbBar>
-                <PageHeading text={"Fields"} />
-                <Flex my="10px">
-                    <HStack>
-                        <Link href={"/scanreports/" + scanReportId + "/details/"}>
-                            <Button variant="blue" my="10px">Scan Report Details</Button>
-                        </Link>
-                        <Link href={"/scanreports/" + scanReportId + "/mapping_rules/"}>
-                            <Button isDisabled={mappingButtonDisabled} variant="blue" my="10px">Go to Rules</Button>
-                        </Link>
-                        {window.canEdit && <Link href={"/scanreports/" + scanReportId + "/tables/" + scanReportTableId + "/update/"}>
-                            <Button variant="blue" my="10px">Edit Table</Button>
-                        </Link>
-                        }
-                    </HStack>
-                </Flex>
-                {isOpen &&
-                    <ScaleFade initialScale={0.9} in={isOpen}>
-                        <ToastAlert hide={onClose} title={alert.title} status={alert.status} description={alert.description} />
-                    </ScaleFade>
+  if (loading) {
+    //Render Loading State
+    return (
+      <Flex padding="30px">
+        <Spinner />
+        <Flex marginLeft="10px">Loading Fields {loadingMessage}</Flex>
+      </Flex>
+    );
+  }
+  if (values.length < 1) {
+    //Render Empty List State
+    return (
+      <Flex padding="30px">
+        <Flex marginLeft="10px">No Fields Found</Flex>
+      </Flex>
+    );
+  } else {
+    return (
+      <div>
+        <CCBreadcrumbBar>
+          <Link href={"/"}>Home</Link>
+          <Link href={"/scanreports/"}>Scan Reports</Link>
+          <Link href={`/scanreports/${scanReportTable.current.scan_report}/`}>
+            {scanReportName.current}
+          </Link>
+          <Link
+            href={`/scanreports/${scanReportTable.current.scan_report}/tables/${scanReportTableId}/`}
+          >
+            {scanReportTable.current.name}
+          </Link>
+        </CCBreadcrumbBar>
+        <PageHeading text={"Fields"} />
+        <Flex my="10px">
+          <HStack>
+            <Link href={"/scanreports/" + scanReportId + "/details/"}>
+              <Button variant="blue" my="10px">
+                Scan Report Details
+              </Button>
+            </Link>
+            <Link href={"/scanreports/" + scanReportId + "/mapping_rules/"}>
+              <Button
+                isDisabled={mappingButtonDisabled}
+                variant="blue"
+                my="10px"
+              >
+                Go to Rules
+              </Button>
+            </Link>
+            {window.canEdit && (
+              <Link
+                href={
+                  "/scanreports/" +
+                  scanReportId +
+                  "/tables/" +
+                  scanReportTableId +
+                  "/update/"
                 }
+              >
+                <Button variant="blue" my="10px">
+                  Edit Table
+                </Button>
+              </Link>
+            )}
+          </HStack>
+        </Flex>
+        {isOpen && (
+          <ScaleFade initialScale={0.9} in={isOpen}>
+            <ToastAlert
+              hide={onClose}
+              title={alert.title}
+              status={alert.status}
+              description={alert.description}
+            />
+          </ScaleFade>
+        )}
 
-                <Table variant="striped" colorScheme="greyBasic">
-                    <TableCaption></TableCaption>
-                    <Thead>
-                        <Tr>
-                            <Th>Field</Th>
-                            <Th>Description</Th>
-                            <Th>Data type</Th>
-                            <Th>Concepts</Th>
-                            <Th></Th>
-                            {window.canEdit && <Th>Edit</Th>}
-                        </Tr>
-                    </Thead>
-                    <Tbody>
-                        {
-                            // Create new row for every value object
-                            values.map((item, index) =>
-                                <Tr key={item.id}>
-                                    <Td><Link style={{ color: "#0000FF", }} href={`/scanreports/${scanReportId}/tables/${scanReportTableId}/fields/${item.id}/`}>{item.name}</Link></Td>
-                                    <Td maxW="250px"><Text maxW="100%" w="max-content">{item.description_column}</Text></Td>
-                                    <Td>{item.type_column}</Td>
+        <Table variant="striped" colorScheme="greyBasic">
+          <TableCaption></TableCaption>
+          <Thead>
+            <Tr>
+              <Th>Field</Th>
+              <Th>Description</Th>
+              <Th>Data type</Th>
+              <Th>Concepts</Th>
+              <Th></Th>
+              {window.canEdit && <Th>Edit</Th>}
+            </Tr>
+          </Thead>
+          <Tbody>
+            {
+              // Create new row for every value object
+              values.map((item, index) => (
+                <Tr key={item.id}>
+                  <Td>
+                    <Link
+                      style={{ color: "#0000FF" }}
+                      href={`/scanreports/${scanReportId}/tables/${scanReportTableId}/fields/${item.id}/`}
+                    >
+                      {item.name}
+                    </Link>
+                  </Td>
+                  <Td maxW="250px">
+                    <Text maxW="100%" w="max-content">
+                      {item.description_column}
+                    </Text>
+                  </Td>
+                  <Td>{item.type_column}</Td>
 
-                                    <Td maxW="300px">
-                                        {item.conceptsLoaded ?
-                                            item.concepts.length > 0 &&
-                                            <VStack alignItems='flex-start' >
-                                                {item.concepts.map((concept) => (
-                                                    <ConceptTag
-                                                        key={concept.concept.concept_id}
-                                                        conceptName={concept.concept.concept_name}
-                                                        conceptId={concept.concept.concept_id.toString()}
-                                                        conceptIdentifier={concept.id.toString()} itemId={item.id}
-                                                        handleDelete={handleDelete}
-                                                        creation_type={concept.creation_type ? concept.creation_type : undefined}
-                                                        readOnly={!window.canEdit}
-                                                    />
-                                                ))}
-                                            </VStack>
-                                            :
-                                            item.conceptsLoaded === false ?
-                                                <Flex >
-                                                    <Spinner />
-                                                    <Flex marginLeft="10px">Loading Concepts</Flex>
-                                                </Flex>
-                                                :
-                                                <Text>Failed to load concepts</Text>
-                                        }
-                                    </Td>
-                                    <Td>
-
-                                        <Formik initialValues={{ concept: '' }} onSubmit={(data, actions) => {
-                                            handleSubmit(item.id, data.concept)
-                                            actions.resetForm();
-                                        }}>
-                                            {({ values, handleChange, handleBlur, handleSubmit }) => (
-                                                <Form onSubmit={handleSubmit}>
-                                                    <HStack>
-                                                        <Input
-                                                            w={"105px"}
-                                                            type='number'
-                                                            name='concept'
-                                                            value={values.concept}
-                                                            onChange={handleChange}
-                                                            onBlur={handleBlur}
-                                                            isDisabled={!window.canEdit}
-                                                        />
-                                                        <div>
-                                                            <Button type='submit' isDisabled={!window.canEdit} backgroundColor='#3C579E' color='white'>Add</Button>
-                                                        </div>
-                                                    </HStack>
-                                                </Form>
-                                            )}
-                                        </Formik>
-                                    </Td>
-                                    {window.canEdit && <Td><Link style={{ color: "#0000FF", }} href={window.location.href + "fields/" + item.id + "/update/"}>Edit Field</Link></Td>}
-                                </Tr>
-                            )
+                  <Td maxW="300px">
+                    {item.conceptsLoaded ? (
+                      item.concepts.length > 0 && (
+                        <VStack alignItems="flex-start">
+                          {item.concepts.map((concept) => (
+                            <ConceptTag
+                              key={concept.concept.concept_id}
+                              conceptName={concept.concept.concept_name}
+                              conceptId={concept.concept.concept_id.toString()}
+                              conceptIdentifier={concept.id.toString()}
+                              itemId={item.id}
+                              handleDelete={handleDelete}
+                              creation_type={
+                                concept.creation_type
+                                  ? concept.creation_type
+                                  : undefined
+                              }
+                              readOnly={!window.canEdit}
+                            />
+                          ))}
+                        </VStack>
+                      )
+                    ) : item.conceptsLoaded === false ? (
+                      <Flex>
+                        <Spinner />
+                        <Flex marginLeft="10px">Loading Concepts</Flex>
+                      </Flex>
+                    ) : (
+                      <Text>Failed to load concepts</Text>
+                    )}
+                  </Td>
+                  <Td>
+                    <Formik
+                      initialValues={{ concept: "" }}
+                      onSubmit={(data, actions) => {
+                        handleSubmit(item.id, data.concept);
+                        actions.resetForm();
+                      }}
+                    >
+                      {({ values, handleChange, handleBlur, handleSubmit }) => (
+                        <Form onSubmit={handleSubmit}>
+                          <HStack>
+                            <Input
+                              w={"105px"}
+                              type="number"
+                              name="concept"
+                              value={values.concept}
+                              onChange={handleChange}
+                              onBlur={handleBlur}
+                              isDisabled={!window.canEdit}
+                            />
+                            <div>
+                              <Button
+                                type="submit"
+                                isDisabled={!window.canEdit}
+                                backgroundColor="#3C579E"
+                                color="white"
+                              >
+                                Add
+                              </Button>
+                            </div>
+                          </HStack>
+                        </Form>
+                      )}
+                    </Formik>
+                  </Td>
+                  {window.canEdit && (
+                    <Td>
+                      <Link
+                        style={{ color: "#0000FF" }}
+                        href={
+                          window.location.href +
+                          "fields/" +
+                          item.id +
+                          "/update/"
                         }
-                    </Tbody>
-                </Table>
-            </div>
-        )
+                      >
+                        Edit Field
+                      </Link>
+                    </Td>
+                  )}
+                </Tr>
+              ))
+            }
+          </Tbody>
+        </Table>
+      </div>
+    );
+  }
+};
 
-    }
-
-}
-
-
-export default FieldsTbl
+export default FieldsTbl;

--- a/app/react-client-app/src/components/ValuesTbl.jsx
+++ b/app/react-client-app/src/components/ValuesTbl.jsx
@@ -1,224 +1,299 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef } from "react";
 import {
-    Button,
-    Table,
-    Thead,
-    Tbody,
-    Tr,
-    Th,
-    Td,
-    TableCaption,
-    Text,
-    HStack,
-    VStack,
-    Flex,
-    Spinner,
-    ScaleFade,
-    Input,
-    useDisclosure,
-    Link
-} from "@chakra-ui/react"
+  Button,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableCaption,
+  Text,
+  HStack,
+  VStack,
+  Flex,
+  Spinner,
+  ScaleFade,
+  Input,
+  useDisclosure,
+  Link,
+} from "@chakra-ui/react";
 
-import { Formik, Form } from 'formik'
-import { getScanReports, getScanReportField, getScanReportTable, useGet } from '../api/values'
-import ConceptTag from './ConceptTag'
-import ToastAlert from './ToastAlert'
-import PageHeading from './PageHeading'
-import CCBreadcrumbBar from './CCBreadcrumbBar'
-import Error404 from '../views/Error404'
+import { Formik, Form } from "formik";
+import {
+  getScanReports,
+  getScanReportField,
+  getScanReportTable,
+  useGet,
+} from "../api/values";
+import ConceptTag from "./ConceptTag";
+import ToastAlert from "./ToastAlert";
+import PageHeading from "./PageHeading";
+import CCBreadcrumbBar from "./CCBreadcrumbBar";
+import Error404 from "../views/Error404";
 
 const ValuesTbl = (props) => {
-    // get value to use in query from page url
-    const pathArray = window.location.pathname.split("/")
-    const scanReportFieldId = pathArray[pathArray.length - 2]
-    const scanReportId = pathArray[pathArray.length - 6]
-    // set page state variables
-    const [alert, setAlert] = useState({ hidden: true, title: '', description: '', status: 'error' });
-    const { isOpen, onOpen, onClose } = useDisclosure()
-    const [scanReports, setScanReports] = useState([]);
-    const [error, setError] = useState(undefined);
-    const [loadingMessage, setLoadingMessage] = useState("");
-    const scanReportsRef = useRef([]);
-    const scanReportTable = useRef([]);
-    const scanReportField = useRef([]);
-    const [mappingButtonDisabled, setMappingButtonDisabled] = useState(true);
-    const scanReportName = useRef([]);
+  // get value to use in query from page url
+  const pathArray = window.location.pathname.split("/");
+  const scanReportFieldId = pathArray[pathArray.length - 2];
+  const scanReportId = pathArray[pathArray.length - 6];
+  // set page state variables
+  const [alert, setAlert] = useState({
+    hidden: true,
+    title: "",
+    description: "",
+    status: "error",
+  });
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [scanReports, setScanReports] = useState([]);
+  const [error, setError] = useState(undefined);
+  const [loadingMessage, setLoadingMessage] = useState("");
+  const scanReportsRef = useRef([]);
+  const scanReportTable = useRef([]);
+  const scanReportField = useRef([]);
+  const [mappingButtonDisabled, setMappingButtonDisabled] = useState(true);
+  const scanReportName = useRef([]);
 
-    useEffect(() => {
-        props.setTitle(null)
-        // Check user can see SR field
-        useGet(`/scanreportfields/${scanReportFieldId}`).then(
-            res => {
-                // get and store scan report table object to use to check person_id and date_event
-                getScanReportField(scanReportFieldId).then(data => {
-                    scanReportField.current = data
-                    getScanReportTable(data.scan_report_table).then(table => {
-                        scanReportTable.current = table
-                        setMappingButtonDisabled(false)
-                    })
-                })
-                // get scan report values
-                getScanReports(scanReportFieldId, setScanReports, scanReportsRef, setLoadingMessage, setError)
-                useGet(`/scanreports/${scanReportId}/`).then(sr => scanReportName.current = sr.dataset)
-            }
-        ).catch(
-            err => {
-                // If user can't see SR field, show an error message
-                setError(true)
-                setLoading(false)
-            }
-        )
-    }, []);
+  useEffect(() => {
+    props.setTitle(null);
+    // Check user can see SR field
+    useGet(`/scanreportfields/${scanReportFieldId}`)
+      .then((res) => {
+        // get and store scan report table object to use to check person_id and date_event
+        getScanReportField(scanReportFieldId).then((data) => {
+          scanReportField.current = data;
+          getScanReportTable(data.scan_report_table).then((table) => {
+            scanReportTable.current = table;
+            setMappingButtonDisabled(false);
+          });
+        });
+        // get scan report values
+        getScanReports(
+          scanReportFieldId,
+          setScanReports,
+          scanReportsRef,
+          setLoadingMessage,
+          setError,
+        );
+        useGet(`/scanreports/${scanReportId}/`).then(
+          (sr) => (scanReportName.current = sr.dataset),
+        );
+      })
+      .catch((err) => {
+        // If user can't see SR field, show an error message
+        setError(true);
+        setLoading(false);
+      });
+  }, []);
 
-    // called to submit a concept to be added. Calls handle submit function from app.js
-    const handleSubmit = (id, concept) => {
-        props.handleSubmit(id, concept, scanReportsRef, setScanReports, setAlert, onOpen, scanReportTable.current, 17)
-    }
+  // called to submit a concept to be added. Calls handle submit function from app.js
+  const handleSubmit = (id, concept) => {
+    props.handleSubmit(
+      id,
+      concept,
+      scanReportsRef,
+      setScanReports,
+      setAlert,
+      onOpen,
+      scanReportTable.current,
+      "scanreportvalue",
+    );
+  };
 
-    // called to delete a concept. Calls handle delete function from app.js
-    const handleDelete = (id, conceptId) => {
-        props.handleDelete(id, conceptId, scanReportsRef, setScanReports, setAlert, onOpen)
-    }
+  // called to delete a concept. Calls handle delete function from app.js
+  const handleDelete = (id, conceptId) => {
+    props.handleDelete(
+      id,
+      conceptId,
+      scanReportsRef,
+      setScanReports,
+      setAlert,
+      onOpen,
+    );
+  };
 
-    if (error) {
-        //Render Loading State
-        return <Error404 setTitle={props.setTitle} />
-    }
+  if (error) {
+    //Render Loading State
+    return <Error404 setTitle={props.setTitle} />;
+  }
 
-    if (scanReports.length < 1) {
-        //Render Loading State
-        return (
-            <Flex padding="30px">
-                <Spinner />
-                <Flex marginLeft="10px">Loading Values {loadingMessage}</Flex>
-            </Flex>
-        )
-    }
-    if (scanReports[0] == undefined) {
-        //Render Loading State
-        return (
-            <Flex padding="30px">
-
-                <Flex marginLeft="10px">No Values Found</Flex>
-            </Flex>
-        )
-    }
-    else {
-        return (
-            <div>
-                <CCBreadcrumbBar>
-                    <Link href={"/"}>Home</Link>
-                    <Link href={"/scanreports/"}>Scan Reports</Link>
-                    <Link href={`/scanreports/${scanReportTable.current.scan_report}/`}>{scanReportName.current}</Link>
-                    <Link href={`/scanreports/${scanReportTable.current.scan_report}/tables/${scanReportTable.current.id}/`}>{scanReportTable.current.name}</Link>
-                    <Link href={`/scanreports/${scanReportTable.current.scan_report}/tables/${scanReportTable.current.id}/fields/${scanReportField.current.id}/`}>{scanReportField.current.name}</Link>
-                </CCBreadcrumbBar>
-                <PageHeading text={"Values"} />
-                <Flex my="10px">
-                    <HStack>
-                        <Link href={"/scanreports/" + scanReportId + "/details/"}>
-                            <Button variant="blue" my="10px">Scan Report Details</Button>
-                        </Link>
-                        <Link href={"/scanreports/" + scanReportId + "/mapping_rules/"}>
-                            <Button isDisabled={mappingButtonDisabled} variant="blue" my="10px">Go to Rules</Button>
-                        </Link>
-                        {window.canEdit && <Link href={"/scanreports/" + scanReportId + "/tables/" + scanReportTable.current.id + "/update/"}>
-                            <Button variant="blue" my="10px">Edit Table</Button>
-                        </Link>
-                        }
-                    </HStack>
-                </Flex>
-                {isOpen &&
-                    <ScaleFade initialScale={0.9} in={isOpen}>
-                        <ToastAlert hide={onClose} title={alert.title} status={alert.status} description={alert.description} />
-                    </ScaleFade>
+  if (scanReports.length < 1) {
+    //Render Loading State
+    return (
+      <Flex padding="30px">
+        <Spinner />
+        <Flex marginLeft="10px">Loading Values {loadingMessage}</Flex>
+      </Flex>
+    );
+  }
+  if (scanReports[0] == undefined) {
+    //Render Loading State
+    return (
+      <Flex padding="30px">
+        <Flex marginLeft="10px">No Values Found</Flex>
+      </Flex>
+    );
+  } else {
+    return (
+      <div>
+        <CCBreadcrumbBar>
+          <Link href={"/"}>Home</Link>
+          <Link href={"/scanreports/"}>Scan Reports</Link>
+          <Link href={`/scanreports/${scanReportTable.current.scan_report}/`}>
+            {scanReportName.current}
+          </Link>
+          <Link
+            href={`/scanreports/${scanReportTable.current.scan_report}/tables/${scanReportTable.current.id}/`}
+          >
+            {scanReportTable.current.name}
+          </Link>
+          <Link
+            href={`/scanreports/${scanReportTable.current.scan_report}/tables/${scanReportTable.current.id}/fields/${scanReportField.current.id}/`}
+          >
+            {scanReportField.current.name}
+          </Link>
+        </CCBreadcrumbBar>
+        <PageHeading text={"Values"} />
+        <Flex my="10px">
+          <HStack>
+            <Link href={"/scanreports/" + scanReportId + "/details/"}>
+              <Button variant="blue" my="10px">
+                Scan Report Details
+              </Button>
+            </Link>
+            <Link href={"/scanreports/" + scanReportId + "/mapping_rules/"}>
+              <Button
+                isDisabled={mappingButtonDisabled}
+                variant="blue"
+                my="10px"
+              >
+                Go to Rules
+              </Button>
+            </Link>
+            {window.canEdit && (
+              <Link
+                href={
+                  "/scanreports/" +
+                  scanReportId +
+                  "/tables/" +
+                  scanReportTable.current.id +
+                  "/update/"
                 }
+              >
+                <Button variant="blue" my="10px">
+                  Edit Table
+                </Button>
+              </Link>
+            )}
+          </HStack>
+        </Flex>
+        {isOpen && (
+          <ScaleFade initialScale={0.9} in={isOpen}>
+            <ToastAlert
+              hide={onClose}
+              title={alert.title}
+              status={alert.status}
+              description={alert.description}
+            />
+          </ScaleFade>
+        )}
 
-                <Table variant="striped" colorScheme="greyBasic">
-                    <TableCaption></TableCaption>
-                    <Thead>
-                        <Tr>
-                            <Th>Value</Th>
-                            <Th>Value Description</Th>
-                            <Th>Frequency</Th>
-                            <Th>Concepts</Th>
-                            <Th px={2}></Th>
-                        </Tr>
-                    </Thead>
-                    <Tbody>
-                        {
-                            // Create new row for every value object
-                            scanReports.map((item, index) =>
-                                <Tr key={item.id}>
-                                    <Td maxW={"300px"}>{item.value}</Td>
-                                    <Td maxW={"300px"}>{item.value_description}</Td>
-                                    <Td maxW={"300px"}>{item.frequency}</Td>
+        <Table variant="striped" colorScheme="greyBasic">
+          <TableCaption></TableCaption>
+          <Thead>
+            <Tr>
+              <Th>Value</Th>
+              <Th>Value Description</Th>
+              <Th>Frequency</Th>
+              <Th>Concepts</Th>
+              <Th px={2}></Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {
+              // Create new row for every value object
+              scanReports.map((item, index) => (
+                <Tr key={item.id}>
+                  <Td maxW={"300px"}>{item.value}</Td>
+                  <Td maxW={"300px"}>{item.value_description}</Td>
+                  <Td maxW={"300px"}>{item.frequency}</Td>
 
-                                    <Td maxW={"300px"}>
-                                        {item.conceptsLoaded ?
-                                            item.concepts.length > 0 &&
-                                            <VStack alignItems='flex-start' >
-                                                {item.concepts.map((concept) => (
-                                                    <ConceptTag
-                                                        key={concept.concept.concept_id}
-                                                        conceptName={concept.concept.concept_name}
-                                                        conceptId={concept.concept.concept_id.toString()}
-                                                        conceptIdentifier={concept.id.toString()}
-                                                        itemId={item.id} handleDelete={handleDelete}
-                                                        creation_type={concept.creation_type ? concept.creation_type : undefined}
-                                                        readOnly={!window.canEdit}
-                                                    />
-                                                ))}
-                                            </VStack>
-                                            :
-                                            item.conceptsLoaded === false ?
-                                                <Flex >
-                                                    <Spinner />
-                                                    <Flex marginLeft="10px">Loading Concepts</Flex>
-                                                </Flex>
-                                                :
-                                                <Text>Failed to load concepts</Text>
-                                        }
-                                    </Td>
-                                    <Td w={"150px"} px={2}>
+                  <Td maxW={"300px"}>
+                    {item.conceptsLoaded ? (
+                      item.concepts.length > 0 && (
+                        <VStack alignItems="flex-start">
+                          {item.concepts.map((concept) => (
+                            <ConceptTag
+                              key={concept.concept.concept_id}
+                              conceptName={concept.concept.concept_name}
+                              conceptId={concept.concept.concept_id.toString()}
+                              conceptIdentifier={concept.id.toString()}
+                              itemId={item.id}
+                              handleDelete={handleDelete}
+                              creation_type={
+                                concept.creation_type
+                                  ? concept.creation_type
+                                  : undefined
+                              }
+                              readOnly={!window.canEdit}
+                            />
+                          ))}
+                        </VStack>
+                      )
+                    ) : item.conceptsLoaded === false ? (
+                      <Flex>
+                        <Spinner />
+                        <Flex marginLeft="10px">Loading Concepts</Flex>
+                      </Flex>
+                    ) : (
+                      <Text>Failed to load concepts</Text>
+                    )}
+                  </Td>
+                  <Td w={"150px"} px={2}>
+                    <Formik
+                      initialValues={{ concept: "" }}
+                      onSubmit={(data, actions) => {
+                        handleSubmit(item.id, data.concept);
+                        actions.resetForm();
+                      }}
+                    >
+                      {({ values, handleChange, handleBlur, handleSubmit }) => (
+                        <Form onSubmit={handleSubmit}>
+                          <HStack>
+                            <Input
+                              w={"105px"}
+                              type="number"
+                              name="concept"
+                              value={values.concept}
+                              onChange={handleChange}
+                              onBlur={handleBlur}
+                              isDisabled={!window.canEdit}
+                            />
+                            <div>
+                              <Button
+                                type="submit"
+                                isDisabled={
+                                  !(item.conceptsToLoad == 0 || window.canEdit)
+                                }
+                                backgroundColor="#3C579E"
+                                color="white"
+                              >
+                                Add
+                              </Button>
+                            </div>
+                          </HStack>
+                        </Form>
+                      )}
+                    </Formik>
+                  </Td>
+                </Tr>
+              ))
+            }
+          </Tbody>
+        </Table>
+      </div>
+    );
+  }
+};
 
-                                        <Formik initialValues={{ concept: '' }} onSubmit={(data, actions) => {
-                                            handleSubmit(item.id, data.concept)
-                                            actions.resetForm();
-                                        }}>
-                                            {({ values, handleChange, handleBlur, handleSubmit }) => (
-                                                <Form onSubmit={handleSubmit}>
-                                                    <HStack>
-                                                        <Input
-                                                            w={"105px"}
-                                                            type='number'
-                                                            name='concept'
-                                                            value={values.concept}
-                                                            onChange={handleChange}
-                                                            onBlur={handleBlur}
-                                                            isDisabled={!window.canEdit}
-                                                        />
-                                                        <div>
-                                                            <Button type='submit' isDisabled={!((item.conceptsToLoad == 0) || window.canEdit)} backgroundColor='#3C579E' color='white'>Add</Button>
-                                                        </div>
-                                                    </HStack>
-                                                </Form>
-                                            )}
-                                        </Formik>
-                                    </Td>
-                                </Tr>
-
-                            )
-                        }
-                    </Tbody>
-                </Table>
-            </div>
-        )
-
-    }
-
-}
-
-
-export default ValuesTbl
-
+export default ValuesTbl;

--- a/app/workers/CreateConcepts/__init__.py
+++ b/app/workers/CreateConcepts/__init__.py
@@ -6,7 +6,6 @@ import azure.functions as func
 from shared_code import blob_parser, helpers, omop_helpers
 from shared_code.api import (
     get_concept_vocabs,
-    get_content_type_id,
     get_scan_report_fields_by_table,
     get_scan_report_table,
     get_scan_report_values_filter_scan_report_table,
@@ -27,20 +26,18 @@ def _create_concepts(table_values: List[Dict[str, Any]]) -> List[Dict[str, Any]]
     Returns:
         List[Dict[str, Any]]: List of Concept dictionaries.
     """
-    # TODO: create_concepts here defaults to 17. it wants the ScanReportFields.
-    content_type = get_content_type_id("scanreportfield")
     concept_id_data = []
     for concept in table_values:
         if concept["concept_id"] != -1:
             if isinstance(concept["concept_id"], list):
                 concept_id_data.extend(
-                    helpers.create_concept(concept_id, concept["id"], content_type)
+                    helpers.create_concept(concept_id, concept["id"], "scanreportfield")
                     for concept_id in concept["concept_id"]
                 )
             else:
                 concept_id_data.append(
                     helpers.create_concept(
-                        concept["concept_id"], concept["id"], content_type
+                        concept["concept_id"], concept["id"], "scanreportfield"
                     )
                 )
 

--- a/app/workers/CreateConcepts/__init__.py
+++ b/app/workers/CreateConcepts/__init__.py
@@ -31,13 +31,13 @@ def _create_concepts(table_values: List[Dict[str, Any]]) -> List[Dict[str, Any]]
         if concept["concept_id"] != -1:
             if isinstance(concept["concept_id"], list):
                 concept_id_data.extend(
-                    helpers.create_concept(concept_id, concept["id"], "scanreportfield")
+                    helpers.create_concept(concept_id, concept["id"], "scanreportvalue")
                     for concept_id in concept["concept_id"]
                 )
             else:
                 concept_id_data.append(
                     helpers.create_concept(
-                        concept["concept_id"], concept["id"], "scanreportfield"
+                        concept["concept_id"], concept["id"], "scanreportvalue"
                     )
                 )
 

--- a/app/workers/CreateConcepts/__init__.py
+++ b/app/workers/CreateConcepts/__init__.py
@@ -6,6 +6,7 @@ import azure.functions as func
 from shared_code import blob_parser, helpers, omop_helpers
 from shared_code.api import (
     get_concept_vocabs,
+    get_content_type_id,
     get_scan_report_fields_by_table,
     get_scan_report_table,
     get_scan_report_values_filter_scan_report_table,
@@ -26,17 +27,21 @@ def _create_concepts(table_values: List[Dict[str, Any]]) -> List[Dict[str, Any]]
     Returns:
         List[Dict[str, Any]]: List of Concept dictionaries.
     """
+    # TODO: create_concepts here defaults to 17. it wants the ScanReportFields.
+    content_type = get_content_type_id("scanreportfield")
     concept_id_data = []
     for concept in table_values:
         if concept["concept_id"] != -1:
             if isinstance(concept["concept_id"], list):
                 concept_id_data.extend(
-                    helpers.create_concept(concept_id, concept["id"])
+                    helpers.create_concept(concept_id, concept["id"], content_type)
                     for concept_id in concept["concept_id"]
                 )
             else:
                 concept_id_data.append(
-                    helpers.create_concept(concept["concept_id"], concept["id"])
+                    helpers.create_concept(
+                        concept["concept_id"], concept["id"], content_type
+                    )
                 )
 
     return concept_id_data
@@ -294,8 +299,8 @@ async def _handle_table(
     logger.info("POST concepts all finished")
 
     # handle reuse of concepts
-    reuse_existing_field_concepts(table_fields, 15)
-    reuse_existing_value_concepts(table_values, 17)
+    reuse_existing_field_concepts(table_fields)
+    reuse_existing_value_concepts(table_values)
 
 
 def main(msg: func.QueueMessage):

--- a/app/workers/CreateConcepts/reuse.py
+++ b/app/workers/CreateConcepts/reuse.py
@@ -2,7 +2,6 @@ from typing import Any, Dict, List, Literal
 
 from shared_code import helpers, omop_helpers
 from shared_code.api import (
-    get_content_type_id,
     get_scan_report_active_concepts,
     get_scan_report_fields,
     get_scan_report_values,

--- a/app/workers/CreateConcepts/reuse.py
+++ b/app/workers/CreateConcepts/reuse.py
@@ -335,16 +335,10 @@ def select_concepts_to_post(
     """
     concepts_to_post = []
 
-    # TODO: proposed fix.
-    # Get the content type from the API here, and pass it to wherever below.
-    # TODO: okay so content_type needs to be a string of the content, not 15 or 17.
-    content_type_id = get_content_type_id(content_type)
-
     for new_content_detail in new_content_details:
-        # TODO: This is a problem, but again it's conditional, so maybe not it.
-        if content_type == "ScanReportValues":
+        if content_type == "scanreportfield":
             key = str(new_content_detail["name"])
-        elif content_type == "ScanReportFields":
+        elif content_type == "scanreportvalue":
             key = (
                 str(new_content_detail["name"]),
                 str(new_content_detail["description"]),
@@ -355,14 +349,13 @@ def select_concepts_to_post(
 
         try:
             existing_content_id, concept_id = details_to_id_and_concept_id_map[key]
-            # logger.info(
-            #     f"Found existing {'field' if content_type == "ScanReportFields" else 'value'} with id: {existing_content_id} "
-            #     f"with existing concept mapping: {concept_id} which matches new {'field' if content_type == "ScanReportFields" else 'value'} id: {new_content_detail['id']}"
-            # )
+            logger.info(
+                f"Found existing {'field' if content_type == 'scanreportfield' else 'value'} with id: {existing_content_id} "
+                f"with existing concept mapping: {concept_id} which matches new {'field' if content_type == 'scanreportfield' else 'value'} id: {new_content_detail['id']}"
+            )
             # Create ScanReportConcept entry for copying over the concept
-            # TODO: This is the "source" of the problem.
             concept_entry = create_concept(
-                concept_id, str(new_content_detail["id"]), content_type_id, "R"
+                concept_id, str(new_content_detail["id"]), content_type, "R"
             )
             concepts_to_post.append(concept_entry)
         except KeyError:

--- a/app/workers/CreateConcepts/reuse.py
+++ b/app/workers/CreateConcepts/reuse.py
@@ -303,7 +303,7 @@ def select_concepts_to_post(
           "description", "field_name") keys (for values), with entries (field_id, concept_id)
           or (value_id, concept_id) respectively.
 
-        content_type (Literal["ScanReportFields", "ScanReportValues"]): Controls whether to handle ScanReportFields (15), or ScanReportValues (17).
+        content_type (Literal["scanreportfield", "scanreportvalue"]): Controls whether to handle ScanReportFields (15), or ScanReportValues (17).
 
     Returns:
         A list of reused `Concepts` to create.

--- a/app/workers/CreateConcepts/reuse.py
+++ b/app/workers/CreateConcepts/reuse.py
@@ -34,9 +34,6 @@ def reuse_existing_value_concepts(new_values_map) -> None:
         new_fields_map (Dict[str, str]): A map of field names to Ids.
     """
     logger.info("reuse_existing_value_concepts")
-    # TODO: I mean this is just setting it anyway.
-    # content_type (Literal[17]): The content type, represents `ScanReportValue` (17)
-    content_type = 17
     content_type = "scanreportvalue"
 
     # Gets all scan report concepts that are for the type value
@@ -197,26 +194,8 @@ def reuse_existing_field_concepts(new_fields_map: List[Dict[str, str]]) -> None:
         None
     """
     logger.info("reuse_existing_field_concepts")
-    # TODO: unfuck this.
-    # content_type (Literal[15]): The content type, represents `ScanReportField` (15)
-    content_type = 15
-    # desired:
     content_type = "scanreportfield"
 
-    # I could just get it from the api here, which would override the below.
-    # problem is that select_concepts_to_post() needs to actually know the specific content type.
-    # so this variable is doing 2 things, it is controlling behaviour inside this logic.
-    # but it is also asking the backend to do things in a specific manner.
-    # if we then ask the backend to tell us what to do, we don't know the difference.
-
-    # 2 options:
-    #     1. we call my nice new api again
-    #     2. we change the below api to filter differently
-    #           TODO: Looks like the api is part of the problem! we might fix it there!
-
-    # Gets all scan report concepts that are for the type field
-    # (or content type which should be field) and in "active" SRs
-    # TODO: I (me, this line of code) don't know what the correct content_type number is to fetch it though
     existing_field_concepts = get_scan_report_active_concepts(content_type)
 
     # create dictionary that maps existing field ids to scan report concepts

--- a/app/workers/shared_code/api.py
+++ b/app/workers/shared_code/api.py
@@ -209,7 +209,7 @@ def get_scan_report_active_concepts(
     - Marked with status "Mapping Complete"
 
     Args:
-        content_type (Literal["ScanReportField", "ScanReportValue"]): The `django_content_type` to filter by.
+        content_type (Literal["scanreportfield", "scanreportvalue"]): The `django_content_type` to filter by.
         Represents `ScanReportField`, or `ScanReportValue`
 
     Returns:

--- a/app/workers/shared_code/api.py
+++ b/app/workers/shared_code/api.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from enum import Enum
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Union
 
 import httpx
 import requests
@@ -198,7 +198,7 @@ def get_scan_report_fields_by_table(id: str) -> List[Dict[str, Any]]:
 
 
 def get_scan_report_active_concepts(
-    content_type: Literal[15, 17]
+    content_type: Literal["scanreportfield", "scanreportvalue"]
 ) -> List[Dict[str, Any]]:
     """
     Get ScanReportConcepts that have the given content_type and are
@@ -209,8 +209,8 @@ def get_scan_report_active_concepts(
     - Marked with status "Mapping Complete"
 
     Args:
-        content_type (Literal[15, 17]): The `django_content_type` Id to filter by.
-        Represents `ScanReportField` (15), or `ScanReportValue` (17)
+        content_type (Literal["ScanReportField", "ScanReportValue"]): The `django_content_type` to filter by.
+        Represents `ScanReportField`, or `ScanReportValue`
 
     Returns:
         A list of ScanReportConcepts matching the criteria.
@@ -323,6 +323,24 @@ def get_concept_vocabs(
         f"{response.reason}"
     )
     return response.json()
+
+
+def get_content_type_id(type_name: str) -> int:
+    """
+    Gets the content type Id for a given content type.
+
+    Args:
+        type_name: Name of the content type to get the Id for.
+
+    Returns:
+        The Id of the content type.
+    """
+    response = requests.get(
+        f"{API_URL}contenttypeid?type_name={type_name}", headers=HEADERS
+    )
+    response.raise_for_status()
+    data = response.json()
+    return data["content_type_id"]
 
 
 async def post_chunks(

--- a/app/workers/shared_code/api.py
+++ b/app/workers/shared_code/api.py
@@ -325,24 +325,6 @@ def get_concept_vocabs(
     return response.json()
 
 
-def get_content_type_id(type_name: str) -> int:
-    """
-    Gets the content type Id for a given content type.
-
-    Args:
-        type_name: Name of the content type to get the Id for.
-
-    Returns:
-        The Id of the content type.
-    """
-    response = requests.get(
-        f"{API_URL}contenttypeid?type_name={type_name}", headers=HEADERS
-    )
-    response.raise_for_status()
-    data = response.json()
-    return data["content_type_id"]
-
-
 async def post_chunks(
     chunked_data: List[List[Dict]],
     endpoint: str,

--- a/app/workers/shared_code/api.py
+++ b/app/workers/shared_code/api.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from enum import Enum
-from typing import Any, Dict, List, Literal, Union
+from typing import Any, Dict, List, Literal
 
 import httpx
 import requests

--- a/app/workers/shared_code/helpers.py
+++ b/app/workers/shared_code/helpers.py
@@ -256,7 +256,7 @@ def create_concept(
     Args:
         concept_id (str): The Id of the Concept to create.
         object_id (str): The Object Id of the Concept to create.
-        content_type (int): The Content Type of the Concept.
+        content_type (Literal["scanreportfield", "scanreportvalue"]): The Content Type of the Concept.
         creation_type (Literal["R", "V"], optional): The Creation Type value of the Concept.
 
     Returns:

--- a/app/workers/shared_code/helpers.py
+++ b/app/workers/shared_code/helpers.py
@@ -247,7 +247,7 @@ def add_vocabulary_id_to_entries(
 def create_concept(
     concept_id: str,
     object_id: str,
-    content_type: Literal[15, 17] = 17,
+    content_type: int,
     creation_type: Literal["V", "R"] = "V",
 ) -> Dict[str, Any]:
     """
@@ -256,14 +256,11 @@ def create_concept(
     Args:
         concept_id (str): The Id of the Concept to create.
         object_id (str): The Object Id of the Concept to create.
-        content_type (Literal[15, 17], optional): The Content Type Id of the Concept.
+        content_type (int): The Content Type Id of the Concept.
         creation_type (Literal["R", "V"], optional): The Creation Type value of the Concept.
 
     Returns:
         Dict[str, Any]: A Concept as a dictionary.
-
-    TODO: we should query `content_type` from the API, when this is fixed:
-    https://github.com/Health-Informatics-UoN/CaRROT-Mapper/issues/637
     """
     return {
         "concept": concept_id,

--- a/app/workers/shared_code/helpers.py
+++ b/app/workers/shared_code/helpers.py
@@ -247,7 +247,7 @@ def add_vocabulary_id_to_entries(
 def create_concept(
     concept_id: str,
     object_id: str,
-    content_type: int,
+    content_type: Literal["scanreportfield", "scanreportvalue"],
     creation_type: Literal["V", "R"] = "V",
 ) -> Dict[str, Any]:
     """
@@ -256,7 +256,7 @@ def create_concept(
     Args:
         concept_id (str): The Id of the Concept to create.
         object_id (str): The Object Id of the Concept to create.
-        content_type (int): The Content Type Id of the Concept.
+        content_type (int): The Content Type of the Concept.
         creation_type (Literal["R", "V"], optional): The Creation Type value of the Concept.
 
     Returns:

--- a/app/workers/test/CreateConcepts/test_create_concepts.py
+++ b/app/workers/test/CreateConcepts/test_create_concepts.py
@@ -21,10 +21,30 @@ def test__create_concepts():
 
     # Assert
     expected_result = [
-        {"concept": 1, "object_id": "A", "content_type": 17, "creation_type": "V"},
-        {"concept": 2, "object_id": "B", "content_type": 17, "creation_type": "V"},
-        {"concept": 3, "object_id": "B", "content_type": 17, "creation_type": "V"},
-        {"concept": 4, "object_id": "D", "content_type": 17, "creation_type": "V"},
+        {
+            "concept": 1,
+            "object_id": "A",
+            "content_type": "scanreportvalue",
+            "creation_type": "V",
+        },
+        {
+            "concept": 2,
+            "object_id": "B",
+            "content_type": "scanreportvalue",
+            "creation_type": "V",
+        },
+        {
+            "concept": 3,
+            "object_id": "B",
+            "content_type": "scanreportvalue",
+            "creation_type": "V",
+        },
+        {
+            "concept": 4,
+            "object_id": "D",
+            "content_type": "scanreportvalue",
+            "creation_type": "V",
+        },
     ]
     assert result == expected_result
 

--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@ Please append a line to the changelog for each change made.
 - Extract Azure function ProcessQueue, into UploadQueue and CreateConcepts. Moving the upload to be standalone, and creating concepts and reusing them to when the user sets the Person ID and Date Event per table.
 ### Bugfixes
 - Bug fixed in `find_existing_scan_report_concepts()` which was causing some `SRConcepts` to be processed multiple times. This didn't cause any issues, but was misleading and wasteful.
-
+- Fixed hardcoded `content_type` id used in the backend, client, and workers.
 
 ## v2.0.12
 ### New features


### PR DESCRIPTION
# Changes

Fixes the hardcoded django `content_type` ids used in the backend, client, and workers.

This enables the app to be deployed fully working.

The approach has been to make the backend to be responsible for the `content_type`, and not trust the client, in two ways:
- When a `ScanReportConcept` is created through the API (when used by the workers, or the frontend), the content type is passed as a string, this is then used to lookup the content type ID.
- When a `content_type` is used for frontend logic, mostly for rendering / filtering, a new API endpoint has been created to get the content type ID.

Closes #637 
Closes #641 

Large diffs in the Javascript are Prettier working away.

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
