### PR TITLE
Fix ProcessQueue magic numbers

### DIFF
--- a/app/workers/CreateConcepts/reuse.py
+++ b/app/workers/CreateConcepts/reuse.py
@@ -303,13 +303,13 @@ def select_concepts_to_post(
           "description", "field_name") keys (for values), with entries (field_id, concept_id)
           or (value_id, concept_id) respectively.
 
-        content_type (Literal["scanreportfield", "scanreportvalue"]): Controls whether to handle ScanReportFields (15), or ScanReportValues (17).
+        content_type (Literal["scanreportfield", "scanreportvalue"]): Controls whether to handle ScanReportFields, or ScanReportValues.
 
     Returns:
         A list of reused `Concepts` to create.
 
     Raises:
-        Exception:  ValueError: A content_type other than 15 or 17 was provided.
+        Exception:  ValueError: A content_type other than scanreportfield or scanreportvalue was provided.
     """
     concepts_to_post = []
 


### PR DESCRIPTION
# Changes

In #652 this updated the web API (amongst other things) to no longer use the hardcoded ids 15 / 17. 
But this broke the `ProcessQueue` function as it still uses them with the API. Although I'm expecting to delete this function soon, I'm keen to preserve it as a fallback option temporarily.

So this PR fixes the `ProcessQueue` to use the correct strings for the API.

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
