### PR TITLE
Fix reusing Concepts without a data dictionary

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
         poetry config virtualenvs.create false
-        poetry export --format requirements.txt --output requirements.txt
+        poetry export --format requirements.txt --output requirements.txt --without-hashes
         popd
       shell: bash
 

--- a/app/workers/shared_code/blob_parser.py
+++ b/app/workers/shared_code/blob_parser.py
@@ -133,7 +133,7 @@ def get_data_dictionary(
     Returns:
         Tuple[Optional[Dict[str, Dict[str, Any]]], Optional[Dict[str, Dict[str, Any]]]]: A tuple containing the data dictionary and vocabulary dictionary.
     """
-    if blob is None:
+    if blob is None or blob == "None":
         return None, None
 
     # Set Storage Account connection string

--- a/app/workers/shared_code/blob_parser.py
+++ b/app/workers/shared_code/blob_parser.py
@@ -133,7 +133,7 @@ def get_data_dictionary(
     Returns:
         Tuple[Optional[Dict[str, Dict[str, Any]]], Optional[Dict[str, Dict[str, Any]]]]: A tuple containing the data dictionary and vocabulary dictionary.
     """
-    if blob == "None":
+    if blob is None:
         return None, None
 
     # Set Storage Account connection string

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ Please append a line to the changelog for each change made.
 ### Improvements
 - Added a `shared` library for the database models, enabling both the Django and Azure Functions to directly access the database.
 ### Bugfixes
+- Fix reusing Concepts without a data dictionary.
 
 ## v2.1.00
 ### New features


### PR DESCRIPTION
# Changes

Fixes a bug introduced in #643, and half fixed in #661. 

Currently when a data dictionary is not supplied with a Scan Report, the two functions mark this as a "None" string, or a None type. So we now safely catch for both cases.
At some point stronger typing will help prevent these! 

Also fixes the functions build from #671 

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
