### PR TITLE
Add serverless mapping rules

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
         poetry config virtualenvs.create false
-        poetry export --format requirements.txt --output requirements.txt
+        poetry export --format requirements.txt --output requirements.txt --without-hashes
         popd
       shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,47 @@ name: test
 on: [pull_request]
 
 jobs:
+  test-shared:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11', '3.12']
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        working-directory: app/shared
+        run: poetry install --no-interaction --no-root
+
+      - name: Test with pytest Poetry
+        working-directory: app/shared
+        run: |
+          poetry run pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=sources test | tee pytest-coverage.txt
+
+      - name: Pytest coverage comment
+        uses: MishaKav/pytest-coverage-comment@main
+        with:
+          pytest-coverage-path: app/shared/pytest-coverage.txt
+          junitxml-path: app/shared/pytest.xml
+
   test-workers:
     runs-on: ubuntu-latest
     strategy:

--- a/app/api/mapping/services_rules.py
+++ b/app/api/mapping/services_rules.py
@@ -856,7 +856,7 @@ def view_mapping_rules(request, qs):
 
 
 def find_existing_scan_report_concepts(request, scan_report_id):
-    # find ScanReportValue associated to this table_id
+    # find ScanReportValue associated to this scan_report_id
     # that have at least one concept added to them
     values = (
         ScanReportValue.objects.all()
@@ -866,7 +866,7 @@ def find_existing_scan_report_concepts(request, scan_report_id):
         .order_by("id")
     )
 
-    # find ScanReportField associated to this table_id
+    # find ScanReportField associated to this scan_report_id
     # that have at least one concept added to them
     fields = (
         ScanReportField.objects.all()

--- a/app/api/mapping/services_rules.py
+++ b/app/api/mapping/services_rules.py
@@ -855,12 +855,12 @@ def view_mapping_rules(request, qs):
     return response
 
 
-def find_existing_scan_report_concepts(request, table_id):
+def find_existing_scan_report_concepts(request, scan_report_id):
     # find ScanReportValue associated to this table_id
     # that have at least one concept added to them
     values = (
         ScanReportValue.objects.all()
-        .filter(scan_report_field__scan_report_table__scan_report=table_id)
+        .filter(scan_report_field__scan_report_table__scan_report=scan_report_id)
         .filter(concepts__isnull=False)
         .distinct()
         .order_by("id")
@@ -870,7 +870,7 @@ def find_existing_scan_report_concepts(request, table_id):
     # that have at least one concept added to them
     fields = (
         ScanReportField.objects.all()
-        .filter(scan_report_table__scan_report=table_id)
+        .filter(scan_report_table__scan_report=scan_report_id)
         .filter(concepts__isnull=False)
         .distinct()
         .order_by("id")

--- a/app/api/mapping/views.py
+++ b/app/api/mapping/views.py
@@ -109,16 +109,11 @@ from .serializers import (
     UserSerializer,
     VocabularySerializer,
 )
-from .services import download_data_dictionary_blob
 from .services_nlp import start_nlp_field_level
 from .services_rules import (
     download_mapping_rules,
     download_mapping_rules_as_csv,
-    find_existing_scan_report_concepts,
     get_mapping_rules_list,
-    m_allowed_tables,
-    remove_mapping_rules,
-    save_mapping_rules,
     view_mapping_rules,
 )
 

--- a/app/api/mapping/views.py
+++ b/app/api/mapping/views.py
@@ -1270,37 +1270,6 @@ class StructuralMappingTableListView(ListView):
             qs = self.get_queryset()
             return download_mapping_rules_as_csv(request, qs)
         elif (
-            request.POST.get("refresh_rules") is not None
-            or body.get("refresh_rules", None) is not None
-        ):
-            # remove all existing rules first
-            remove_mapping_rules(request, self.kwargs.get("pk"))
-            # get all associated ScanReportConcepts for this given ScanReport
-            # this method could be taking too long to execute
-            all_associated_concepts = find_existing_scan_report_concepts(
-                request, self.kwargs.get("pk")
-            )
-            # save all of them
-            nconcepts = 0
-            nbadconcepts = 0
-            for concept in all_associated_concepts:
-                if save_mapping_rules(request, concept):
-                    nconcepts += 1
-                else:
-                    nbadconcepts += 1
-
-            if nbadconcepts == 0:
-                messages.success(
-                    request, f"Found and added rules for {nconcepts} existing concepts"
-                )
-            else:
-                messages.success(
-                    request,
-                    f"Found and added rules for {nconcepts} existing concepts. However, couldnt add rules for {nbadconcepts} concepts.",
-                )
-            return redirect(request.path)
-
-        elif (
             request.POST.get("get_svg") is not None
             or body.get("get_svg", None) is not None
         ):

--- a/app/react-client-app/src/components/EditTable.jsx
+++ b/app/react-client-app/src/components/EditTable.jsx
@@ -1,130 +1,175 @@
-import React, { useState, useEffect, useRef } from 'react'
-import { Button, Flex, Link, Spinner, useDisclosure, ScaleFade } from "@chakra-ui/react"
-import CCBreadcrumbBar from './CCBreadcrumbBar'
-import CCSelectInput from './CCSelectInput'
-import ToastAlert from '../components/ToastAlert'
-import PageHeading from './PageHeading'
-import { useGet, usePatch } from '../api/values'
+import React, { useState, useEffect, useRef } from "react";
+import {
+  Alert,
+  AlertIcon,
+  Button,
+  Flex,
+  Link,
+  Spinner,
+  useDisclosure,
+  ScaleFade,
+} from "@chakra-ui/react";
+import CCBreadcrumbBar from "./CCBreadcrumbBar";
+import CCSelectInput from "./CCSelectInput";
+import ToastAlert from "../components/ToastAlert";
+import PageHeading from "./PageHeading";
+import { useGet, usePatch } from "../api/values";
 const EditTable = (props) => {
-    const { isOpen, onOpen, onClose } = useDisclosure()
-    const [alert, setAlert] = useState({ hidden: true, title: '', description: '', status: 'error' })
-    const value = window.pk ? window.pk : window.location.href.split("tables/")[1].split("/")[0]
-    const [fields, setFields] = useState(null);
-    const [table, setTable] = useState(null);
-    const [selectedPerson, setPerson] = useState("------");
-    const [selectedDate, setDate] = useState("------");
-    const [loadingMessage, setLoadingMessage] = useState(null)
-    const canEdit = window.canEdit
-    const scanReport = useRef([]);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [alert, setAlert] = useState({
+    hidden: true,
+    title: "",
+    description: "",
+    status: "error",
+  });
+  const value = window.pk
+    ? window.pk
+    : window.location.href.split("tables/")[1].split("/")[0];
+  const [fields, setFields] = useState(null);
+  const [table, setTable] = useState(null);
+  const [selectedPerson, setPerson] = useState("------");
+  const [selectedDate, setDate] = useState("------");
+  const [loadingMessage, setLoadingMessage] = useState(null);
+  const canEdit = window.canEdit;
+  const scanReport = useRef([]);
 
-    useEffect(async () => {
-        props.setTitle(null)
-        // get scan report table to use to get tables 
-        const scanreporttable = await useGet(`/scanreporttables/${value}/`)
-        // get scan report for name and id for breadcrumbs
-        scanReport.current = await useGet(`/scanreports/${scanreporttable.scan_report}/`)
-        // get scan report tables for the scan report the table belongs to
-        const tablesFilter = useGet(`/scanreporttables/?scan_report=${scanreporttable.scan_report}`)
-        // get all fields for the scan report table
-        const fieldsFilter = useGet(`/scanreportfields/?scan_report_table=${value}&fields=name,id`)
-        const promises = await Promise.all([tablesFilter, fieldsFilter])
-        let options = promises[1]
-        let tables = promises[0]
-        // sort the options alphabetically
-        options = options.sort((a, b) => a.name.localeCompare(b.name))
-        // add a null option to use to set person_id or date_event to null
-        const nullfield = { name: "------", id: null }
-        options = [nullfield, ...options]
-        setFields(options)
-        // set initial values to current values in the database
-        const table = tables.find(table => table.id == value)
-        const person_id = options.find(field => field.id == table.person_id)
-        const date_event = options.find(field => field.id == table.date_event)
-        if (person_id) {
-            setPerson(person_id.name)
-        }
-        if (date_event) {
-            setDate(date_event.name)
-        }
-        setTable(table)
-
-    }, []);
-
-    const updateTable = () => {
-        setLoadingMessage("Updating table")
-        // update the table then redirect
-        const person_id = fields.find(field => field.name == selectedPerson)
-        const date_event = fields.find(field => field.name == selectedDate)
-        const data =
-        {
-            person_id: person_id.id,
-            date_event: date_event.id
-        }
-        usePatch(`/scanreporttables/${value}/`, data).then((res) => {
-            // redirect
-            window.location.href = `/scanreports/${table.scan_report}/`
-        })
-            .catch(err => {
-                setAlert({
-                    hidden: false,
-                    status: 'error',
-                    title: 'Could not update scan report table',
-                    description: err.statusText ? err.statusText : ""
-                })
-                onOpen()
-            })
-    }
-    if (!table || !fields || loadingMessage) {
-        //Render Loading State
-        return (
-            <div>
-                <Flex padding="30px">
-                    <Spinner />
-                    <Flex marginLeft="10px">{loadingMessage ? loadingMessage : "Loading page"}</Flex>
-                </Flex>
-            </div>
-        )
-    }
-    return (
-        <div>
-            <CCBreadcrumbBar>
-                <Link href={"/"}>Home</Link>
-                <Link href={"/scanreports/"}>Scan Reports</Link>
-                <Link href={`/scanreports/${scanReport.current.id}/`}>{scanReport.current.dataset}</Link>
-                <Link href={`/scanreports/${scanReport.current.id}/tables/${table.id}/`}>{table.name}</Link>
-                <Link href={`/scanreports/${scanReport.current.id}/tables/${table.id}/update/`}>Update</Link>
-            </CCBreadcrumbBar>
-            <PageHeading text={"Update Table"} />
-            {isOpen &&
-                <ScaleFade initialScale={0.9} in={isOpen}>
-                    <ToastAlert hide={onClose} title={alert.title} status={alert.status} description={alert.description} />
-                </ScaleFade>
-            }
-            <CCSelectInput
-                id={"table-person-id"}
-                label={"Person ID"}
-                selectOptions={fields.map((item) => item.name)}
-                handleInput={setPerson}
-                isDisabled={!canEdit}
-            />
-            <CCSelectInput
-                id={"table-date-event"}
-                label={"Date Event"}
-                selectOptions={fields.map((item) => item.name)}
-                handleInput={setDate}
-                isDisabled={!canEdit}
-            />
-            {canEdit &&
-                <Button
-                    bgColor="#3db28c"
-                    mt="10px"
-                    onClick={updateTable}
-                >
-                    Update {table.name}
-                </Button>
-            }
-        </div>
+  useEffect(async () => {
+    props.setTitle(null);
+    // get scan report table to use to get tables
+    const scanreporttable = await useGet(`/scanreporttables/${value}/`);
+    // get scan report for name and id for breadcrumbs
+    scanReport.current = await useGet(
+      `/scanreports/${scanreporttable.scan_report}/`,
     );
-}
+    // get scan report tables for the scan report the table belongs to
+    const tablesFilter = useGet(
+      `/scanreporttables/?scan_report=${scanreporttable.scan_report}`,
+    );
+    // get all fields for the scan report table
+    const fieldsFilter = useGet(
+      `/scanreportfields/?scan_report_table=${value}&fields=name,id`,
+    );
+    const promises = await Promise.all([tablesFilter, fieldsFilter]);
+    let options = promises[1];
+    let tables = promises[0];
+    // sort the options alphabetically
+    options = options.sort((a, b) => a.name.localeCompare(b.name));
+    // add a null option to use to set person_id or date_event to null
+    const nullfield = { name: "------", id: null };
+    options = [nullfield, ...options];
+    setFields(options);
+    // set initial values to current values in the database
+    const table = tables.find((table) => table.id == value);
+    const person_id = options.find((field) => field.id == table.person_id);
+    const date_event = options.find((field) => field.id == table.date_event);
+    if (person_id) {
+      setPerson(person_id.name);
+    }
+    if (date_event) {
+      setDate(date_event.name);
+    }
+    setTable(table);
+  }, []);
+
+  const updateTable = () => {
+    setLoadingMessage("Updating table");
+    // update the table then redirect
+    const person_id = fields.find((field) => field.name == selectedPerson);
+    const date_event = fields.find((field) => field.name == selectedDate);
+    const data = {
+      person_id: person_id.id,
+      date_event: date_event.id,
+    };
+    usePatch(`/scanreporttables/${value}/`, data)
+      .then((res) => {
+        // redirect
+        window.location.href = `/scanreports/${table.scan_report}/`;
+      })
+      .catch((err) => {
+        setAlert({
+          hidden: false,
+          status: "error",
+          title: "Could not update scan report table",
+          description: err.statusText ? err.statusText : "",
+        });
+        onOpen();
+      });
+  };
+  if (!table || !fields || loadingMessage) {
+    //Render Loading State
+    return (
+      <div>
+        <Flex padding="30px">
+          <Spinner />
+          <Flex marginLeft="10px">
+            {loadingMessage ? loadingMessage : "Loading page"}
+          </Flex>
+        </Flex>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <CCBreadcrumbBar>
+        <Link href={"/"}>Home</Link>
+        <Link href={"/scanreports/"}>Scan Reports</Link>
+        <Link href={`/scanreports/${scanReport.current.id}/`}>
+          {scanReport.current.dataset}
+        </Link>
+        <Link
+          href={`/scanreports/${scanReport.current.id}/tables/${table.id}/`}
+        >
+          {table.name}
+        </Link>
+        <Link
+          href={`/scanreports/${scanReport.current.id}/tables/${table.id}/update/`}
+        >
+          Update
+        </Link>
+      </CCBreadcrumbBar>
+      <PageHeading text={"Update Table"} />
+      {isOpen && (
+        <ScaleFade initialScale={0.9} in={isOpen}>
+          <ToastAlert
+            hide={onClose}
+            title={alert.title}
+            status={alert.status}
+            description={alert.description}
+          />
+        </ScaleFade>
+      )}
+      <Flex paddingTop={5} paddingBottom={5}>
+        <Alert status="info">
+          <AlertIcon />
+          Mapping Rules cannot be generated without the Person ID and Date Event
+          being set.
+          <br />
+          Once you set these, Concepts that are reusable will be associated and
+          Mapping Rules will be generated.
+          <br />
+        </Alert>
+      </Flex>
+      <CCSelectInput
+        id={"table-person-id"}
+        label={"Person ID"}
+        selectOptions={fields.map((item) => item.name)}
+        handleInput={setPerson}
+        isDisabled={!canEdit}
+      />
+      <CCSelectInput
+        id={"table-date-event"}
+        label={"Date Event"}
+        selectOptions={fields.map((item) => item.name)}
+        handleInput={setDate}
+        isDisabled={!canEdit}
+      />
+      {canEdit && (
+        <Button bgColor="#3db28c" mt="10px" onClick={updateTable}>
+          Update {table.name}
+        </Button>
+      )}
+    </div>
+  );
+};
 
 export default EditTable;

--- a/app/react-client-app/src/components/EditTable.jsx
+++ b/app/react-client-app/src/components/EditTable.jsx
@@ -144,8 +144,8 @@ const EditTable = (props) => {
           Mapping Rules cannot be generated without the Person ID and Date Event
           being set.
           <br />
-          Once you set these, Concepts that are reusable will be associated and
-          Mapping Rules will be generated.
+          Once you set these, Mapping Rules will be generated for all Concepts
+          currently associated to the table.
           <br />
         </Alert>
       </Flex>

--- a/app/react-client-app/src/components/MappingTbl.jsx
+++ b/app/react-client-app/src/components/MappingTbl.jsx
@@ -1,413 +1,530 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef } from "react";
 import {
-    Center,
-    Flex,
-    Spinner,
-    Link,
-    Wrap,
-    Button,
-    useDisclosure,
-} from "@chakra-ui/react"
+  Center,
+  Flex,
+  Spinner,
+  Link,
+  Wrap,
+  Button,
+  useDisclosure,
+} from "@chakra-ui/react";
 
-import { ArrowForwardIcon } from '@chakra-ui/icons'
-import { useGet, usePost } from '../api/values'
-import { set_pagination_variables } from '../api/pagination_helpers'
-import ConceptTag from './ConceptTag'
-import MappingModal from './MappingModal'
-import AnalysisModal from './AnalysisModal'
-import SummaryTbl from './SummaryTbl'
-import RulesTbl from './RulesTbl'
-import ConceptAnalysis from './ConceptAnalysis'
-import PageHeading from './PageHeading'
-import CCBreadcrumbBar from './CCBreadcrumbBar'
-import Pagination from 'react-js-pagination'
-
+import { ArrowForwardIcon } from "@chakra-ui/icons";
+import { useGet, usePost } from "../api/values";
+import { set_pagination_variables } from "../api/pagination_helpers";
+import ConceptTag from "./ConceptTag";
+import MappingModal from "./MappingModal";
+import AnalysisModal from "./AnalysisModal";
+import SummaryTbl from "./SummaryTbl";
+import RulesTbl from "./RulesTbl";
+import ConceptAnalysis from "./ConceptAnalysis";
+import PageHeading from "./PageHeading";
+import CCBreadcrumbBar from "./CCBreadcrumbBar";
+import Pagination from "react-js-pagination";
 
 const MappingTbl = (props) => {
-    const pathArray = window.location.pathname.split("/")
-    const scan_report_id = pathArray[pathArray.length - 3]
-    const scanReportName = useRef(null);
-    const [values, setValues] = useState([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(undefined);
-    const [loadingMessage, setLoadingMessage] = useState("");
-    const [mapDiagram, setMapDiagram] = useState({ showing: false, image: null });
-    const svg = useRef(null);
-    const [destinationTableFilter, setDestinationTableFilter] = useState([]);
-    const [sourceTableFilter, setSourceTableFilter] = useState([]);
-    const [filters, setFilters] = useState([]);
-    const [isDownloading, setDownloading] = useState(false);
-    const [isDownloadingCSV, setDownloadingCSV] = useState(false);
-    const [isDownloadingImg, setDownloadingImg] = useState(false);
-    const downLoadingImgRef = useRef(false)
-    const { isOpen, onOpen, onClose } = useDisclosure()
-    const { isOpen: isOpenAnalyse, onOpen: onOpenAnalyse, onClose: onCloseAnalyse } = useDisclosure()
-    const [page_size, set_page_size] = useState(30)
-    const [currentPage, setCurrentPage] = useState(1);
-    const [totalItemsCount, setTotalItemsCount] = useState(null);
-    const [firstLoad, setFirstLoad] = useState(true);
+  const pathArray = window.location.pathname.split("/");
+  const scan_report_id = pathArray[pathArray.length - 3];
+  const scanReportName = useRef(null);
+  const [values, setValues] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(undefined);
+  const [loadingMessage, setLoadingMessage] = useState("");
+  const [mapDiagram, setMapDiagram] = useState({ showing: false, image: null });
+  const svg = useRef(null);
+  const [destinationTableFilter, setDestinationTableFilter] = useState([]);
+  const [sourceTableFilter, setSourceTableFilter] = useState([]);
+  const [filters, setFilters] = useState([]);
+  const [isDownloading, setDownloading] = useState(false);
+  const [isDownloadingCSV, setDownloadingCSV] = useState(false);
+  const [isDownloadingImg, setDownloadingImg] = useState(false);
+  const downLoadingImgRef = useRef(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isOpenAnalyse,
+    onOpen: onOpenAnalyse,
+    onClose: onCloseAnalyse,
+  } = useDisclosure();
+  const [page_size, set_page_size] = useState(30);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalItemsCount, setTotalItemsCount] = useState(null);
+  const [firstLoad, setFirstLoad] = useState(true);
 
-    useEffect(async () => {
-        // run on initial load of the page
-        props.setTitle(null)
-        // get scan report name for breadcrumbs
-        useGet(`/scanreports/${scan_report_id}/`).then(sr => scanReportName.current = sr.dataset)
-
-        let { local_page, local_page_size } = await set_pagination_variables(window.location.search, page_size, set_page_size, currentPage, setCurrentPage);
-        window.history.pushState({}, '', `/scanreports/${scan_report_id}/mapping_rules/?p=${local_page}&page_size=${local_page_size}`)
-
-        setFirstLoad(false)
-    }, []);
-
-
-    useEffect(async () => {
-        // if not the first load, then load data etc. This clause avoids an initial call using the default values of
-        // currentPage and page_size, which is not desired.
-        if (!firstLoad) {
-            try {
-                // get all mapping rules for the page unfiltered
-                let res = await useGet(`/mappingruleslist/?id=${scan_report_id}&p=${currentPage}&page_size=${page_size}`)
-                setTotalItemsCount(res.count)
-
-                // sort results and add an index to be able to find them later
-                let tempRules = res.results.sort((a, b) => a.rule_id > b.rule_id ? 1 : b.rule_id > a.rule_id ? -1 : 0).map((item, index) => ({ ...item, startIndex: index }));
-
-                // Here there used to be functionality to highlight any values/fields with more than one associated concept.
-                // This has now been removed due to the way pagination works.
-                // Look in the git history if this needs rectifying in future!
-
-                const setValuesAsync = async (tempRules) => {
-                    setValues(tempRules)
-                }
-                setValuesAsync(tempRules)
-
-                setLoading(false);
-                setLoadingMessage("");
-            }
-            catch (error) {
-                setLoading(false);
-                setLoadingMessage("");
-                setError("An error has occurred while fetching the rules")
-            }
-        }
-    }, [currentPage, page_size, firstLoad]);
-
-    useEffect(async () => {
-        // run when map diagram state has changed
-        if (!mapDiagram.image) {
-            // if no map diagram is loaded, request to get a new one
-
-            const result = await usePost(window.location.href, { 'get_svg': true }, false);
-            const diagramString = await result.data
-            var parser = new DOMParser();
-            var diagram = parser.parseFromString(diagramString, "text/html");
-
-            setMapDiagram((mapDiagram2) => ({ ...mapDiagram2, image: diagram.getElementsByTagName("svg")[0] }));
-            if (svg.current) {
-                if (svg.current.hasChildNodes()) {
-                    while (svg.current.firstChild) {
-                        svg.current.removeChild(svg.current.lastChild);
-                    }
-                }
-                svg.current.appendChild(diagram.getElementsByTagName("svg")[0]);
-            }
-            if (downLoadingImgRef.current == true) {
-                downloadImage(diagram.getElementsByTagName("svg")[0]);
-            }
-        }
-        else {
-            if (svg.current) {
-                if (svg.current.hasChildNodes()) {
-                    // remove all other diagrams if they exist
-                    while (svg.current.firstChild) {
-                        svg.current.removeChild(svg.current.lastChild);
-                    }
-                }
-                svg.current.appendChild(mapDiagram.image)
-            }
-        }
-    }, [mapDiagram]);
-
-    const onPageChange = (page) => {
-        window.history.pushState({}, '', `/scanreports/${scan_report_id}/mapping_rules/?p=${page}&page_size=${page_size}`)
-        setCurrentPage(page)
-    }
-
-    // call refresh rules function from django then get new data
-    const refreshRules = async () => {
-        setLoading(true)
-        setLoadingMessage("Refreshing rules")
-        try {
-            await usePost(window.location.href, { 'refresh_rules': true }, false)
-            setLoadingMessage("Rules Refreshed. Getting Mapping Rules")
-            window.location.reload(true)
-        }
-        catch (err) {
-            console.log(err)
-        }
-
-    }
-    // download map diagram
-    const downloadImage = (img) => {
-        setDownloadingImg(true);
-        if (mapDiagram.image || img) {
-            let svg2;
-            if (img) {
-                svg2 = img;
-            } else {
-                svg2 = mapDiagram.image;
-            }
-            var serializer = new XMLSerializer();
-            var source = serializer.serializeToString(svg2);
-            if (!source.match(/^<svg[^>]+xmlns="http\:\/\/www\.w3\.org\/2000\/svg"/)) {
-                source = source.replace(/^<svg/, '<svg xmlns="http://www.w3.org/2000/svg"');
-            }
-            if (!source.match(/^<svg[^>]+"http\:\/\/www\.w3\.org\/1999\/xlink"/)) {
-                source = source.replace(/^<svg/, '<svg xmlns:xlink="http://www.w3.org/1999/xlink"');
-            }
-            source = '<?xml version="1.0" standalone="no"?>\r\n' + source;
-            var url = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(source);
-            var element = document.createElement("a");
-            element.download = "diagram.svg";
-            element.href = url;
-            element.click();
-            element.remove();
-            setDownloadingImg(false);
-            downLoadingImgRef.current = false;
-        } else {
-            downLoadingImgRef.current = true;
-        }
-    };
-
-    // apply destination table and source table filters to data
-    const applyFilters = (variable) => {
-        let newData = variable.map((scanreport) => scanreport);
-        if (destinationTableFilter.length > 0) {
-            newData = newData.filter((rule) => destinationTableFilter.includes(rule.destination_table.name));
-        }
-        if (sourceTableFilter.length > 0) {
-            newData = newData.filter((rule) => sourceTableFilter.includes(rule.source_table.name));
-        }
-        return newData;
-    };
-
-    // if filter does not already exist, create a new destination table filter
-    // and get a new map diagram
-    const setDestinationFilter = (value) => {
-        if (filters.find(filter => filter.name == value) == null) {
-            setFilters(current => [...current, { title: "Destination Table:", name: value }])
-            setDestinationTableFilter(current => [...current, value])
-
-        }
-    };
-    // if filter does not already exist, create a new source table filter
-    // and get a new map diagram
-    const setSourceFilter = (value) => {
-        if (filters.find(filter => filter.name == value) == null) {
-            setFilters(current => [...current, { title: "Source Table:", name: value }])
-            setSourceTableFilter(current => [...current, value])
-
-        }
-
-    };
-    // remove a filter. Called inside concept tag
-    const removeFilter = (title, name) => {
-        setFilters(current => current.filter(filter => filter.name != name || filter.title != title))
-
-        if (title.includes("Destination Table")) {
-            setDestinationTableFilter(current => current.filter(filter => filter != name))
-        }
-        if (title.includes("Source Table")) {
-            setSourceTableFilter(current => current.filter(filter => filter != name))
-        }
-    };
-
-    const downloadRules = async () => {
-        try {
-            setDownloading(true)
-            const response = await usePost(window.location.href, { 'download_rules': true }, false)
-            var type = response.headers['content-type'];
-            var blob = new Blob([JSON.stringify(response.data, null, 6)], { type: type });
-
-            // check for a filename
-            var filename = "";
-            var disposition = response.headers['content-disposition'];
-            if (disposition && disposition.indexOf('attachment') !== -1) {
-                var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-                var matches = filenameRegex.exec(disposition);
-                if (matches != null && matches[1]) filename = matches[1].replace(/['"]/g, '');
-            }
-
-
-            if (typeof window.navigator.msSaveBlob !== 'undefined') {
-                // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
-                window.navigator.msSaveBlob(blob, filename);
-            }
-            else {
-                var URL = window.URL || window.webkitURL;
-                var downloadUrl = URL.createObjectURL(blob);
-                if (filename) {
-                    // use HTML5 a[download] attribute to specify filename
-                    var a = document.createElement("a");
-                    // safari doesn't support this yet
-                    if (typeof a.download === 'undefined') {
-                        window.location.href = downloadUrl;
-                    }
-                    else {
-                        a.href = downloadUrl;
-                        a.download = filename;
-                        document.body.appendChild(a);
-                        a.click();
-                    }
-                }
-                else {
-                    window.location = downloadUrl;
-                }
-                setTimeout(function () { URL.revokeObjectURL(downloadUrl); }, 100); // cleanup
-
-            }
-            setDownloading(false)
-        }
-        catch (err) {
-            setDownloading(false)
-            alert("Could not download rules")
-        }
-
-    };
-
-    const downloadCSV = async () => {
-        try {
-            setDownloadingCSV(true)
-            const response = await usePost(window.location.href, { 'download_rules_as_csv': true }, false)
-            var type = response.headers['content-type'];
-            var blob = new Blob([response.data], { type: type });
-
-            // check for a filename
-            var filename = "";
-            var disposition = response.headers['content-disposition'];
-            if (disposition && disposition.indexOf('attachment') !== -1) {
-                var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-                var matches = filenameRegex.exec(disposition);
-                if (matches != null && matches[1]) filename = matches[1].replace(/['"]/g, '');
-            }
-
-
-            if (typeof window.navigator.msSaveBlob !== 'undefined') {
-                // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
-                window.navigator.msSaveBlob(blob, filename);
-            }
-            else {
-                var URL = window.URL || window.webkitURL;
-                var downloadUrl = URL.createObjectURL(blob);
-                if (filename) {
-                    // use HTML5 a[download] attribute to specify filename
-                    var a = document.createElement("a");
-                    // safari doesn't support this yet
-                    if (typeof a.download === 'undefined') {
-                        window.location.href = downloadUrl;
-                    }
-                    else {
-                        a.href = downloadUrl;
-                        a.download = filename;
-                        document.body.appendChild(a);
-                        a.click();
-                    }
-                }
-                else {
-                    window.location = downloadUrl;
-                }
-                setTimeout(function () { URL.revokeObjectURL(downloadUrl); }, 100); // cleanup
-
-            }
-            setDownloadingCSV(false)
-        }
-        catch (err) {
-            setDownloadingCSV(false)
-            alert("Could not download csv")
-        }
-
-    }
-
-    if (loading) {
-        //Render Loading State
-        return (
-            <div>
-                <Flex padding="30px">
-                    <Spinner />
-                    <Flex marginLeft="10px">{loadingMessage ? loadingMessage : "Loading Mapping rules"}</Flex>
-                </Flex>
-            </div>
-        )
-    }
-    return (
-        <div >
-            <MappingModal isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
-                <SummaryTbl values={values}
-                    filters={filters} removeFilter={removeFilter} setDestinationFilter={setDestinationFilter} setSourceFilter={setSourceFilter}
-                    destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} scanReportId={scan_report_id} />
-            </MappingModal>
-            <AnalysisModal isOpenAnalyse={isOpenAnalyse} onOpenAnalyse={onOpenAnalyse} onCloseAnalyse={onCloseAnalyse}>
-                <ConceptAnalysis scan_report_id={scan_report_id} />
-            </AnalysisModal>
-            <CCBreadcrumbBar>
-                <Link href={"/"}>Home</Link>
-                <Link href={"/scanreports/"}>Scan Reports</Link>
-                <Link href={`/scanreports/${scan_report_id}/`}>{scanReportName.current}</Link>
-                <Link href={`/scanreports/${scan_report_id}/mapping_rules/`}>Mapping Rules</Link>
-            </CCBreadcrumbBar>
-            <PageHeading text={"Mapping Rules"} />
-            <Wrap my="10px">
-                <Button variant="green" onClick={() => { refreshRules() }}>Refresh Rules</Button>
-                <Button variant="blue" isLoading={isDownloading} loadingText="Downloading" spinnerPlacement="start" onClick={downloadRules}>Download Mapping JSON</Button>
-                <Button variant="yellow" onClick={() => { setMapDiagram(mapDiagram => ({ ...mapDiagram, showing: !mapDiagram.showing })) }}>{mapDiagram.showing ? "Hide " : "View "}Map Diagram</Button>
-                <Button variant="red" isLoading={isDownloadingImg} loadingText="Downloading" spinnerPlacement="start" onClick={() => { downloadImage() }}>Download Map Diagram</Button>
-                <Button variant="blue" isLoading={isDownloadingCSV} loadingText="Downloading" spinnerPlacement="start" onClick={downloadCSV}>Download Mapping CSV</Button>
-                <Button variant="blue" onClick={onOpen}>Show Summary view</Button>
-                <Button variant="blue" onClick={onOpenAnalyse}>Analyse Rules</Button>
-            </Wrap>
-
-            <div>
-                {mapDiagram.showing &&
-                    <>
-                        <div style={{ marginTop: '10px', marginBottom: '10px' }} ref={svg} />
-                        {values.length > 0 ?
-                            <>
-                                {mapDiagram.image == null &&
-                                    <Flex padding="30px">
-                                        <Spinner />
-                                        <Flex marginLeft="10px">Loading Map Diagram</Flex>
-                                    </Flex>
-                                }
-                            </>
-                            :
-                            <Flex padding="30px">
-                                <Flex marginLeft="10px">No Diagram to load</Flex>
-                            </Flex>
-                        }
-                    </>
-                }
-            </div>
-            <Center>
-                <Pagination
-                    activePage={currentPage}
-                    itemsCountPerPage={page_size}
-                    totalItemsCount={totalItemsCount}
-                    pageRangeDisplayed={5}
-                    onChange={onPageChange}
-                    itemClass='btn paginate-inactive'
-                    activeClass='btn paginate-active'
-                />
-            </Center>
-            {error ?
-                <div>{error}</div>
-                :
-                <RulesTbl values={values}
-                    filters={filters} removeFilter={removeFilter} setDestinationFilter={setDestinationFilter} setSourceFilter={setSourceFilter}
-                    destinationTableFilter={destinationTableFilter} sourceTableFilter={sourceTableFilter} applyFilters={applyFilters} scanReportId={scan_report_id} />
-
-            }
-        </div>
+  useEffect(async () => {
+    // run on initial load of the page
+    props.setTitle(null);
+    // get scan report name for breadcrumbs
+    useGet(`/scanreports/${scan_report_id}/`).then(
+      (sr) => (scanReportName.current = sr.dataset),
     );
-}
+
+    let { local_page, local_page_size } = await set_pagination_variables(
+      window.location.search,
+      page_size,
+      set_page_size,
+      currentPage,
+      setCurrentPage,
+    );
+    window.history.pushState(
+      {},
+      "",
+      `/scanreports/${scan_report_id}/mapping_rules/?p=${local_page}&page_size=${local_page_size}`,
+    );
+
+    setFirstLoad(false);
+  }, []);
+
+  useEffect(async () => {
+    // if not the first load, then load data etc. This clause avoids an initial call using the default values of
+    // currentPage and page_size, which is not desired.
+    if (!firstLoad) {
+      try {
+        // get all mapping rules for the page unfiltered
+        let res = await useGet(
+          `/mappingruleslist/?id=${scan_report_id}&p=${currentPage}&page_size=${page_size}`,
+        );
+        setTotalItemsCount(res.count);
+
+        // sort results and add an index to be able to find them later
+        let tempRules = res.results
+          .sort((a, b) =>
+            a.rule_id > b.rule_id ? 1 : b.rule_id > a.rule_id ? -1 : 0,
+          )
+          .map((item, index) => ({ ...item, startIndex: index }));
+
+        // Here there used to be functionality to highlight any values/fields with more than one associated concept.
+        // This has now been removed due to the way pagination works.
+        // Look in the git history if this needs rectifying in future!
+
+        const setValuesAsync = async (tempRules) => {
+          setValues(tempRules);
+        };
+        setValuesAsync(tempRules);
+
+        setLoading(false);
+        setLoadingMessage("");
+      } catch (error) {
+        setLoading(false);
+        setLoadingMessage("");
+        setError("An error has occurred while fetching the rules");
+      }
+    }
+  }, [currentPage, page_size, firstLoad]);
+
+  useEffect(async () => {
+    // run when map diagram state has changed
+    if (!mapDiagram.image) {
+      // if no map diagram is loaded, request to get a new one
+
+      const result = await usePost(
+        window.location.href,
+        { get_svg: true },
+        false,
+      );
+      const diagramString = await result.data;
+      var parser = new DOMParser();
+      var diagram = parser.parseFromString(diagramString, "text/html");
+
+      setMapDiagram((mapDiagram2) => ({
+        ...mapDiagram2,
+        image: diagram.getElementsByTagName("svg")[0],
+      }));
+      if (svg.current) {
+        if (svg.current.hasChildNodes()) {
+          while (svg.current.firstChild) {
+            svg.current.removeChild(svg.current.lastChild);
+          }
+        }
+        svg.current.appendChild(diagram.getElementsByTagName("svg")[0]);
+      }
+      if (downLoadingImgRef.current == true) {
+        downloadImage(diagram.getElementsByTagName("svg")[0]);
+      }
+    } else {
+      if (svg.current) {
+        if (svg.current.hasChildNodes()) {
+          // remove all other diagrams if they exist
+          while (svg.current.firstChild) {
+            svg.current.removeChild(svg.current.lastChild);
+          }
+        }
+        svg.current.appendChild(mapDiagram.image);
+      }
+    }
+  }, [mapDiagram]);
+
+  const onPageChange = (page) => {
+    window.history.pushState(
+      {},
+      "",
+      `/scanreports/${scan_report_id}/mapping_rules/?p=${page}&page_size=${page_size}`,
+    );
+    setCurrentPage(page);
+  };
+
+  // call refresh rules function from django then get new data
+  const refreshRules = async () => {
+    setLoading(true);
+    setLoadingMessage("Refreshing rules");
+    try {
+      await usePost(window.location.href, { refresh_rules: true }, false);
+      setLoadingMessage("Rules Refreshed. Getting Mapping Rules");
+      window.location.reload(true);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+  // download map diagram
+  const downloadImage = (img) => {
+    setDownloadingImg(true);
+    if (mapDiagram.image || img) {
+      let svg2;
+      if (img) {
+        svg2 = img;
+      } else {
+        svg2 = mapDiagram.image;
+      }
+      var serializer = new XMLSerializer();
+      var source = serializer.serializeToString(svg2);
+      if (
+        !source.match(/^<svg[^>]+xmlns="http\:\/\/www\.w3\.org\/2000\/svg"/)
+      ) {
+        source = source.replace(
+          /^<svg/,
+          '<svg xmlns="http://www.w3.org/2000/svg"',
+        );
+      }
+      if (!source.match(/^<svg[^>]+"http\:\/\/www\.w3\.org\/1999\/xlink"/)) {
+        source = source.replace(
+          /^<svg/,
+          '<svg xmlns:xlink="http://www.w3.org/1999/xlink"',
+        );
+      }
+      source = '<?xml version="1.0" standalone="no"?>\r\n' + source;
+      var url =
+        "data:image/svg+xml;charset=utf-8," + encodeURIComponent(source);
+      var element = document.createElement("a");
+      element.download = "diagram.svg";
+      element.href = url;
+      element.click();
+      element.remove();
+      setDownloadingImg(false);
+      downLoadingImgRef.current = false;
+    } else {
+      downLoadingImgRef.current = true;
+    }
+  };
+
+  // apply destination table and source table filters to data
+  const applyFilters = (variable) => {
+    let newData = variable.map((scanreport) => scanreport);
+    if (destinationTableFilter.length > 0) {
+      newData = newData.filter((rule) =>
+        destinationTableFilter.includes(rule.destination_table.name),
+      );
+    }
+    if (sourceTableFilter.length > 0) {
+      newData = newData.filter((rule) =>
+        sourceTableFilter.includes(rule.source_table.name),
+      );
+    }
+    return newData;
+  };
+
+  // if filter does not already exist, create a new destination table filter
+  // and get a new map diagram
+  const setDestinationFilter = (value) => {
+    if (filters.find((filter) => filter.name == value) == null) {
+      setFilters((current) => [
+        ...current,
+        { title: "Destination Table:", name: value },
+      ]);
+      setDestinationTableFilter((current) => [...current, value]);
+    }
+  };
+  // if filter does not already exist, create a new source table filter
+  // and get a new map diagram
+  const setSourceFilter = (value) => {
+    if (filters.find((filter) => filter.name == value) == null) {
+      setFilters((current) => [
+        ...current,
+        { title: "Source Table:", name: value },
+      ]);
+      setSourceTableFilter((current) => [...current, value]);
+    }
+  };
+  // remove a filter. Called inside concept tag
+  const removeFilter = (title, name) => {
+    setFilters((current) =>
+      current.filter((filter) => filter.name != name || filter.title != title),
+    );
+
+    if (title.includes("Destination Table")) {
+      setDestinationTableFilter((current) =>
+        current.filter((filter) => filter != name),
+      );
+    }
+    if (title.includes("Source Table")) {
+      setSourceTableFilter((current) =>
+        current.filter((filter) => filter != name),
+      );
+    }
+  };
+
+  const downloadRules = async () => {
+    try {
+      setDownloading(true);
+      const response = await usePost(
+        window.location.href,
+        { download_rules: true },
+        false,
+      );
+      var type = response.headers["content-type"];
+      var blob = new Blob([JSON.stringify(response.data, null, 6)], {
+        type: type,
+      });
+
+      // check for a filename
+      var filename = "";
+      var disposition = response.headers["content-disposition"];
+      if (disposition && disposition.indexOf("attachment") !== -1) {
+        var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+        var matches = filenameRegex.exec(disposition);
+        if (matches != null && matches[1])
+          filename = matches[1].replace(/['"]/g, "");
+      }
+
+      if (typeof window.navigator.msSaveBlob !== "undefined") {
+        // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
+        window.navigator.msSaveBlob(blob, filename);
+      } else {
+        var URL = window.URL || window.webkitURL;
+        var downloadUrl = URL.createObjectURL(blob);
+        if (filename) {
+          // use HTML5 a[download] attribute to specify filename
+          var a = document.createElement("a");
+          // safari doesn't support this yet
+          if (typeof a.download === "undefined") {
+            window.location.href = downloadUrl;
+          } else {
+            a.href = downloadUrl;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+          }
+        } else {
+          window.location = downloadUrl;
+        }
+        setTimeout(function () {
+          URL.revokeObjectURL(downloadUrl);
+        }, 100); // cleanup
+      }
+      setDownloading(false);
+    } catch (err) {
+      setDownloading(false);
+      alert("Could not download rules");
+    }
+  };
+
+  const downloadCSV = async () => {
+    try {
+      setDownloadingCSV(true);
+      const response = await usePost(
+        window.location.href,
+        { download_rules_as_csv: true },
+        false,
+      );
+      var type = response.headers["content-type"];
+      var blob = new Blob([response.data], { type: type });
+
+      // check for a filename
+      var filename = "";
+      var disposition = response.headers["content-disposition"];
+      if (disposition && disposition.indexOf("attachment") !== -1) {
+        var filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+        var matches = filenameRegex.exec(disposition);
+        if (matches != null && matches[1])
+          filename = matches[1].replace(/['"]/g, "");
+      }
+
+      if (typeof window.navigator.msSaveBlob !== "undefined") {
+        // IE workaround for "HTML7007: One or more blob URLs were revoked by closing the blob for which they were created. These URLs will no longer resolve as the data backing the URL has been freed."
+        window.navigator.msSaveBlob(blob, filename);
+      } else {
+        var URL = window.URL || window.webkitURL;
+        var downloadUrl = URL.createObjectURL(blob);
+        if (filename) {
+          // use HTML5 a[download] attribute to specify filename
+          var a = document.createElement("a");
+          // safari doesn't support this yet
+          if (typeof a.download === "undefined") {
+            window.location.href = downloadUrl;
+          } else {
+            a.href = downloadUrl;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+          }
+        } else {
+          window.location = downloadUrl;
+        }
+        setTimeout(function () {
+          URL.revokeObjectURL(downloadUrl);
+        }, 100); // cleanup
+      }
+      setDownloadingCSV(false);
+    } catch (err) {
+      setDownloadingCSV(false);
+      alert("Could not download csv");
+    }
+  };
+
+  if (loading) {
+    //Render Loading State
+    return (
+      <div>
+        <Flex padding="30px">
+          <Spinner />
+          <Flex marginLeft="10px">
+            {loadingMessage ? loadingMessage : "Loading Mapping rules"}
+          </Flex>
+        </Flex>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <MappingModal isOpen={isOpen} onOpen={onOpen} onClose={onClose}>
+        <SummaryTbl
+          values={values}
+          filters={filters}
+          removeFilter={removeFilter}
+          setDestinationFilter={setDestinationFilter}
+          setSourceFilter={setSourceFilter}
+          destinationTableFilter={destinationTableFilter}
+          sourceTableFilter={sourceTableFilter}
+          scanReportId={scan_report_id}
+        />
+      </MappingModal>
+      <AnalysisModal
+        isOpenAnalyse={isOpenAnalyse}
+        onOpenAnalyse={onOpenAnalyse}
+        onCloseAnalyse={onCloseAnalyse}
+      >
+        <ConceptAnalysis scan_report_id={scan_report_id} />
+      </AnalysisModal>
+      <CCBreadcrumbBar>
+        <Link href={"/"}>Home</Link>
+        <Link href={"/scanreports/"}>Scan Reports</Link>
+        <Link href={`/scanreports/${scan_report_id}/`}>
+          {scanReportName.current}
+        </Link>
+        <Link href={`/scanreports/${scan_report_id}/mapping_rules/`}>
+          Mapping Rules
+        </Link>
+      </CCBreadcrumbBar>
+      <PageHeading text={"Mapping Rules"} />
+      <Wrap my="10px">
+        <Button
+          variant="blue"
+          isLoading={isDownloading}
+          loadingText="Downloading"
+          spinnerPlacement="start"
+          onClick={downloadRules}
+        >
+          Download Mapping JSON
+        </Button>
+        <Button
+          variant="yellow"
+          onClick={() => {
+            setMapDiagram((mapDiagram) => ({
+              ...mapDiagram,
+              showing: !mapDiagram.showing,
+            }));
+          }}
+        >
+          {mapDiagram.showing ? "Hide " : "View "}Map Diagram
+        </Button>
+        <Button
+          variant="red"
+          isLoading={isDownloadingImg}
+          loadingText="Downloading"
+          spinnerPlacement="start"
+          onClick={() => {
+            downloadImage();
+          }}
+        >
+          Download Map Diagram
+        </Button>
+        <Button
+          variant="blue"
+          isLoading={isDownloadingCSV}
+          loadingText="Downloading"
+          spinnerPlacement="start"
+          onClick={downloadCSV}
+        >
+          Download Mapping CSV
+        </Button>
+        <Button variant="blue" onClick={onOpen}>
+          Show Summary view
+        </Button>
+        <Button variant="blue" onClick={onOpenAnalyse}>
+          Analyse Rules
+        </Button>
+      </Wrap>
+
+      <div>
+        {mapDiagram.showing && (
+          <>
+            <div
+              style={{ marginTop: "10px", marginBottom: "10px" }}
+              ref={svg}
+            />
+            {values.length > 0 ? (
+              <>
+                {mapDiagram.image == null && (
+                  <Flex padding="30px">
+                    <Spinner />
+                    <Flex marginLeft="10px">Loading Map Diagram</Flex>
+                  </Flex>
+                )}
+              </>
+            ) : (
+              <Flex padding="30px">
+                <Flex marginLeft="10px">No Diagram to load</Flex>
+              </Flex>
+            )}
+          </>
+        )}
+      </div>
+      <Center>
+        <Pagination
+          activePage={currentPage}
+          itemsCountPerPage={page_size}
+          totalItemsCount={totalItemsCount}
+          pageRangeDisplayed={5}
+          onChange={onPageChange}
+          itemClass="btn paginate-inactive"
+          activeClass="btn paginate-active"
+        />
+      </Center>
+      {error ? (
+        <div>{error}</div>
+      ) : (
+        <RulesTbl
+          values={values}
+          filters={filters}
+          removeFilter={removeFilter}
+          setDestinationFilter={setDestinationFilter}
+          setSourceFilter={setSourceFilter}
+          destinationTableFilter={destinationTableFilter}
+          sourceTableFilter={sourceTableFilter}
+          applyFilters={applyFilters}
+          scanReportId={scan_report_id}
+        />
+      )}
+    </div>
+  );
+};
 
 export default MappingTbl;

--- a/app/shared/.vscode/settings.json
+++ b/app/shared/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "python.testing.pytestEnabled": true,
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestArgs": [
+    "test"
+  ]
+}

--- a/app/shared/poetry.lock
+++ b/app/shared/poetry.lock
@@ -15,6 +15,219 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
+name = "azure-core"
+version = "1.30.1"
+description = "Microsoft Azure Core Library for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "azure-core-1.30.1.tar.gz", hash = "sha256:26273a254131f84269e8ea4464f3560c731f29c0c1f69ac99010845f239c1a8f"},
+    {file = "azure_core-1.30.1-py3-none-any.whl", hash = "sha256:7c5ee397e48f281ec4dd773d67a0a47a0962ed6fa833036057f9ea067f688e74"},
+]
+
+[package.dependencies]
+requests = ">=2.21.0"
+six = ">=1.11.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["aiohttp (>=3.0)"]
+
+[[package]]
+name = "azure-storage-queue"
+version = "12.9.0"
+description = "Microsoft Azure Azure Queue Storage Client Library for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "azure-storage-queue-12.9.0.tar.gz", hash = "sha256:98101b0e17da0d470cf5700b6c40cfe74439ec3c9c76cf38398096e7371b9d1b"},
+    {file = "azure_storage_queue-12.9.0-py3-none-any.whl", hash = "sha256:67857d102e5baeded46a1911a750bbcee28a3db61a82809e2a1082f280b9fddb"},
+]
+
+[package.dependencies]
+azure-core = ">=1.28.0,<2.0.0"
+cryptography = ">=2.1.4"
+isodate = ">=0.6.1"
+typing-extensions = ">=4.3.0"
+
+[package.extras]
+aio = ["azure-core[aio] (>=1.28.0,<2.0.0)"]
+
+[[package]]
+name = "certifi"
+version = "2024.2.2"
+description = "Python package for providing Mozilla's CA Bundle."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
+    {file = "certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"},
+]
+
+[[package]]
+name = "cffi"
+version = "1.16.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
+    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
+    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb"},
+    {file = "cffi-1.16.0-cp311-cp311-win32.whl", hash = "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab"},
+    {file = "cffi-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969"},
+    {file = "cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520"},
+    {file = "cffi-1.16.0-cp312-cp312-win32.whl", hash = "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b"},
+    {file = "cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235"},
+    {file = "cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324"},
+    {file = "cffi-1.16.0-cp38-cp38-win32.whl", hash = "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a"},
+    {file = "cffi-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe"},
+    {file = "cffi-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4"},
+    {file = "cffi-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8"},
+    {file = "cffi-1.16.0.tar.gz", hash = "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"},
+]
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
+name = "charset-normalizer"
+version = "3.3.2"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+optional = false
+python-versions = ">=3.7.0"
+files = [
+    {file = "charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:25baf083bf6f6b341f4121c2f3c548875ee6f5339300e08be3f2b2ba1721cdd3"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9063e24fdb1e498ab71cb7419e24622516c4a04476b17a2dab57e8baa30d6e03"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6897af51655e3691ff853668779c7bad41579facacf5fd7253b0133308cf000d"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1d3193f4a680c64b4b6a9115943538edb896edc190f0b222e73761716519268e"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd70574b12bb8a4d2aaa0094515df2463cb429d8536cfb6c7ce983246983e5a6"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8465322196c8b4d7ab6d1e049e4c5cb460d0394da4a27d23cc242fbf0034b6b5"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9a8e9031d613fd2009c182b69c7b2c1ef8239a0efb1df3f7c8da66d5dd3d537"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:beb58fe5cdb101e3a055192ac291b7a21e3b7ef4f67fa1d74e331a7f2124341c"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e06ed3eb3218bc64786f7db41917d4e686cc4856944f53d5bdf83a6884432e12"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2e81c7b9c8979ce92ed306c249d46894776a909505d8f5a4ba55b14206e3222f"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:572c3763a264ba47b3cf708a44ce965d98555f618ca42c926a9c1616d8f34269"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd1abc0d89e30cc4e02e4064dc67fcc51bd941eb395c502aac3ec19fab46b519"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win32.whl", hash = "sha256:3d47fa203a7bd9c5b6cee4736ee84ca03b8ef23193c0d1ca99b5089f72645c73"},
+    {file = "charset_normalizer-3.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:10955842570876604d404661fbccbc9c7e684caf432c09c715ec38fbae45ae09"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab"},
+    {file = "charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7"},
+    {file = "charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:95f2a5796329323b8f0512e09dbb7a1860c46a39da62ecb2324f116fa8fdc85c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c002b4ffc0be611f0d9da932eb0f704fe2602a9a949d1f738e4c34c75b0863d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a981a536974bbc7a512cf44ed14938cf01030a99e9b3a06dd59578882f06f985"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3287761bc4ee9e33561a7e058c72ac0938c4f57fe49a09eae428fd88aafe7bb6"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42cb296636fcc8b0644486d15c12376cb9fa75443e00fb25de0b8602e64c1714"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a55554a2fa0d408816b3b5cedf0045f4b8e1a6065aec45849de2d6f3f8e9786"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c083af607d2515612056a31f0a8d9e0fcb5876b7bfc0abad3ecd275bc4ebc2d5"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:87d1351268731db79e0f8e745d92493ee2841c974128ef629dc518b937d9194c"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:bd8f7df7d12c2db9fab40bdd87a7c09b1530128315d047a086fa3ae3435cb3a8"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:c180f51afb394e165eafe4ac2936a14bee3eb10debc9d9e4db8958fe36afe711"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c622a5fe39a48f78944a87d4fb8a53ee07344641b0562c540d840748571b811"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win32.whl", hash = "sha256:db364eca23f876da6f9e16c9da0df51aa4f104a972735574842618b8c6d999d4"},
+    {file = "charset_normalizer-3.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:86216b5cee4b06df986d214f664305142d9c76df9b6512be2738aa72a2048f99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:6463effa3186ea09411d50efc7d85360b38d5f09b870c48e4600f63af490e56a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6c4caeef8fa63d06bd437cd4bdcf3ffefe6738fb1b25951440d80dc7df8c03ac"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37e55c8e51c236f95b033f6fb391d7d7970ba5fe7ff453dad675e88cf303377a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb69256e180cb6c8a894fee62b3afebae785babc1ee98b81cdf68bbca1987f33"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ae5f4161f18c61806f411a13b0310bea87f987c7d2ecdbdaad0e94eb2e404238"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b2b0a0c0517616b6869869f8c581d4eb2dd83a4d79e0ebcb7d373ef9956aeb0a"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:45485e01ff4d3630ec0d9617310448a8702f70e9c01906b0d0118bdf9d124cf2"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb00ed941194665c332bf8e078baf037d6c35d7c4f3102ea2d4f16ca94a26dc8"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:2127566c664442652f024c837091890cb1942c30937add288223dc895793f898"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a50aebfa173e157099939b17f18600f72f84eed3049e743b68ad15bd69b6bf99"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:4d0d1650369165a14e14e1e47b372cfcb31d6ab44e6e33cb2d4e57265290044d"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:923c0c831b7cfcb071580d3f46c4baf50f174be571576556269530f4bbd79d04"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win32.whl", hash = "sha256:6ef1d82a3af9d3eecdba2321dc1b3c238245d890843e040e41e470ffa64c3e25"},
+    {file = "charset_normalizer-3.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:eb8821e09e916165e160797a6c17edda0679379a4be5c716c260e836e122f54b"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c235ebd9baae02f1b77bcea61bce332cb4331dc3617d254df3323aa01ab47bd4"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5b4c145409bef602a690e7cfad0a15a55c13320ff7a3ad7ca59c13bb8ba4d45d"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:68d1f8a9e9e37c1223b656399be5d6b448dea850bed7d0f87a8311f1ff3dabb0"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22afcb9f253dac0696b5a4be4a1c0f8762f8239e21b99680099abd9b2b1b2269"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e27ad930a842b4c5eb8ac0016b0a54f5aebbe679340c26101df33424142c143c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1f79682fbe303db92bc2b1136016a38a42e835d932bab5b3b1bfcfbf0640e519"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b261ccdec7821281dade748d088bb6e9b69e6d15b30652b74cbbac25e280b796"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:122c7fa62b130ed55f8f285bfd56d5f4b4a5b503609d181f9ad85e55c89f4185"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d0eccceffcb53201b5bfebb52600a5fb483a20b61da9dbc885f8b103cbe7598c"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f96df6923e21816da7e0ad3fd47dd8f94b2a5ce594e00677c0013018b813458"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:7f04c839ed0b6b98b1a7501a002144b76c18fb1c1850c8b98d458ac269e26ed2"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:34d1c8da1e78d2e001f363791c98a272bb734000fcef47a491c1e3b0505657a8"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ff8fa367d09b717b2a17a052544193ad76cd49979c805768879cb63d9ca50561"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win32.whl", hash = "sha256:aed38f6e4fb3f5d6bf81bfa990a07806be9d83cf7bacef998ab1a9bd660a581f"},
+    {file = "charset_normalizer-3.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:b01b88d45a6fcb69667cd6d2f7a9aeb4bf53760d7fc536bf679ec94fe9f3ff3d"},
+    {file = "charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc"},
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -24,6 +237,60 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+
+[[package]]
+name = "cryptography"
+version = "42.0.5"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cryptography-42.0.5-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16"},
+    {file = "cryptography-42.0.5-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da"},
+    {file = "cryptography-42.0.5-cp37-abi3-win32.whl", hash = "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74"},
+    {file = "cryptography-42.0.5-cp37-abi3-win_amd64.whl", hash = "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940"},
+    {file = "cryptography-42.0.5-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30"},
+    {file = "cryptography-42.0.5-cp39-abi3-win32.whl", hash = "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413"},
+    {file = "cryptography-42.0.5-cp39-abi3-win_amd64.whl", hash = "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd"},
+    {file = "cryptography-42.0.5.tar.gz", hash = "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
+nox = ["nox"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "django"
@@ -46,6 +313,17 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "idna"
+version = "3.7"
+description = "Internationalized Domain Names in Applications (IDNA)"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
+    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -55,6 +333,20 @@ files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
 ]
+
+[[package]]
+name = "isodate"
+version = "0.6.1"
+description = "An ISO 8601 date/time/duration parser and formatter"
+optional = false
+python-versions = "*"
+files = [
+    {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
+    {file = "isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"},
+]
+
+[package.dependencies]
+six = "*"
 
 [[package]]
 name = "mypy"
@@ -221,6 +513,17 @@ files = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
+
+[[package]]
 name = "pytest"
 version = "8.1.1"
 description = "pytest: simple powerful testing with Python"
@@ -239,6 +542,38 @@ pluggy = ">=1.4,<2.0"
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
+name = "requests"
+version = "2.31.0"
+description = "Python HTTP for Humans."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
+    {file = "requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+]
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<3"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 
 [[package]]
 name = "sqlparse"
@@ -278,7 +613,24 @@ files = [
     {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
 ]
 
+[[package]]
+name = "urllib3"
+version = "2.2.1"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
+    {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
+]
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+h2 = ["h2 (>=4,<5)"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2eafb780ccd6b384bd980872c1713d7234f00702ea8fcae9b41c29e00b599c8f"
+content-hash = "df08f3d68eb5102da5ffe0ecb3ddffe7535f3833836902a1a57dff9ac0ef432c"

--- a/app/shared/poetry.lock
+++ b/app/shared/poetry.lock
@@ -544,6 +544,20 @@ pluggy = ">=1.4,<2.0"
 testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -633,4 +647,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "df08f3d68eb5102da5ffe0ecb3ddffe7535f3833836902a1a57dff9ac0ef432c"
+content-hash = "1efe2ae391d7047cbb7f8fb032f3f90a39e3254420a9811baec4fd5ec238956a"

--- a/app/shared/poetry.lock
+++ b/app/shared/poetry.lock
@@ -15,6 +15,17 @@ files = [
 tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+description = "Cross-platform colored terminal text."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+
+[[package]]
 name = "django"
 version = "4.2"
 description = "A high-level Python web framework that encourages rapid development and clean, pragmatic design."
@@ -33,6 +44,100 @@ tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 [package.extras]
 argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
+
+[[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
+name = "mypy"
+version = "1.9.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f8a67616990062232ee4c3952f41c779afac41405806042a8126fe96e098419f"},
+    {file = "mypy-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d357423fa57a489e8c47b7c85dfb96698caba13d66e086b412298a1a0ea3b0ed"},
+    {file = "mypy-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49c87c15aed320de9b438ae7b00c1ac91cd393c1b854c2ce538e2a72d55df150"},
+    {file = "mypy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:48533cdd345c3c2e5ef48ba3b0d3880b257b423e7995dada04248725c6f77374"},
+    {file = "mypy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:4d3dbd346cfec7cb98e6cbb6e0f3c23618af826316188d587d1c1bc34f0ede03"},
+    {file = "mypy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:653265f9a2784db65bfca694d1edd23093ce49740b2244cde583aeb134c008f3"},
+    {file = "mypy-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3a3c007ff3ee90f69cf0a15cbcdf0995749569b86b6d2f327af01fd1b8aee9dc"},
+    {file = "mypy-1.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2418488264eb41f69cc64a69a745fad4a8f86649af4b1041a4c64ee61fc61129"},
+    {file = "mypy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:68edad3dc7d70f2f17ae4c6c1b9471a56138ca22722487eebacfd1eb5321d612"},
+    {file = "mypy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:85ca5fcc24f0b4aeedc1d02f93707bccc04733f21d41c88334c5482219b1ccb3"},
+    {file = "mypy-1.9.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aceb1db093b04db5cd390821464504111b8ec3e351eb85afd1433490163d60cd"},
+    {file = "mypy-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0235391f1c6f6ce487b23b9dbd1327b4ec33bb93934aa986efe8a9563d9349e6"},
+    {file = "mypy-1.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4d5ddc13421ba3e2e082a6c2d74c2ddb3979c39b582dacd53dd5d9431237185"},
+    {file = "mypy-1.9.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:190da1ee69b427d7efa8aa0d5e5ccd67a4fb04038c380237a0d96829cb157913"},
+    {file = "mypy-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:fe28657de3bfec596bbeef01cb219833ad9d38dd5393fc649f4b366840baefe6"},
+    {file = "mypy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e54396d70be04b34f31d2edf3362c1edd023246c82f1730bbf8768c28db5361b"},
+    {file = "mypy-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5e6061f44f2313b94f920e91b204ec600982961e07a17e0f6cd83371cb23f5c2"},
+    {file = "mypy-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a10926e5473c5fc3da8abb04119a1f5811a236dc3a38d92015cb1e6ba4cb9e"},
+    {file = "mypy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b685154e22e4e9199fc95f298661deea28aaede5ae16ccc8cbb1045e716b3e04"},
+    {file = "mypy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:5d741d3fc7c4da608764073089e5f58ef6352bedc223ff58f2f038c2c4698a89"},
+    {file = "mypy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:587ce887f75dd9700252a3abbc9c97bbe165a4a630597845c61279cf32dfbf02"},
+    {file = "mypy-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f88566144752999351725ac623471661c9d1cd8caa0134ff98cceeea181789f4"},
+    {file = "mypy-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61758fabd58ce4b0720ae1e2fea5cfd4431591d6d590b197775329264f86311d"},
+    {file = "mypy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e49499be624dead83927e70c756970a0bc8240e9f769389cdf5714b0784ca6bf"},
+    {file = "mypy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:571741dc4194b4f82d344b15e8837e8c5fcc462d66d076748142327626a1b6e9"},
+    {file = "mypy-1.9.0-py3-none-any.whl", hash = "sha256:a260627a570559181a9ea5de61ac6297aa5af202f06fd7ab093ce74e7181e43e"},
+    {file = "mypy-1.9.0.tar.gz", hash = "sha256:3cc5da0127e6a478cddd906068496a97a7618a21ce9b54bde5bf7e539c7af974"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
+name = "packaging"
+version = "24.0"
+description = "Core utilities for Python packages"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
+    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+]
+
+[[package]]
+name = "pluggy"
+version = "1.4.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.4.0-py3-none-any.whl", hash = "sha256:7db9f7b503d67d1c5b95f59773ebb58a8c1c288129a88665838012cfb07b8981"},
+    {file = "pluggy-1.4.0.tar.gz", hash = "sha256:8c85c2876142a764e5b7548e7d9a0e0ddb46f5185161049a79b7e974454223be"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "psycopg2-binary"
@@ -116,6 +221,26 @@ files = [
 ]
 
 [[package]]
+name = "pytest"
+version = "8.1.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7"},
+    {file = "pytest-8.1.1.tar.gz", hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.4,<2.0"
+
+[package.extras]
+testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+
+[[package]]
 name = "sqlparse"
 version = "0.4.4"
 description = "A non-validating SQL parser."
@@ -132,6 +257,17 @@ doc = ["sphinx"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "typing-extensions"
+version = "4.11.0"
+description = "Backported and Experimental Type Hints for Python 3.8+"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
+]
+
+[[package]]
 name = "tzdata"
 version = "2024.1"
 description = "Provider of IANA time zone data"
@@ -145,4 +281,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b8867dfab9e220cc92a4ccc0ecf89be86f843fd65ff4e8ddeaf205b113418368"
+content-hash = "2eafb780ccd6b384bd980872c1713d7234f00702ea8fcae9b41c29e00b599c8f"

--- a/app/shared/poetry.lock
+++ b/app/shared/poetry.lock
@@ -432,6 +432,28 @@ dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
+name = "psycopg2"
+version = "2.9.9"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "psycopg2-2.9.9-cp310-cp310-win32.whl", hash = "sha256:38a8dcc6856f569068b47de286b472b7c473ac7977243593a288ebce0dc89516"},
+    {file = "psycopg2-2.9.9-cp310-cp310-win_amd64.whl", hash = "sha256:426f9f29bde126913a20a96ff8ce7d73fd8a216cfb323b1f04da402d452853c3"},
+    {file = "psycopg2-2.9.9-cp311-cp311-win32.whl", hash = "sha256:ade01303ccf7ae12c356a5e10911c9e1c51136003a9a1d92f7aa9d010fb98372"},
+    {file = "psycopg2-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:121081ea2e76729acfb0673ff33755e8703d45e926e416cb59bae3a86c6a4981"},
+    {file = "psycopg2-2.9.9-cp312-cp312-win32.whl", hash = "sha256:d735786acc7dd25815e89cc4ad529a43af779db2e25aa7c626de864127e5a024"},
+    {file = "psycopg2-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:a7653d00b732afb6fc597e29c50ad28087dcb4fbfb28e86092277a559ae4e693"},
+    {file = "psycopg2-2.9.9-cp37-cp37m-win32.whl", hash = "sha256:5e0d98cade4f0e0304d7d6f25bbfbc5bd186e07b38eac65379309c4ca3193efa"},
+    {file = "psycopg2-2.9.9-cp37-cp37m-win_amd64.whl", hash = "sha256:7e2dacf8b009a1c1e843b5213a87f7c544b2b042476ed7755be813eaf4e8347a"},
+    {file = "psycopg2-2.9.9-cp38-cp38-win32.whl", hash = "sha256:ff432630e510709564c01dafdbe996cb552e0b9f3f065eb89bdce5bd31fabf4c"},
+    {file = "psycopg2-2.9.9-cp38-cp38-win_amd64.whl", hash = "sha256:bac58c024c9922c23550af2a581998624d6e02350f4ae9c5f0bc642c633a2d5e"},
+    {file = "psycopg2-2.9.9-cp39-cp39-win32.whl", hash = "sha256:c92811b2d4c9b6ea0285942b2e7cac98a59e166d59c588fe5cfe1eda58e72d59"},
+    {file = "psycopg2-2.9.9-cp39-cp39-win_amd64.whl", hash = "sha256:de80739447af31525feddeb8effd640782cf5998e1a4e9192ebdf829717e3913"},
+    {file = "psycopg2-2.9.9.tar.gz", hash = "sha256:d1454bde93fb1e224166811694d600e746430c006fbb031ea06ecc2ea41bf156"},
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.9"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
@@ -647,4 +669,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "1efe2ae391d7047cbb7f8fb032f3f90a39e3254420a9811baec4fd5ec238956a"
+content-hash = "6f759a2bf714d2a4b2bee3d88f4742da3fdb9b7848abb6144ec419f834219bce"

--- a/app/shared/pyproject.toml
+++ b/app/shared/pyproject.toml
@@ -9,6 +9,7 @@ license = "MIT"
 python = "^3.11"
 django = "4.2"
 psycopg2-binary = "^2.9.9"
+azure-storage-queue = "^12.9.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.9.0"

--- a/app/shared/pyproject.toml
+++ b/app/shared/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.11"
 django = "4.2"
 psycopg2-binary = "^2.9.9"
 azure-storage-queue = "^12.9.0"
+python-dotenv = "^1.0.1"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.9.0"

--- a/app/shared/pyproject.toml
+++ b/app/shared/pyproject.toml
@@ -10,6 +10,13 @@ python = "^3.11"
 django = "4.2"
 psycopg2-binary = "^2.9.9"
 
+[tool.poetry.group.dev.dependencies]
+mypy = "^1.9.0"
+
+
+[tool.poetry.group.test.dependencies]
+pytest = "^8.1.1"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/app/shared/pyproject.toml
+++ b/app/shared/pyproject.toml
@@ -14,6 +14,7 @@ python-dotenv = "^1.0.1"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^1.9.0"
+psycopg2 = "^2.9.9"
 
 
 [tool.poetry.group.test.dependencies]

--- a/app/shared/pyproject.toml
+++ b/app/shared/pyproject.toml
@@ -21,3 +21,7 @@ pytest = "^8.1.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+pythonpath = ["."]

--- a/app/shared/shared/services/__init__.py
+++ b/app/shared/shared/services/__init__.py
@@ -1,0 +1,1 @@
+from .rules import refresh_mapping_rules

--- a/app/shared/shared/services/__init__.py
+++ b/app/shared/shared/services/__init__.py
@@ -1,1 +1,0 @@
-from .rules import refresh_mapping_rules

--- a/app/shared/shared/services/azurequeue.py
+++ b/app/shared/shared/services/azurequeue.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from azure.storage.queue import QueueClient
 
@@ -9,8 +9,8 @@ from azure.storage.queue import QueueClient
 def add_message(
     queue_name: str,
     message: Dict[str, Any],
-    conn_str: str = None,
-    queue_client: QueueClient = None,
+    conn_str: Optional[str] = None,
+    queue_client: Optional[QueueClient] = None,
 ) -> None:
     """
     Add a message to the specified Azure Storage Queue.

--- a/app/shared/shared/services/azurequeue.py
+++ b/app/shared/shared/services/azurequeue.py
@@ -1,0 +1,46 @@
+import base64
+import json
+import os
+from typing import Any, Dict
+
+from azure.storage.queue import QueueClient
+
+
+def add_message(
+    queue_name: str,
+    message: Dict[str, Any],
+    conn_str: str = None,
+    queue_client: QueueClient = None,
+) -> None:
+    """
+    Add a message to the specified Azure Storage Queue.
+
+    Args:
+        - queue_name (str): The name of the Azure Storage Queue.
+        - message (Dict[str, Any]): The message to be added to the queue.
+        - conn_str (str, optional): The connection string for Azure Storage. If not provided, it will be retrieved from environment variables.
+        - queue_client (QueueClient, optional): The QueueClient instance. If not provided, it will be created internally.
+
+    Returns:
+        - None
+
+    Raises:
+        - ValueError: If no connection string can be found.
+    """
+    # Encode the message
+    queue_message = json.dumps(message)
+    message_bytes = queue_message.encode("utf-8")
+    base64_message = base64.b64encode(message_bytes).decode("utf-8")
+
+    # Get the connection string
+    if conn_str is None:
+        conn_str = os.environ.get("STORAGE_CONN_STRING")
+    if not conn_str:
+        raise ValueError("Storage connection string is not provided.")
+
+    if queue_client is None:
+        queue_client = QueueClient.from_connection_string(
+            conn_str=conn_str, queue_name=queue_name
+        )
+
+    queue_client.send_message(base64_message)

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -39,10 +39,10 @@ def delete_mapping_rules(table_id: int) -> None:
     Delete existing mapping rules related to a Scan Report Table.
 
     Args:
-        table_id (int): The Id of the ScanReportTable to delete the rules for.
+        - table_id (int): The Id of the ScanReportTable to delete the rules for.
 
     Returns:
-        None
+        - None
     """
     rules = MappingRule.objects.all().filter(source_field__scan_report_table=table_id)
 
@@ -54,10 +54,10 @@ def find_existing_concepts(table_id: int) -> List[ScanReportConcept]:
     Get ScanReportConcepts associated to a table.
 
     Args:
-        table_id (int): Id of the ScanReportTable to filter by.
+        - table_id (int): Id of the ScanReportTable to filter by.
 
     Returns:
-        A list of ScanReportConcept attached to the Table Id.
+        - A list of ScanReportConcept attached to the Table Id.
     """
 
     values = (
@@ -152,7 +152,7 @@ def get_person_id_rule(
         - destination_table (OmopTable):
 
     Returns:
-        - MappingRule:
+        - MappingRule for the person_id
     """
     # look up what source_field for this table contains the person id
     person_id_source_field = source_table.person_id
@@ -174,8 +174,25 @@ def get_person_id_rule(
     return rule_domain_person_id
 
 
-def get_date_rules(scan_report, scan_report_concept, source_table, destination_table):
-    # !todo - need some checks for this
+def get_date_rules(
+    scan_report: ScanReport,
+    scan_report_concept: ScanReportConcept,
+    source_table: ScanReportTable,
+    destination_table: OmopTable,
+):
+    """
+    Get date rules for mapping between source and destination tables.
+
+    Args:
+        - scan_report: The ScanReport object.
+        - scan_report_concept: The ScanReportConcept object.
+        - source_table: The ScanReportTable object.
+        - destination_table: The OmopTable object.
+
+    Returns:
+        - List of MappingRule representing the date rules.
+    """
+
     date_event_source_field = source_table.date_event
 
     date_omop_fields = m_date_field_mapper[destination_table.table]
@@ -208,10 +225,10 @@ def find_destination_table(concept: ScanReportConcept) -> Optional[OmopTable]:
     Get the destination table for a given ScanReportConcept
 
     Args:
-        concept (ScanReportConcept): The Concept to get the table for.
+        - concept (ScanReportConcept): The Concept to get the table for.
 
     Returns:
-        destination_table (OmopTable): The destination table for the concept.
+        - destination_table (OmopTable): The destination table for the concept.
     """
     domain = concept.domain_id.lower()
     # get the omop field for the source_concept_id for this domain
@@ -228,11 +245,13 @@ def find_destination_table(concept: ScanReportConcept) -> Optional[OmopTable]:
 
 def save_mapping_rules(concept: ScanReportConcept) -> bool:
     """
-    Save mapping rules from a given ScanReportConcept
+    Save mapping rules from a given ScanReportConcept.
 
-    function to save the rules
     Args:
-       - concept (ScanReportConcept) : object containing the Concept and Link to source_value
+        - concept (ScanReportConcept) : object containing the Concept and Link to source_value
+
+    Returns:
+        - bool: If the rule has been saved.
     """
     content_object = concept.content_object
     if isinstance(content_object, ScanReportValue):
@@ -333,9 +352,17 @@ def save_mapping_rules(concept: ScanReportConcept) -> bool:
     return True
 
 
-def refresh_mapping_rules(table_id: int):
+def refresh_mapping_rules(table_id: int) -> None:
     """
-    TODO: Docs
+    Refreshes the Mapping Rules for a given Scan Report Table.
+
+    Deletes all the existing rules, gets the concepts, and saves the mapping rules again.
+
+    Args:
+        - table_id (int): The Id of the table to refresh the rules for.
+
+    Returns:
+        - None
     """
     delete_mapping_rules(table_id)
 

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from shared.data.models import (
     MappingRule,
@@ -104,7 +104,7 @@ def validate_person_id_and_date(source_table: ScanReportTable):
     return date_event_source_field is not None
 
 
-def get_omop_field(destination_field: str, destination_table: str = None):
+def get_omop_field(destination_field: str, destination_table: Optional[str] = None):
     """
     Get the destination_field object, given a field name, and/or the table.
 
@@ -203,7 +203,7 @@ def get_date_rules(scan_report, scan_report_concept, source_table, destination_t
     return date_rules
 
 
-def find_destination_table(concept: ScanReportConcept) -> OmopTable:
+def find_destination_table(concept: ScanReportConcept) -> Optional[OmopTable]:
     """
     Get the destination table for a given ScanReportConcept
 
@@ -226,7 +226,7 @@ def find_destination_table(concept: ScanReportConcept) -> OmopTable:
     return destination_table
 
 
-def save_mapping_rules(concept: ScanReportConcept) -> None:
+def save_mapping_rules(concept: ScanReportConcept) -> bool:
     """
     Save mapping rules from a given ScanReportConcept
 

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -3,6 +3,8 @@ from typing import List
 from shared.data.models import (
     MappingRule,
     OmopField,
+    OmopTable,
+    ScanReport,
     ScanReportConcept,
     ScanReportField,
     ScanReportTable,
@@ -102,13 +104,14 @@ def validate_person_id_and_date(source_table: ScanReportTable):
     return date_event_source_field is not None
 
 
-def get_omop_field(destination_field: str, destination_table=None):
+def get_omop_field(destination_field: str, destination_table: str = None):
     """
-    function to return the destination_field object, given lookup names
+    Get the destination_field object, given a field name, and/or the table.
 
     Args:
       - destination_field (str) : the name of the destination field
       - [optional] destination_table (str) : the name of destination table, if known
+
     Returns:
       - OmopField : the destination field object
     """
@@ -134,8 +137,23 @@ def get_omop_field(destination_field: str, destination_table=None):
 
 
 def get_person_id_rule(
-    scan_report, scan_report_concept, source_table, destination_table
-):
+    scan_report: ScanReport,
+    scan_report_concept: ScanReportConcept,
+    source_table: ScanReportTable,
+    destination_table: OmopTable,
+) -> MappingRule:
+    """
+    Get the rule for person_id, given
+
+    Args:
+        - scan_report (ScanReport):
+        - scan_report_concept (ScanReportConcept):
+        - source_table (ScanReportTable):
+        - destination_table (OmopTable):
+
+    Returns:
+        - MappingRule:
+    """
     # look up what source_field for this table contains the person id
     person_id_source_field = source_table.person_id
 
@@ -185,7 +203,16 @@ def get_date_rules(scan_report, scan_report_concept, source_table, destination_t
     return date_rules
 
 
-def find_destination_table(concept):
+def find_destination_table(concept: ScanReportConcept) -> OmopTable:
+    """
+    Get the destination table for a given ScanReportConcept
+
+    Args:
+        concept (ScanReportConcept): The Concept to get the table for.
+
+    Returns:
+        destination_table (OmopTable): The destination table for the concept.
+    """
     domain = concept.domain_id.lower()
     # get the omop field for the source_concept_id for this domain
     omop_field = get_omop_field(f"{domain}_source_concept_id")

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -2,10 +2,33 @@ from typing import List
 
 from shared.data.models import (
     MappingRule,
+    OmopField,
     ScanReportConcept,
     ScanReportField,
     ScanReportValue,
 )
+
+# allowed tables
+m_allowed_tables = [
+    "person",
+    "measurement",
+    "condition_occurrence",
+    "observation",
+    "drug_exposure",
+    "procedure_occurrence",
+    "specimen",
+]
+
+# look up of date-events in all the allowed (destination) tables
+m_date_field_mapper = {
+    "person": ["birth_datetime"],
+    "condition_occurrence": ["condition_start_datetime", "condition_end_datetime"],
+    "measurement": ["measurement_datetime"],
+    "observation": ["observation_datetime"],
+    "drug_exposure": ["drug_exposure_start_datetime", "drug_exposure_end_datetime"],
+    "procedure_occurrence": ["procedure_datetime"],
+    "specimen": ["specimen_datetime"],
+}
 
 
 def delete_mapping_rules(table_id: int) -> None:
@@ -23,7 +46,7 @@ def delete_mapping_rules(table_id: int) -> None:
     rules.delete()
 
 
-def find_existing_scan_report_concepts(table_id: int) -> List[ScanReportConcept]:
+def find_existing_concepts(table_id: int) -> List[ScanReportConcept]:
     # TODO: Docs
     # find ScanReportValue associated to this table_id
     # that have at least one concept added to them
@@ -52,11 +75,226 @@ def find_existing_scan_report_concepts(table_id: int) -> List[ScanReportConcept]
     return all_concepts
 
 
+def validate_person_id_and_date(request, source_table):
+    """
+    Before creating any rules, we need to make sure the person_id and date_event
+    has been set
+    """
+
+    # find the date event first
+    person_id_source_field = source_table.person_id
+
+    if person_id_source_field is None:
+        return False
+
+    date_event_source_field = source_table.date_event
+    return date_event_source_field is not None
+
+
+def get_omop_field(destination_field, destination_table=None):
+    """
+    function to return the destination_field object, given lookup names
+    Args:
+      - destination_field (str) : the name of the destination field
+      - [optional] destination_table (str) : the name of destination table, if known
+    Returns:
+      - OmopField : the destination field object
+    """
+
+    # if we haven't specified the table name
+    if destination_table is None:
+        # look up the field from the "allowed_tables"
+        omop_field = OmopField.objects.filter(field=destination_field)
+
+        if len(omop_field) > 1:
+            return omop_field.filter(table__table__in=m_allowed_tables)[0]
+        elif len(omop_field) == 0:
+            return None
+        else:
+            return omop_field[0]
+
+    else:
+        # otherwise, if we know which table the field is in, use this to find the field
+        omop_field = OmopField.objects.filter(table__table=destination_table).get(
+            field=destination_field
+        )
+    return omop_field
+
+
+def get_person_id_rule(
+    request, scan_report, scan_report_concept, source_table, destination_table
+):
+    # look up what source_field for this table contains the person id
+    person_id_source_field = source_table.person_id
+
+    # get the associated OmopField Object (aka destination_table::person_id)
+    person_id_omop_field = OmopField.objects.get(
+        table=destination_table, field="person_id"
+    )
+
+    # create a new 1-1 rule
+    rule_domain_person_id, created = MappingRule.objects.update_or_create(
+        scan_report=scan_report,
+        omop_field=person_id_omop_field,
+        source_field=person_id_source_field,
+        concept=scan_report_concept,
+        approved=True,
+    )
+    # return the rule mapping
+    return rule_domain_person_id
+
+
+def get_date_rules(
+    request, scan_report, scan_report_concept, source_table, destination_table
+):
+    # !todo - need some checks for this
+    date_event_source_field = source_table.date_event
+
+    date_omop_fields = m_date_field_mapper[destination_table.table]
+    # loop over all returned
+    # most will return just one date event
+    # in the case of condition_occurrence, it returns start and end
+    date_rules = []
+    for date_omop_field in date_omop_fields:
+        # get the actual omop field object
+        date_event_omop_field = OmopField.objects.get(
+            table=destination_table, field=date_omop_field
+        )
+
+        # create a new 1-1 rule
+        rule_domain_date_event, created = MappingRule.objects.update_or_create(
+            scan_report=scan_report,
+            omop_field=date_event_omop_field,
+            source_field=date_event_source_field,
+            concept=scan_report_concept,
+            approved=True,
+        )
+
+        date_rules.append(rule_domain_date_event)
+
+    return date_rules
+
+
+def find_destination_table(concept):
+    domain = concept.domain_id.lower()
+    # get the omop field for the source_concept_id for this domain
+    omop_field = get_omop_field(f"{domain}_source_concept_id")
+    if omop_field is None:
+        return None
+    # start looking up what table we're looking at
+    destination_table = omop_field.table
+
+    if destination_table.table not in m_allowed_tables:
+        return None
+    return destination_table
+
+
 def save_mapping_rules(concept: ScanReportConcept) -> None:
     """
     Save mapping rules from a given ScanReportConcept
+
+    function to save the rules
+    Args:
+       - request (HttpRequest): django object for the request (get/post)
+       - concept (ScanReportConcept) : object containing the Concept and Link to source_value
     """
-    pass
+    content_object = concept.content_object
+    if isinstance(content_object, ScanReportValue):
+        scan_report_value = content_object
+        source_field = scan_report_value.scan_report_field
+    else:
+        source_field = content_object
+
+    scan_report = source_field.scan_report_table.scan_report
+
+    concept = concept.concept
+
+    # start looking up what table we're looking at
+    destination_table = find_destination_table(concept)
+    if destination_table is None:
+        return False
+
+    # get the omop field for the source_concept_id for this domain
+    domain = concept.domain_id.lower()
+    omop_field = get_omop_field(f"{domain}_source_concept_id")
+
+    # obtain the source table
+    source_table = source_field.scan_report_table
+
+    # check whether the person_id and date events for this table are valid
+    # if not, we dont want to create any rules for this concept
+    if not validate_person_id_and_date(source_table):
+        return False
+
+    # create a person_id rule
+    person_id_rule = get_person_id_rule(
+        scan_report, concept, source_table, destination_table
+    )
+    rules = [person_id_rule]
+    # create(potentially multiple) date_rules
+    date_rules = get_date_rules(scan_report, concept, source_table, destination_table)
+    rules += date_rules
+
+    # create/update a model for the domain source_concept_id
+    #  - for this destination_field and source_field
+    #  - do_term_mapping is set to true:
+    #    - all term mapping rules associated need to be applied
+    rule_domain_source_concept_id, created = MappingRule.objects.update_or_create(
+        scan_report=scan_report,
+        omop_field=omop_field,
+        source_field=source_field,
+        concept=concept,
+        approved=True,
+    )
+    rules.append(rule_domain_source_concept_id)
+
+    # create/update a model for the domain concept_id
+    #  - for this destination_field and source_field
+    #  - do_term_mapping is set to true:
+    #    - all term mapping rules associated need to be applied
+    rule_domain_concept_id, created = MappingRule.objects.update_or_create(
+        scan_report=scan_report,
+        omop_field=get_omop_field(f"{domain}_concept_id"),
+        source_field=source_field,
+        concept=concept,
+        approved=True,
+    )
+    rules.append(rule_domain_concept_id)
+
+    # create/update a model for the domain source_value
+    #  - for this destination_field and source_field
+    #  - do_term_mapping is set to false
+    rule_domain_source_value, created = MappingRule.objects.update_or_create(
+        scan_report=scan_report,
+        omop_field=get_omop_field(f"{domain}_source_value"),
+        source_field=source_field,
+        concept=concept,
+        approved=True,
+    )
+    # add this new concept mapping
+    # - the concept wont be used, because  do_term_mapping=False
+    # - but we need to preserve the link,
+    #   so when all associated concepts are deleted, the rule is deleted
+    rules.append(rule_domain_source_value)
+
+    if domain == "measurement":
+        # create/update a model for the domain value_as_number
+        #  - for this destination_field and source_field
+        #  - do_term_mapping is set to false
+        rule_domain_value_as_number, created = MappingRule.objects.update_or_create(
+            scan_report=scan_report,
+            omop_field=get_omop_field("value_as_number", "measurement"),
+            source_field=source_field,
+            concept=concept,
+            approved=True,
+        )
+        rules.append(rule_domain_value_as_number)
+
+    # now we are sure all rules have been created, we can save them safely
+    for rule in rules:
+        rule.save()
+
+    return True
 
 
 def refresh_mapping_rules(table_id: int):
@@ -65,7 +303,7 @@ def refresh_mapping_rules(table_id: int):
     """
     delete_mapping_rules(table_id)
 
-    concepts = find_existing_scan_report_concepts(table_id)
+    concepts = find_existing_concepts(table_id)
 
     nconcepts = 0
     nbadconcepts = 0

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -52,8 +52,26 @@ def find_existing_scan_report_concepts(table_id: int) -> List[ScanReportConcept]
     return all_concepts
 
 
+def save_mapping_rules(concept: ScanReportConcept) -> None:
+    """
+    Save mapping rules from a given ScanReportConcept
+    """
+    pass
+
+
 def refresh_mapping_rules(table_id: int):
     """
     TODO: Docs
     """
     delete_mapping_rules(table_id)
+
+    concepts = find_existing_scan_report_concepts(table_id)
+
+    nconcepts = 0
+    nbadconcepts = 0
+
+    for concept in concepts:
+        if save_mapping_rules(concept):
+            nconcepts += 1
+        else:
+            nbadconcepts += 1

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -1,0 +1,59 @@
+from typing import List
+
+from shared.data.models import (
+    MappingRule,
+    ScanReportConcept,
+    ScanReportField,
+    ScanReportValue,
+)
+
+
+def delete_mapping_rules(table_id: int) -> None:
+    """
+    Delete existing mapping rules related to a Scan Report Table.
+
+    Args:
+        table_id (int): The Id of the ScanReportTable to delete the rules for.
+
+    Returns:
+        None
+    """
+    rules = MappingRule.objects.all().filter(source_field__scan_report_table=table_id)
+
+    rules.delete()
+
+
+def find_existing_scan_report_concepts(table_id: int) -> List[ScanReportConcept]:
+    # TODO: Docs
+    # find ScanReportValue associated to this table_id
+    # that have at least one concept added to them
+    values = (
+        ScanReportValue.objects.all()
+        .filter(scan_report_field__scan_report_table=table_id)
+        .filter(concepts__isnull=False)
+        .distinct()
+        .order_by("id")
+    )
+
+    # find ScanReportField associated to this table_id
+    # that have at least one concept added to them
+    fields = (
+        ScanReportField.objects.all()
+        .filter(scan_report_table=table_id)
+        .filter(concepts__isnull=False)
+        .distinct()
+        .order_by("id")
+    )
+
+    # retrieve all value concepts
+    all_concepts = [concept for obj in values for concept in obj.concepts.all()]
+    # retrieve all field concepts
+    all_concepts += [concept for obj in fields for concept in obj.concepts.all()]
+    return all_concepts
+
+
+def refresh_mapping_rules(table_id: int):
+    """
+    TODO: Docs
+    """
+    delete_mapping_rules(table_id)

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -5,6 +5,7 @@ from shared.data.models import (
     OmopField,
     ScanReportConcept,
     ScanReportField,
+    ScanReportTable,
     ScanReportValue,
 )
 
@@ -47,9 +48,16 @@ def delete_mapping_rules(table_id: int) -> None:
 
 
 def find_existing_concepts(table_id: int) -> List[ScanReportConcept]:
-    # TODO: Docs
-    # find ScanReportValue associated to this table_id
-    # that have at least one concept added to them
+    """
+    Get ScanReportConcepts associated to a table.
+
+    Args:
+        table_id (int): Id of the ScanReportTable to filter by.
+
+    Returns:
+        A list of ScanReportConcept attached to the Table Id.
+    """
+
     values = (
         ScanReportValue.objects.all()
         .filter(scan_report_field__scan_report_table=table_id)
@@ -75,13 +83,16 @@ def find_existing_concepts(table_id: int) -> List[ScanReportConcept]:
     return all_concepts
 
 
-def validate_person_id_and_date(request, source_table):
+def validate_person_id_and_date(source_table: ScanReportTable):
     """
-    Before creating any rules, we need to make sure the person_id and date_event
-    has been set
-    """
+    Check that the person_id and date_event is set on the table
 
-    # find the date event first
+    Args:
+        source_table (ScanReportTable): The ScanReportTable to validate
+
+    Returns:
+        bool: True if both person_id and date_event are both set on the Table.
+    """
     person_id_source_field = source_table.person_id
 
     if person_id_source_field is None:
@@ -91,9 +102,10 @@ def validate_person_id_and_date(request, source_table):
     return date_event_source_field is not None
 
 
-def get_omop_field(destination_field, destination_table=None):
+def get_omop_field(destination_field: str, destination_table=None):
     """
     function to return the destination_field object, given lookup names
+
     Args:
       - destination_field (str) : the name of the destination field
       - [optional] destination_table (str) : the name of destination table, if known
@@ -122,7 +134,7 @@ def get_omop_field(destination_field, destination_table=None):
 
 
 def get_person_id_rule(
-    request, scan_report, scan_report_concept, source_table, destination_table
+    scan_report, scan_report_concept, source_table, destination_table
 ):
     # look up what source_field for this table contains the person id
     person_id_source_field = source_table.person_id
@@ -144,9 +156,7 @@ def get_person_id_rule(
     return rule_domain_person_id
 
 
-def get_date_rules(
-    request, scan_report, scan_report_concept, source_table, destination_table
-):
+def get_date_rules(scan_report, scan_report_concept, source_table, destination_table):
     # !todo - need some checks for this
     date_event_source_field = source_table.date_event
 
@@ -195,7 +205,6 @@ def save_mapping_rules(concept: ScanReportConcept) -> None:
 
     function to save the rules
     Args:
-       - request (HttpRequest): django object for the request (get/post)
        - concept (ScanReportConcept) : object containing the Concept and Link to source_value
     """
     content_object = concept.content_object

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -243,7 +243,7 @@ def _find_destination_table(concept: ScanReportConcept) -> Optional[OmopTable]:
     return destination_table
 
 
-def _save_mapping_rules(concept: ScanReportConcept) -> bool:
+def _save_mapping_rules(scan_report_concept: ScanReportConcept) -> bool:
     """
     Save mapping rules from a given ScanReportConcept.
 
@@ -253,7 +253,7 @@ def _save_mapping_rules(concept: ScanReportConcept) -> bool:
     Returns:
         - bool: If the rule has been saved.
     """
-    content_object = concept.content_object
+    content_object = scan_report_concept.content_object
     if isinstance(content_object, ScanReportValue):
         scan_report_value = content_object
         source_field = scan_report_value.scan_report_field
@@ -262,7 +262,7 @@ def _save_mapping_rules(concept: ScanReportConcept) -> bool:
 
     scan_report = source_field.scan_report_table.scan_report
 
-    concept = concept.concept
+    concept = scan_report_concept.concept
 
     # start looking up what table we're looking at
     destination_table = _find_destination_table(concept)
@@ -283,11 +283,13 @@ def _save_mapping_rules(concept: ScanReportConcept) -> bool:
 
     # create a person_id rule
     person_id_rule = _get_person_id_rule(
-        scan_report, concept, source_table, destination_table
+        scan_report, scan_report_concept, source_table, destination_table
     )
     rules = [person_id_rule]
     # create(potentially multiple) date_rules
-    date_rules = _get_date_rules(scan_report, concept, source_table, destination_table)
+    date_rules = _get_date_rules(
+        scan_report, scan_report_concept, source_table, destination_table
+    )
     rules += date_rules
 
     # create/update a model for the domain source_concept_id
@@ -298,7 +300,7 @@ def _save_mapping_rules(concept: ScanReportConcept) -> bool:
         scan_report=scan_report,
         omop_field=omop_field,
         source_field=source_field,
-        concept=concept,
+        concept=scan_report_concept,
         approved=True,
     )
     rules.append(rule_domain_source_concept_id)
@@ -311,7 +313,7 @@ def _save_mapping_rules(concept: ScanReportConcept) -> bool:
         scan_report=scan_report,
         omop_field=_get_omop_field(f"{domain}_concept_id"),
         source_field=source_field,
-        concept=concept,
+        concept=scan_report_concept,
         approved=True,
     )
     rules.append(rule_domain_concept_id)
@@ -323,7 +325,7 @@ def _save_mapping_rules(concept: ScanReportConcept) -> bool:
         scan_report=scan_report,
         omop_field=_get_omop_field(f"{domain}_source_value"),
         source_field=source_field,
-        concept=concept,
+        concept=scan_report_concept,
         approved=True,
     )
     # add this new concept mapping
@@ -340,7 +342,7 @@ def _save_mapping_rules(concept: ScanReportConcept) -> bool:
             scan_report=scan_report,
             omop_field=_get_omop_field("value_as_number", "measurement"),
             source_field=source_field,
-            concept=concept,
+            concept=scan_report_concept,
             approved=True,
         )
         rules.append(rule_domain_value_as_number)

--- a/app/shared/test/services/settings.py
+++ b/app/shared/test/services/settings.py
@@ -1,0 +1,28 @@
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+SECRET_KEY = os.environ.get("SECRET_KEY")
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "shared",
+]
+
+DATABASES = {
+    "default": {
+        "ENGINE": os.environ.get("COCONNECT_DB_ENGINE"),
+        "HOST": os.environ.get("COCONNECT_DB_HOST"),
+        "PORT": os.environ.get("COCONNECT_DB_PORT"),
+        "NAME": os.environ.get("COCONNECT_DB_NAME"),
+        "USER": os.environ.get("COCONNECT_DB_USER"),
+        "PASSWORD": os.environ.get("COCONNECT_DB_PASSWORD"),
+        "TEST": {
+            "NAME": "throwawaydb",
+        },
+    }
+}

--- a/app/shared/test/services/test_azurequeue.py
+++ b/app/shared/test/services/test_azurequeue.py
@@ -1,0 +1,49 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from shared.services.azurequeue import add_message
+
+
+@pytest.fixture
+def mock_queue_client():
+    mock_instance = MagicMock()
+    mock_instance.send_message.return_value = None
+    mock_class = MagicMock(return_value=mock_instance)
+    mock_class.from_connection_string.return_value = mock_instance
+    with patch("shared.services.azurequeue.QueueClient", mock_class):
+        yield mock_class
+
+
+def test_add_message_with_connection_string(mock_queue_client):
+    queue_name = "test_queue"
+    message = {"key": "value"}
+    conn_str = "mock_connection_string"
+
+    add_message(queue_name, message, conn_str=conn_str)
+
+    mock_queue_client.from_connection_string.assert_called_once_with(
+        conn_str=conn_str, queue_name=queue_name
+    )
+    mock_queue_client.return_value.send_message.assert_called_once()
+
+
+def test_add_message_with_environment_variable(mock_queue_client):
+    queue_name = "test_queue"
+    message = {"key": "value"}
+
+    with patch.dict(os.environ, {"STORAGE_CONN_STRING": "mock_conn_str"}):
+        add_message(queue_name, message)
+
+    mock_queue_client.from_connection_string.assert_called_once_with(
+        conn_str="mock_conn_str", queue_name=queue_name
+    )
+    mock_queue_client.return_value.send_message.assert_called_once()
+
+
+def test_add_message_without_connection_string():
+    queue_name = "test_queue"
+    message = {"key": "value"}
+
+    with pytest.raises(ValueError):
+        add_message(queue_name, message)

--- a/app/shared/test/services/test_rules.py
+++ b/app/shared/test/services/test_rules.py
@@ -8,7 +8,7 @@ import django
 
 django.setup()
 
-from shared.data.models import ScanReportField, ScanReportTable
+from shared.data.models import OmopField, ScanReportField, ScanReportTable
 from shared.services import rules
 
 
@@ -34,3 +34,24 @@ def test__validate_person_id_and_date():
     assert rules._validate_person_id_and_date(table_with_only_person_id) is False
     assert rules._validate_person_id_and_date(table_with_only_date_event) is False
     assert rules._validate_person_id_and_date(table_with_neither_field) is False
+
+
+@pytest.fixture
+def mock_omop_field():
+    return MagicMock(spec=OmopField)
+
+
+def test_get_omop_field_without_destination_table(mock_omop_field):
+    # Arrange
+    destination_field = "test"
+    expected_omop_field = mock_omop_field
+
+    with patch("shared.services.rules.OmopField.objects") as mock_omop_field_objects:
+        mock_omop_field_objects.filter.return_value = [expected_omop_field]
+
+        # Act
+        result = rules._get_omop_field(destination_field)
+
+        # Assert
+        mock_omop_field_objects.filter.assert_called_once_with(field=destination_field)
+        assert result == expected_omop_field

--- a/app/shared/test/services/test_rules.py
+++ b/app/shared/test/services/test_rules.py
@@ -1,4 +1,11 @@
-# from shared.services import rules
+import os
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+import django
+
+django.setup()
+
+from shared.services import rules
 
 
 def test_plus():

--- a/app/shared/test/services/test_rules.py
+++ b/app/shared/test/services/test_rules.py
@@ -1,12 +1,36 @@
 import os
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
 import django
 
 django.setup()
 
+from shared.data.models import ScanReportField, ScanReportTable
 from shared.services import rules
 
 
-def test_plus():
-    assert 1 == 1
+def test__validate_person_id_and_date():
+    # Arrange
+    person_id = ScanReportField()
+    date_event = ScanReportField()
+
+    # Instance with person_id and date_event set
+    table_with_both_fields = ScanReportTable(person_id=person_id, date_event=date_event)
+
+    # Instance with only person_id set
+    table_with_only_person_id = ScanReportTable(person_id=person_id, date_event=None)
+
+    # Instance with only date_event set
+    table_with_only_date_event = ScanReportTable(person_id=None, date_event=date_event)
+
+    # Instance with neither set
+    table_with_neither_field = ScanReportTable(person_id=None, date_event=None)
+
+    # Act + Assert
+    assert rules._validate_person_id_and_date(table_with_both_fields) is True
+    assert rules._validate_person_id_and_date(table_with_only_person_id) is False
+    assert rules._validate_person_id_and_date(table_with_only_date_event) is False
+    assert rules._validate_person_id_and_date(table_with_neither_field) is False

--- a/app/shared/test/services/test_rules.py
+++ b/app/shared/test/services/test_rules.py
@@ -1,0 +1,5 @@
+# from shared.services import rules
+
+
+def test_plus():
+    assert 1 == 1

--- a/app/workers/CreateConcepts/__init__.py
+++ b/app/workers/CreateConcepts/__init__.py
@@ -1,8 +1,10 @@
 import asyncio
+import os
 from collections import defaultdict
 from typing import Any, Dict, List
 
 import azure.functions as func
+from shared.services.azurequeue import add_message
 from shared_code import blob_parser, helpers, omop_helpers
 from shared_code.api import (
     get_concept_vocabs,
@@ -319,5 +321,11 @@ def main(msg: func.QueueMessage):
     _, vocab_dictionary = blob_parser.get_data_dictionary(data_dictionary_blob)
 
     asyncio.run(_handle_table(table, vocab_dictionary))
+
+    # send to MappingRules queue
+    message = {
+        "table_id": table_id,
+    }
+    add_message(os.environ.get("MAPPING_RULES_QUEUE_NAME"), message)
 
     return

--- a/app/workers/MappingRules/__init__.py
+++ b/app/workers/MappingRules/__init__.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import azure.functions as func
@@ -12,18 +13,17 @@ from shared.services import refresh_mapping_rules
 
 def main(msg: func.QueueMessage):
     """
-    Creates mapping rules.
-    Args:
-        msg (func.QueueMessage): The message received from the queue.
-    """
-    # probably the most direct route to do this is to create a shared service
-    # and move the shared code to it.
-    # then use it only here
+    Refreshes mapping rules for a ScanReportTable.
 
-    # once we are satisfied it duplicates the legacy behaviour in prod.
-    # then we can move all the refresh mapping rules to use the service.
-    # TODO: parse message to get table_id
-    table_id = 1
+    Args:
+        - msg (func.QueueMessage): The message received from the queue.
+
+    Return:
+        - None
+    """
+    message_body = json.loads(msg.get_body().decode("utf-8"))
+    table_id = message_body.get("table_id")
+
     refresh_mapping_rules(table_id)
 
     return

--- a/app/workers/MappingRules/__init__.py
+++ b/app/workers/MappingRules/__init__.py
@@ -8,7 +8,7 @@ import django
 
 django.setup()
 
-from shared.services import refresh_mapping_rules
+from shared.services.rules import refresh_mapping_rules
 
 
 def main(msg: func.QueueMessage):

--- a/app/workers/MappingRules/__init__.py
+++ b/app/workers/MappingRules/__init__.py
@@ -1,0 +1,11 @@
+import azure.functions as func
+
+
+def main(msg: func.QueueMessage):
+    """
+    Creates mapping rules.
+    Args:
+        msg (func.QueueMessage): The message received from the queue.
+    """
+
+    return

--- a/app/workers/MappingRules/__init__.py
+++ b/app/workers/MappingRules/__init__.py
@@ -2,7 +2,7 @@ import json
 import os
 
 import azure.functions as func
-from shared_code import logger
+from shared_code.logger import logger
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "shared_code.django_settings")
 import django

--- a/app/workers/MappingRules/__init__.py
+++ b/app/workers/MappingRules/__init__.py
@@ -1,4 +1,12 @@
+import os
+
 import azure.functions as func
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "shared_code.django_settings")
+import django
+
+django.setup()
+
 from shared.services import refresh_mapping_rules
 
 

--- a/app/workers/MappingRules/__init__.py
+++ b/app/workers/MappingRules/__init__.py
@@ -24,9 +24,9 @@ def main(msg: func.QueueMessage):
     """
     message_body = json.loads(msg.get_body().decode("utf-8"))
     table_id = message_body.get("table_id")
-    logger.info("We're now mapping some rules")
+    logger.info(f"Generating mapping rules for table: {table_id}")
 
     refresh_mapping_rules(table_id)
-    logger.info("We are now refreshed.")
+    logger.info(f"Finished mapping rules for table: {table_id}")
 
     return

--- a/app/workers/MappingRules/__init__.py
+++ b/app/workers/MappingRules/__init__.py
@@ -2,6 +2,7 @@ import json
 import os
 
 import azure.functions as func
+from shared_code import logger
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "shared_code.django_settings")
 import django
@@ -23,7 +24,9 @@ def main(msg: func.QueueMessage):
     """
     message_body = json.loads(msg.get_body().decode("utf-8"))
     table_id = message_body.get("table_id")
+    logger.info("We're now mapping some rules")
 
     refresh_mapping_rules(table_id)
+    logger.info("We are now refreshed.")
 
     return

--- a/app/workers/MappingRules/__init__.py
+++ b/app/workers/MappingRules/__init__.py
@@ -1,4 +1,5 @@
 import azure.functions as func
+from shared.services import refresh_mapping_rules
 
 
 def main(msg: func.QueueMessage):
@@ -7,5 +8,14 @@ def main(msg: func.QueueMessage):
     Args:
         msg (func.QueueMessage): The message received from the queue.
     """
+    # probably the most direct route to do this is to create a shared service
+    # and move the shared code to it.
+    # then use it only here
+
+    # once we are satisfied it duplicates the legacy behaviour in prod.
+    # then we can move all the refresh mapping rules to use the service.
+    # TODO: parse message to get table_id
+    table_id = 1
+    refresh_mapping_rules(table_id)
 
     return

--- a/app/workers/MappingRules/function.json
+++ b/app/workers/MappingRules/function.json
@@ -1,0 +1,12 @@
+{
+  "scriptFile": "__init__.py",
+  "bindings": [
+    {
+      "name": "msg",
+      "type": "queueTrigger",
+      "direction": "in",
+      "queueName": "%MAPPING_RULES_QUEUE_NAME%",
+      "connection": "STORAGE_CONN_STRING"
+    }
+  ]
+}

--- a/app/workers/mapping/__init__.py
+++ b/app/workers/mapping/__init__.py
@@ -1,0 +1,4 @@
+"""
+We need a "mapping" project for the Django models to work correctly.
+So this is used as an empty project.
+"""

--- a/app/workers/poetry.lock
+++ b/app/workers/poetry.lock
@@ -739,6 +739,28 @@ files = [
 test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
+name = "psycopg2"
+version = "2.9.9"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "psycopg2-2.9.9-cp310-cp310-win32.whl", hash = "sha256:38a8dcc6856f569068b47de286b472b7c473ac7977243593a288ebce0dc89516"},
+    {file = "psycopg2-2.9.9-cp310-cp310-win_amd64.whl", hash = "sha256:426f9f29bde126913a20a96ff8ce7d73fd8a216cfb323b1f04da402d452853c3"},
+    {file = "psycopg2-2.9.9-cp311-cp311-win32.whl", hash = "sha256:ade01303ccf7ae12c356a5e10911c9e1c51136003a9a1d92f7aa9d010fb98372"},
+    {file = "psycopg2-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:121081ea2e76729acfb0673ff33755e8703d45e926e416cb59bae3a86c6a4981"},
+    {file = "psycopg2-2.9.9-cp312-cp312-win32.whl", hash = "sha256:d735786acc7dd25815e89cc4ad529a43af779db2e25aa7c626de864127e5a024"},
+    {file = "psycopg2-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:a7653d00b732afb6fc597e29c50ad28087dcb4fbfb28e86092277a559ae4e693"},
+    {file = "psycopg2-2.9.9-cp37-cp37m-win32.whl", hash = "sha256:5e0d98cade4f0e0304d7d6f25bbfbc5bd186e07b38eac65379309c4ca3193efa"},
+    {file = "psycopg2-2.9.9-cp37-cp37m-win_amd64.whl", hash = "sha256:7e2dacf8b009a1c1e843b5213a87f7c544b2b042476ed7755be813eaf4e8347a"},
+    {file = "psycopg2-2.9.9-cp38-cp38-win32.whl", hash = "sha256:ff432630e510709564c01dafdbe996cb552e0b9f3f065eb89bdce5bd31fabf4c"},
+    {file = "psycopg2-2.9.9-cp38-cp38-win_amd64.whl", hash = "sha256:bac58c024c9922c23550af2a581998624d6e02350f4ae9c5f0bc642c633a2d5e"},
+    {file = "psycopg2-2.9.9-cp39-cp39-win32.whl", hash = "sha256:c92811b2d4c9b6ea0285942b2e7cac98a59e166d59c588fe5cfe1eda58e72d59"},
+    {file = "psycopg2-2.9.9-cp39-cp39-win_amd64.whl", hash = "sha256:de80739447af31525feddeb8effd640782cf5998e1a4e9192ebdf829717e3913"},
+    {file = "psycopg2-2.9.9.tar.gz", hash = "sha256:d1454bde93fb1e224166811694d600e746430c006fbb031ea06ecc2ea41bf156"},
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.9"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
@@ -1222,4 +1244,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e1aa0833d057038f4a58f16f38654ce92545be1f2d713ead6c8cf96f3c393f97"
+content-hash = "1a23a2eb1eeb466f0cf130102dfbdd5023ce1bab514fbba3e695f08abfb6eb2b"

--- a/app/workers/poetry.lock
+++ b/app/workers/poetry.lock
@@ -2,13 +2,13 @@
 
 [[package]]
 name = "anyio"
-version = "4.2.0"
+version = "4.3.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "anyio-4.2.0-py3-none-any.whl", hash = "sha256:745843b39e829e108e518c489b31dc757de7d2131d53fac32bd8df268227bfee"},
-    {file = "anyio-4.2.0.tar.gz", hash = "sha256:e1875bb4b4e2de1669f4bc7869b6d3f54231cdced71605e6e64c9be77e3be50f"},
+    {file = "anyio-4.3.0-py3-none-any.whl", hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8"},
+    {file = "anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6"},
 ]
 
 [package.dependencies]
@@ -66,13 +66,13 @@ files = [
 
 [[package]]
 name = "azure-core"
-version = "1.30.0"
+version = "1.30.1"
 description = "Microsoft Azure Core Library for Python"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "azure-core-1.30.0.tar.gz", hash = "sha256:6f3a7883ef184722f6bd997262eddaf80cfe7e5b3e0caaaf8db1695695893d35"},
-    {file = "azure_core-1.30.0-py3-none-any.whl", hash = "sha256:3dae7962aad109610e68c9a7abb31d79720e1d982ddf61363038d175a5025e89"},
+    {file = "azure-core-1.30.1.tar.gz", hash = "sha256:26273a254131f84269e8ea4464f3560c731f29c0c1f69ac99010845f239c1a8f"},
+    {file = "azure_core-1.30.1-py3-none-any.whl", hash = "sha256:7c5ee397e48f281ec4dd773d67a0a47a0962ed6fa833036057f9ea067f688e74"},
 ]
 
 [package.dependencies]
@@ -112,6 +112,26 @@ files = [
 azure-core = ">=1.10.0,<2.0.0"
 cryptography = ">=2.1.4"
 msrest = ">=0.6.18"
+
+[[package]]
+name = "azure-storage-queue"
+version = "12.9.0"
+description = "Microsoft Azure Azure Queue Storage Client Library for Python"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "azure-storage-queue-12.9.0.tar.gz", hash = "sha256:98101b0e17da0d470cf5700b6c40cfe74439ec3c9c76cf38398096e7371b9d1b"},
+    {file = "azure_storage_queue-12.9.0-py3-none-any.whl", hash = "sha256:67857d102e5baeded46a1911a750bbcee28a3db61a82809e2a1082f280b9fddb"},
+]
+
+[package.dependencies]
+azure-core = ">=1.28.0,<2.0.0"
+cryptography = ">=2.1.4"
+isodate = ">=0.6.1"
+typing-extensions = ">=4.3.0"
+
+[package.extras]
+aio = ["azure-core[aio] (>=1.28.0,<2.0.0)"]
 
 [[package]]
 name = "certifi"
@@ -300,63 +320,63 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.4.3"
+version = "7.4.4"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "coverage-7.4.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8580b827d4746d47294c0e0b92854c85a92c2227927433998f0d3320ae8a71b6"},
-    {file = "coverage-7.4.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:718187eeb9849fc6cc23e0d9b092bc2348821c5e1a901c9f8975df0bc785bfd4"},
-    {file = "coverage-7.4.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:767b35c3a246bcb55b8044fd3a43b8cd553dd1f9f2c1eeb87a302b1f8daa0524"},
-    {file = "coverage-7.4.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae7f19afe0cce50039e2c782bff379c7e347cba335429678450b8fe81c4ef96d"},
-    {file = "coverage-7.4.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba3a8aaed13770e970b3df46980cb068d1c24af1a1968b7818b69af8c4347efb"},
-    {file = "coverage-7.4.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:ee866acc0861caebb4f2ab79f0b94dbfbdbfadc19f82e6e9c93930f74e11d7a0"},
-    {file = "coverage-7.4.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:506edb1dd49e13a2d4cac6a5173317b82a23c9d6e8df63efb4f0380de0fbccbc"},
-    {file = "coverage-7.4.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fd6545d97c98a192c5ac995d21c894b581f1fd14cf389be90724d21808b657e2"},
-    {file = "coverage-7.4.3-cp310-cp310-win32.whl", hash = "sha256:f6a09b360d67e589236a44f0c39218a8efba2593b6abdccc300a8862cffc2f94"},
-    {file = "coverage-7.4.3-cp310-cp310-win_amd64.whl", hash = "sha256:18d90523ce7553dd0b7e23cbb28865db23cddfd683a38fb224115f7826de78d0"},
-    {file = "coverage-7.4.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cbbe5e739d45a52f3200a771c6d2c7acf89eb2524890a4a3aa1a7fa0695d2a47"},
-    {file = "coverage-7.4.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:489763b2d037b164846ebac0cbd368b8a4ca56385c4090807ff9fad817de4113"},
-    {file = "coverage-7.4.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:451f433ad901b3bb00184d83fd83d135fb682d780b38af7944c9faeecb1e0bfe"},
-    {file = "coverage-7.4.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fcc66e222cf4c719fe7722a403888b1f5e1682d1679bd780e2b26c18bb648cdc"},
-    {file = "coverage-7.4.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b3ec74cfef2d985e145baae90d9b1b32f85e1741b04cd967aaf9cfa84c1334f3"},
-    {file = "coverage-7.4.3-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:abbbd8093c5229c72d4c2926afaee0e6e3140de69d5dcd918b2921f2f0c8baba"},
-    {file = "coverage-7.4.3-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:35eb581efdacf7b7422af677b92170da4ef34500467381e805944a3201df2079"},
-    {file = "coverage-7.4.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8249b1c7334be8f8c3abcaaa996e1e4927b0e5a23b65f5bf6cfe3180d8ca7840"},
-    {file = "coverage-7.4.3-cp311-cp311-win32.whl", hash = "sha256:cf30900aa1ba595312ae41978b95e256e419d8a823af79ce670835409fc02ad3"},
-    {file = "coverage-7.4.3-cp311-cp311-win_amd64.whl", hash = "sha256:18c7320695c949de11a351742ee001849912fd57e62a706d83dfc1581897fa2e"},
-    {file = "coverage-7.4.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b51bfc348925e92a9bd9b2e48dad13431b57011fd1038f08316e6bf1df107d10"},
-    {file = "coverage-7.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d6cdecaedea1ea9e033d8adf6a0ab11107b49571bbb9737175444cea6eb72328"},
-    {file = "coverage-7.4.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b2eccb883368f9e972e216c7b4c7c06cabda925b5f06dde0650281cb7666a30"},
-    {file = "coverage-7.4.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6c00cdc8fa4e50e1cc1f941a7f2e3e0f26cb2a1233c9696f26963ff58445bac7"},
-    {file = "coverage-7.4.3-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b9a4a8dd3dcf4cbd3165737358e4d7dfbd9d59902ad11e3b15eebb6393b0446e"},
-    {file = "coverage-7.4.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:062b0a75d9261e2f9c6d071753f7eef0fc9caf3a2c82d36d76667ba7b6470003"},
-    {file = "coverage-7.4.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:ebe7c9e67a2d15fa97b77ea6571ce5e1e1f6b0db71d1d5e96f8d2bf134303c1d"},
-    {file = "coverage-7.4.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:c0a120238dd71c68484f02562f6d446d736adcc6ca0993712289b102705a9a3a"},
-    {file = "coverage-7.4.3-cp312-cp312-win32.whl", hash = "sha256:37389611ba54fd6d278fde86eb2c013c8e50232e38f5c68235d09d0a3f8aa352"},
-    {file = "coverage-7.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:d25b937a5d9ffa857d41be042b4238dd61db888533b53bc76dc082cb5a15e914"},
-    {file = "coverage-7.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:28ca2098939eabab044ad68850aac8f8db6bf0b29bc7f2887d05889b17346454"},
-    {file = "coverage-7.4.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:280459f0a03cecbe8800786cdc23067a8fc64c0bd51dc614008d9c36e1659d7e"},
-    {file = "coverage-7.4.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c0cdedd3500e0511eac1517bf560149764b7d8e65cb800d8bf1c63ebf39edd2"},
-    {file = "coverage-7.4.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9a9babb9466fe1da12417a4aed923e90124a534736de6201794a3aea9d98484e"},
-    {file = "coverage-7.4.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dec9de46a33cf2dd87a5254af095a409ea3bf952d85ad339751e7de6d962cde6"},
-    {file = "coverage-7.4.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:16bae383a9cc5abab9bb05c10a3e5a52e0a788325dc9ba8499e821885928968c"},
-    {file = "coverage-7.4.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:2c854ce44e1ee31bda4e318af1dbcfc929026d12c5ed030095ad98197eeeaed0"},
-    {file = "coverage-7.4.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:ce8c50520f57ec57aa21a63ea4f325c7b657386b3f02ccaedeccf9ebe27686e1"},
-    {file = "coverage-7.4.3-cp38-cp38-win32.whl", hash = "sha256:708a3369dcf055c00ddeeaa2b20f0dd1ce664eeabde6623e516c5228b753654f"},
-    {file = "coverage-7.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:1bf25fbca0c8d121a3e92a2a0555c7e5bc981aee5c3fdaf4bb7809f410f696b9"},
-    {file = "coverage-7.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3b253094dbe1b431d3a4ac2f053b6d7ede2664ac559705a704f621742e034f1f"},
-    {file = "coverage-7.4.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:77fbfc5720cceac9c200054b9fab50cb2a7d79660609200ab83f5db96162d20c"},
-    {file = "coverage-7.4.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6679060424faa9c11808598504c3ab472de4531c571ab2befa32f4971835788e"},
-    {file = "coverage-7.4.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4af154d617c875b52651dd8dd17a31270c495082f3d55f6128e7629658d63765"},
-    {file = "coverage-7.4.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8640f1fde5e1b8e3439fe482cdc2b0bb6c329f4bb161927c28d2e8879c6029ee"},
-    {file = "coverage-7.4.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:69b9f6f66c0af29642e73a520b6fed25ff9fd69a25975ebe6acb297234eda501"},
-    {file = "coverage-7.4.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:0842571634f39016a6c03e9d4aba502be652a6e4455fadb73cd3a3a49173e38f"},
-    {file = "coverage-7.4.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a78ed23b08e8ab524551f52953a8a05d61c3a760781762aac49f8de6eede8c45"},
-    {file = "coverage-7.4.3-cp39-cp39-win32.whl", hash = "sha256:c0524de3ff096e15fcbfe8f056fdb4ea0bf497d584454f344d59fce069d3e6e9"},
-    {file = "coverage-7.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:0209a6369ccce576b43bb227dc8322d8ef9e323d089c6f3f26a597b09cb4d2aa"},
-    {file = "coverage-7.4.3-pp38.pp39.pp310-none-any.whl", hash = "sha256:7cbde573904625509a3f37b6fecea974e363460b556a627c60dc2f47e2fffa51"},
-    {file = "coverage-7.4.3.tar.gz", hash = "sha256:276f6077a5c61447a48d133ed13e759c09e62aff0dc84274a68dc18660104d52"},
+    {file = "coverage-7.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0be5efd5127542ef31f165de269f77560d6cdef525fffa446de6f7e9186cfb2"},
+    {file = "coverage-7.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ccd341521be3d1b3daeb41960ae94a5e87abe2f46f17224ba5d6f2b8398016cf"},
+    {file = "coverage-7.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09fa497a8ab37784fbb20ab699c246053ac294d13fc7eb40ec007a5043ec91f8"},
+    {file = "coverage-7.4.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b1a93009cb80730c9bca5d6d4665494b725b6e8e157c1cb7f2db5b4b122ea562"},
+    {file = "coverage-7.4.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:690db6517f09336559dc0b5f55342df62370a48f5469fabf502db2c6d1cffcd2"},
+    {file = "coverage-7.4.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:09c3255458533cb76ef55da8cc49ffab9e33f083739c8bd4f58e79fecfe288f7"},
+    {file = "coverage-7.4.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:8ce1415194b4a6bd0cdcc3a1dfbf58b63f910dcb7330fe15bdff542c56949f87"},
+    {file = "coverage-7.4.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b91cbc4b195444e7e258ba27ac33769c41b94967919f10037e6355e998af255c"},
+    {file = "coverage-7.4.4-cp310-cp310-win32.whl", hash = "sha256:598825b51b81c808cb6f078dcb972f96af96b078faa47af7dfcdf282835baa8d"},
+    {file = "coverage-7.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:09ef9199ed6653989ebbcaacc9b62b514bb63ea2f90256e71fea3ed74bd8ff6f"},
+    {file = "coverage-7.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0f9f50e7ef2a71e2fae92774c99170eb8304e3fdf9c8c3c7ae9bab3e7229c5cf"},
+    {file = "coverage-7.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:623512f8ba53c422fcfb2ce68362c97945095b864cda94a92edbaf5994201083"},
+    {file = "coverage-7.4.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0513b9508b93da4e1716744ef6ebc507aff016ba115ffe8ecff744d1322a7b63"},
+    {file = "coverage-7.4.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40209e141059b9370a2657c9b15607815359ab3ef9918f0196b6fccce8d3230f"},
+    {file = "coverage-7.4.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8a2b2b78c78293782fd3767d53e6474582f62443d0504b1554370bde86cc8227"},
+    {file = "coverage-7.4.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:73bfb9c09951125d06ee473bed216e2c3742f530fc5acc1383883125de76d9cd"},
+    {file = "coverage-7.4.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:1f384c3cc76aeedce208643697fb3e8437604b512255de6d18dae3f27655a384"},
+    {file = "coverage-7.4.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:54eb8d1bf7cacfbf2a3186019bcf01d11c666bd495ed18717162f7eb1e9dd00b"},
+    {file = "coverage-7.4.4-cp311-cp311-win32.whl", hash = "sha256:cac99918c7bba15302a2d81f0312c08054a3359eaa1929c7e4b26ebe41e9b286"},
+    {file = "coverage-7.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:b14706df8b2de49869ae03a5ccbc211f4041750cd4a66f698df89d44f4bd30ec"},
+    {file = "coverage-7.4.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:201bef2eea65e0e9c56343115ba3814e896afe6d36ffd37bab783261db430f76"},
+    {file = "coverage-7.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41c9c5f3de16b903b610d09650e5e27adbfa7f500302718c9ffd1c12cf9d6818"},
+    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d898fe162d26929b5960e4e138651f7427048e72c853607f2b200909794ed978"},
+    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ea79bb50e805cd6ac058dfa3b5c8f6c040cb87fe83de10845857f5535d1db70"},
+    {file = "coverage-7.4.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce4b94265ca988c3f8e479e741693d143026632672e3ff924f25fab50518dd51"},
+    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c"},
+    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:fdfafb32984684eb03c2d83e1e51f64f0906b11e64482df3c5db936ce3839d48"},
+    {file = "coverage-7.4.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:69eb372f7e2ece89f14751fbcbe470295d73ed41ecd37ca36ed2eb47512a6ab9"},
+    {file = "coverage-7.4.4-cp312-cp312-win32.whl", hash = "sha256:137eb07173141545e07403cca94ab625cc1cc6bc4c1e97b6e3846270e7e1fea0"},
+    {file = "coverage-7.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:d71eec7d83298f1af3326ce0ff1d0ea83c7cb98f72b577097f9083b20bdaf05e"},
+    {file = "coverage-7.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d5ae728ff3b5401cc320d792866987e7e7e880e6ebd24433b70a33b643bb0384"},
+    {file = "coverage-7.4.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:cc4f1358cb0c78edef3ed237ef2c86056206bb8d9140e73b6b89fbcfcbdd40e1"},
+    {file = "coverage-7.4.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8130a2aa2acb8788e0b56938786c33c7c98562697bf9f4c7d6e8e5e3a0501e4a"},
+    {file = "coverage-7.4.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf271892d13e43bc2b51e6908ec9a6a5094a4df1d8af0bfc360088ee6c684409"},
+    {file = "coverage-7.4.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a4cdc86d54b5da0df6d3d3a2f0b710949286094c3a6700c21e9015932b81447e"},
+    {file = "coverage-7.4.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ae71e7ddb7a413dd60052e90528f2f65270aad4b509563af6d03d53e979feafd"},
+    {file = "coverage-7.4.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:38dd60d7bf242c4ed5b38e094baf6401faa114fc09e9e6632374388a404f98e7"},
+    {file = "coverage-7.4.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:aa5b1c1bfc28384f1f53b69a023d789f72b2e0ab1b3787aae16992a7ca21056c"},
+    {file = "coverage-7.4.4-cp38-cp38-win32.whl", hash = "sha256:dfa8fe35a0bb90382837b238fff375de15f0dcdb9ae68ff85f7a63649c98527e"},
+    {file = "coverage-7.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:b2991665420a803495e0b90a79233c1433d6ed77ef282e8e152a324bbbc5e0c8"},
+    {file = "coverage-7.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3b799445b9f7ee8bf299cfaed6f5b226c0037b74886a4e11515e569b36fe310d"},
+    {file = "coverage-7.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b4d33f418f46362995f1e9d4f3a35a1b6322cb959c31d88ae56b0298e1c22357"},
+    {file = "coverage-7.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aadacf9a2f407a4688d700e4ebab33a7e2e408f2ca04dbf4aef17585389eff3e"},
+    {file = "coverage-7.4.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7c95949560050d04d46b919301826525597f07b33beba6187d04fa64d47ac82e"},
+    {file = "coverage-7.4.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ff7687ca3d7028d8a5f0ebae95a6e4827c5616b31a4ee1192bdfde697db110d4"},
+    {file = "coverage-7.4.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:5fc1de20b2d4a061b3df27ab9b7c7111e9a710f10dc2b84d33a4ab25065994ec"},
+    {file = "coverage-7.4.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c74880fc64d4958159fbd537a091d2a585448a8f8508bf248d72112723974cbd"},
+    {file = "coverage-7.4.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:742a76a12aa45b44d236815d282b03cfb1de3b4323f3e4ec933acfae08e54ade"},
+    {file = "coverage-7.4.4-cp39-cp39-win32.whl", hash = "sha256:d89d7b2974cae412400e88f35d86af72208e1ede1a541954af5d944a8ba46c57"},
+    {file = "coverage-7.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:9ca28a302acb19b6af89e90f33ee3e1906961f94b54ea37de6737b7ca9d8827c"},
+    {file = "coverage-7.4.4-pp38.pp39.pp310-none-any.whl", hash = "sha256:b2c5edc4ac10a7ef6605a966c58929ec6c1bd0917fb8c15cb3363f65aa40e677"},
+    {file = "coverage-7.4.4.tar.gz", hash = "sha256:c901df83d097649e257e803be22592aedfd5182f07b3cc87d640bbb9afd50f49"},
 ]
 
 [package.extras]
@@ -364,43 +384,43 @@ toml = ["tomli"]
 
 [[package]]
 name = "cryptography"
-version = "42.0.3"
+version = "42.0.5"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "cryptography-42.0.3-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:de5086cd475d67113ccb6f9fae6d8fe3ac54a4f9238fd08bfdb07b03d791ff0a"},
-    {file = "cryptography-42.0.3-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:935cca25d35dda9e7bd46a24831dfd255307c55a07ff38fd1a92119cffc34857"},
-    {file = "cryptography-42.0.3-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20100c22b298c9eaebe4f0b9032ea97186ac2555f426c3e70670f2517989543b"},
-    {file = "cryptography-42.0.3-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2eb6368d5327d6455f20327fb6159b97538820355ec00f8cc9464d617caecead"},
-    {file = "cryptography-42.0.3-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:39d5c93e95bcbc4c06313fc6a500cee414ee39b616b55320c1904760ad686938"},
-    {file = "cryptography-42.0.3-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3d96ea47ce6d0055d5b97e761d37b4e84195485cb5a38401be341fabf23bc32a"},
-    {file = "cryptography-42.0.3-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:d1998e545081da0ab276bcb4b33cce85f775adb86a516e8f55b3dac87f469548"},
-    {file = "cryptography-42.0.3-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:93fbee08c48e63d5d1b39ab56fd3fdd02e6c2431c3da0f4edaf54954744c718f"},
-    {file = "cryptography-42.0.3-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:90147dad8c22d64b2ff7331f8d4cddfdc3ee93e4879796f837bdbb2a0b141e0c"},
-    {file = "cryptography-42.0.3-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4dcab7c25e48fc09a73c3e463d09ac902a932a0f8d0c568238b3696d06bf377b"},
-    {file = "cryptography-42.0.3-cp37-abi3-win32.whl", hash = "sha256:1e935c2900fb53d31f491c0de04f41110351377be19d83d908c1fd502ae8daa5"},
-    {file = "cryptography-42.0.3-cp37-abi3-win_amd64.whl", hash = "sha256:762f3771ae40e111d78d77cbe9c1035e886ac04a234d3ee0856bf4ecb3749d54"},
-    {file = "cryptography-42.0.3-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:0d3ec384058b642f7fb7e7bff9664030011ed1af8f852540c76a1317a9dd0d20"},
-    {file = "cryptography-42.0.3-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35772a6cffd1f59b85cb670f12faba05513446f80352fe811689b4e439b5d89e"},
-    {file = "cryptography-42.0.3-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:04859aa7f12c2b5f7e22d25198ddd537391f1695df7057c8700f71f26f47a129"},
-    {file = "cryptography-42.0.3-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c3d1f5a1d403a8e640fa0887e9f7087331abb3f33b0f2207d2cc7f213e4a864c"},
-    {file = "cryptography-42.0.3-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:df34312149b495d9d03492ce97471234fd9037aa5ba217c2a6ea890e9166f151"},
-    {file = "cryptography-42.0.3-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:de4ae486041878dc46e571a4c70ba337ed5233a1344c14a0790c4c4be4bbb8b4"},
-    {file = "cryptography-42.0.3-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:0fab2a5c479b360e5e0ea9f654bcebb535e3aa1e493a715b13244f4e07ea8eec"},
-    {file = "cryptography-42.0.3-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:25b09b73db78facdfd7dd0fa77a3f19e94896197c86e9f6dc16bce7b37a96504"},
-    {file = "cryptography-42.0.3-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d5cf11bc7f0b71fb71af26af396c83dfd3f6eed56d4b6ef95d57867bf1e4ba65"},
-    {file = "cryptography-42.0.3-cp39-abi3-win32.whl", hash = "sha256:0fea01527d4fb22ffe38cd98951c9044400f6eff4788cf52ae116e27d30a1ba3"},
-    {file = "cryptography-42.0.3-cp39-abi3-win_amd64.whl", hash = "sha256:2619487f37da18d6826e27854a7f9d4d013c51eafb066c80d09c63cf24505306"},
-    {file = "cryptography-42.0.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ead69ba488f806fe1b1b4050febafdbf206b81fa476126f3e16110c818bac396"},
-    {file = "cryptography-42.0.3-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:20180da1b508f4aefc101cebc14c57043a02b355d1a652b6e8e537967f1e1b46"},
-    {file = "cryptography-42.0.3-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:5fbf0f3f0fac7c089308bd771d2c6c7b7d53ae909dce1db52d8e921f6c19bb3a"},
-    {file = "cryptography-42.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:c23f03cfd7d9826cdcbad7850de67e18b4654179e01fe9bc623d37c2638eb4ef"},
-    {file = "cryptography-42.0.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db0480ffbfb1193ac4e1e88239f31314fe4c6cdcf9c0b8712b55414afbf80db4"},
-    {file = "cryptography-42.0.3-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:6c25e1e9c2ce682d01fc5e2dde6598f7313027343bd14f4049b82ad0402e52cd"},
-    {file = "cryptography-42.0.3-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:9541c69c62d7446539f2c1c06d7046aef822940d248fa4b8962ff0302862cc1f"},
-    {file = "cryptography-42.0.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1b797099d221df7cce5ff2a1d272761d1554ddf9a987d3e11f6459b38cd300fd"},
-    {file = "cryptography-42.0.3.tar.gz", hash = "sha256:069d2ce9be5526a44093a0991c450fe9906cdf069e0e7cd67d9dee49a62b9ebe"},
+    {file = "cryptography-42.0.5-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16"},
+    {file = "cryptography-42.0.5-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278"},
+    {file = "cryptography-42.0.5-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d"},
+    {file = "cryptography-42.0.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da"},
+    {file = "cryptography-42.0.5-cp37-abi3-win32.whl", hash = "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74"},
+    {file = "cryptography-42.0.5-cp37-abi3-win_amd64.whl", hash = "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940"},
+    {file = "cryptography-42.0.5-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc"},
+    {file = "cryptography-42.0.5-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc"},
+    {file = "cryptography-42.0.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30"},
+    {file = "cryptography-42.0.5-cp39-abi3-win32.whl", hash = "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413"},
+    {file = "cryptography-42.0.5-cp39-abi3-win_amd64.whl", hash = "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9481ffe3cf013b71b2428b905c4f7a9a4f76ec03065b05ff499bb5682a8d9ad8"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:ba334e6e4b1d92442b75ddacc615c5476d4ad55cc29b15d590cc6b86efa487e2"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:ba3e4a42397c25b7ff88cdec6e2a16c2be18720f317506ee25210f6d31925f9c"},
+    {file = "cryptography-42.0.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:111a0d8553afcf8eb02a4fea6ca4f59d48ddb34497aa8706a6cf536f1a5ec576"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:cd65d75953847815962c84a4654a84850b2bb4aed3f26fadcc1c13892e1e29f6"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:e807b3188f9eb0eaa7bbb579b462c5ace579f1cedb28107ce8b48a9f7ad3679e"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:f12764b8fffc7a123f641d7d049d382b73f96a34117e0b637b80643169cec8ac"},
+    {file = "cryptography-42.0.5-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:37dd623507659e08be98eec89323469e8c7b4c1407c85112634ae3dbdb926fdd"},
+    {file = "cryptography-42.0.5.tar.gz", hash = "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1"},
 ]
 
 [package.dependencies]
@@ -460,13 +480,13 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.3"
+version = "1.0.5"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.3-py3-none-any.whl", hash = "sha256:9a6a501c3099307d9fd76ac244e08503427679b1e81ceb1d922485e2f2462ad2"},
-    {file = "httpcore-1.0.3.tar.gz", hash = "sha256:5c0f9546ad17dac4d0772b0808856eb616eb8b48ce94f49ed819fd6982a8a544"},
+    {file = "httpcore-1.0.5-py3-none-any.whl", hash = "sha256:421f18bac248b25d310f3cacd198d55b8e6125c107797b609ff9b7a6ba7991b5"},
+    {file = "httpcore-1.0.5.tar.gz", hash = "sha256:34a38e2f9291467ee3b44e89dd52615370e152954ba21721378a87b2960f7a61"},
 ]
 
 [package.dependencies]
@@ -477,7 +497,7 @@ h11 = ">=0.13,<0.15"
 asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.24.0)"]
+trio = ["trio (>=0.22.0,<0.26.0)"]
 
 [[package]]
 name = "httpx"
@@ -505,13 +525,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "idna"
-version = "3.6"
+version = "3.7"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.5"
 files = [
-    {file = "idna-3.6-py3-none-any.whl", hash = "sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f"},
-    {file = "idna-3.6.tar.gz", hash = "sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"},
+    {file = "idna-3.7-py3-none-any.whl", hash = "sha256:82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0"},
+    {file = "idna-3.7.tar.gz", hash = "sha256:028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"},
 ]
 
 [[package]]
@@ -666,13 +686,13 @@ et-xmlfile = "*"
 
 [[package]]
 name = "packaging"
-version = "23.2"
+version = "24.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
-    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
+    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
 ]
 
 [[package]]
@@ -719,35 +739,116 @@ files = [
 test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
+name = "psycopg2-binary"
+version = "2.9.9"
+description = "psycopg2 - Python-PostgreSQL Database Adapter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "psycopg2-binary-2.9.9.tar.gz", hash = "sha256:7f01846810177d829c7692f1f5ada8096762d9172af1b1a28d4ab5b77c923c1c"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c2470da5418b76232f02a2fcd2229537bb2d5a7096674ce61859c3229f2eb202"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c6af2a6d4b7ee9615cbb162b0738f6e1fd1f5c3eda7e5da17861eacf4c717ea7"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75723c3c0fbbf34350b46a3199eb50638ab22a0228f93fb472ef4d9becc2382b"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:83791a65b51ad6ee6cf0845634859d69a038ea9b03d7b26e703f94c7e93dbcf9"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ef4854e82c09e84cc63084a9e4ccd6d9b154f1dbdd283efb92ecd0b5e2b8c84"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed1184ab8f113e8d660ce49a56390ca181f2981066acc27cf637d5c1e10ce46e"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d2997c458c690ec2bc6b0b7ecbafd02b029b7b4283078d3b32a852a7ce3ddd98"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:b58b4710c7f4161b5e9dcbe73bb7c62d65670a87df7bcce9e1faaad43e715245"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:0c009475ee389757e6e34611d75f6e4f05f0cf5ebb76c6037508318e1a1e0d7e"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8dbf6d1bc73f1d04ec1734bae3b4fb0ee3cb2a493d35ede9badbeb901fb40f6f"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-win32.whl", hash = "sha256:3f78fd71c4f43a13d342be74ebbc0666fe1f555b8837eb113cb7416856c79682"},
+    {file = "psycopg2_binary-2.9.9-cp310-cp310-win_amd64.whl", hash = "sha256:876801744b0dee379e4e3c38b76fc89f88834bb15bf92ee07d94acd06ec890a0"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ee825e70b1a209475622f7f7b776785bd68f34af6e7a46e2e42f27b659b5bc26"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ea665f8ce695bcc37a90ee52de7a7980be5161375d42a0b6c6abedbf0d81f0f"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:143072318f793f53819048fdfe30c321890af0c3ec7cb1dfc9cc87aa88241de2"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c332c8d69fb64979ebf76613c66b985414927a40f8defa16cf1bc028b7b0a7b0"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7fc5a5acafb7d6ccca13bfa8c90f8c51f13d8fb87d95656d3950f0158d3ce53"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:977646e05232579d2e7b9c59e21dbe5261f403a88417f6a6512e70d3f8a046be"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b6356793b84728d9d50ead16ab43c187673831e9d4019013f1402c41b1db9b27"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:bc7bb56d04601d443f24094e9e31ae6deec9ccb23581f75343feebaf30423359"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:77853062a2c45be16fd6b8d6de2a99278ee1d985a7bd8b103e97e41c034006d2"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:78151aa3ec21dccd5cdef6c74c3e73386dcdfaf19bced944169697d7ac7482fc"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-win32.whl", hash = "sha256:dc4926288b2a3e9fd7b50dc6a1909a13bbdadfc67d93f3374d984e56f885579d"},
+    {file = "psycopg2_binary-2.9.9-cp311-cp311-win_amd64.whl", hash = "sha256:b76bedd166805480ab069612119ea636f5ab8f8771e640ae103e05a4aae3e417"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:8532fd6e6e2dc57bcb3bc90b079c60de896d2128c5d9d6f24a63875a95a088cf"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0605eaed3eb239e87df0d5e3c6489daae3f7388d455d0c0b4df899519c6a38d"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f8544b092a29a6ddd72f3556a9fcf249ec412e10ad28be6a0c0d948924f2212"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2d423c8d8a3c82d08fe8af900ad5b613ce3632a1249fd6a223941d0735fce493"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2e5afae772c00980525f6d6ecf7cbca55676296b580c0e6abb407f15f3706996"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e6f98446430fdf41bd36d4faa6cb409f5140c1c2cf58ce0bbdaf16af7d3f119"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c77e3d1862452565875eb31bdb45ac62502feabbd53429fdc39a1cc341d681ba"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:cb16c65dcb648d0a43a2521f2f0a2300f40639f6f8c1ecbc662141e4e3e1ee07"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:911dda9c487075abd54e644ccdf5e5c16773470a6a5d3826fda76699410066fb"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:57fede879f08d23c85140a360c6a77709113efd1c993923c59fde17aa27599fe"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-win32.whl", hash = "sha256:64cf30263844fa208851ebb13b0732ce674d8ec6a0c86a4e160495d299ba3c93"},
+    {file = "psycopg2_binary-2.9.9-cp312-cp312-win_amd64.whl", hash = "sha256:81ff62668af011f9a48787564ab7eded4e9fb17a4a6a74af5ffa6a457400d2ab"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:2293b001e319ab0d869d660a704942c9e2cce19745262a8aba2115ef41a0a42a"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:03ef7df18daf2c4c07e2695e8cfd5ee7f748a1d54d802330985a78d2a5a6dca9"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a602ea5aff39bb9fac6308e9c9d82b9a35c2bf288e184a816002c9fae930b77"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8359bf4791968c5a78c56103702000105501adb557f3cf772b2c207284273984"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:275ff571376626195ab95a746e6a04c7df8ea34638b99fc11160de91f2fef503"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:f9b5571d33660d5009a8b3c25dc1db560206e2d2f89d3df1cb32d72c0d117d52"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:420f9bbf47a02616e8554e825208cb947969451978dceb77f95ad09c37791dae"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:4154ad09dac630a0f13f37b583eae260c6aa885d67dfbccb5b02c33f31a6d420"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:a148c5d507bb9b4f2030a2025c545fccb0e1ef317393eaba42e7eabd28eb6041"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-win32.whl", hash = "sha256:68fc1f1ba168724771e38bee37d940d2865cb0f562380a1fb1ffb428b75cb692"},
+    {file = "psycopg2_binary-2.9.9-cp37-cp37m-win_amd64.whl", hash = "sha256:281309265596e388ef483250db3640e5f414168c5a67e9c665cafce9492eda2f"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:60989127da422b74a04345096c10d416c2b41bd7bf2a380eb541059e4e999980"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:246b123cc54bb5361588acc54218c8c9fb73068bf227a4a531d8ed56fa3ca7d6"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34eccd14566f8fe14b2b95bb13b11572f7c7d5c36da61caf414d23b91fcc5d94"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:18d0ef97766055fec15b5de2c06dd8e7654705ce3e5e5eed3b6651a1d2a9a152"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3f82c171b4ccd83bbaf35aa05e44e690113bd4f3b7b6cc54d2219b132f3ae55"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ead20f7913a9c1e894aebe47cccf9dc834e1618b7aa96155d2091a626e59c972"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ca49a8119c6cbd77375ae303b0cfd8c11f011abbbd64601167ecca18a87e7cdd"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:323ba25b92454adb36fa425dc5cf6f8f19f78948cbad2e7bc6cdf7b0d7982e59"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:1236ed0952fbd919c100bc839eaa4a39ebc397ed1c08a97fc45fee2a595aa1b3"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:729177eaf0aefca0994ce4cffe96ad3c75e377c7b6f4efa59ebf003b6d398716"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-win32.whl", hash = "sha256:804d99b24ad523a1fe18cc707bf741670332f7c7412e9d49cb5eab67e886b9b5"},
+    {file = "psycopg2_binary-2.9.9-cp38-cp38-win_amd64.whl", hash = "sha256:a6cdcc3ede532f4a4b96000b6362099591ab4a3e913d70bcbac2b56c872446f7"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:72dffbd8b4194858d0941062a9766f8297e8868e1dd07a7b36212aaa90f49472"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:30dcc86377618a4c8f3b72418df92e77be4254d8f89f14b8e8f57d6d43603c0f"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:31a34c508c003a4347d389a9e6fcc2307cc2150eb516462a7a17512130de109e"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:15208be1c50b99203fe88d15695f22a5bed95ab3f84354c494bcb1d08557df67"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1873aade94b74715be2246321c8650cabf5a0d098a95bab81145ffffa4c13876"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a58c98a7e9c021f357348867f537017057c2ed7f77337fd914d0bedb35dace7"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4686818798f9194d03c9129a4d9a702d9e113a89cb03bffe08c6cf799e053291"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:ebdc36bea43063116f0486869652cb2ed7032dbc59fbcb4445c4862b5c1ecf7f"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:ca08decd2697fdea0aea364b370b1249d47336aec935f87b8bbfd7da5b2ee9c1"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ac05fb791acf5e1a3e39402641827780fe44d27e72567a000412c648a85ba860"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-win32.whl", hash = "sha256:9dba73be7305b399924709b91682299794887cbbd88e38226ed9f6712eabee90"},
+    {file = "psycopg2_binary-2.9.9-cp39-cp39-win_amd64.whl", hash = "sha256:f7ae5d65ccfbebdfa761585228eb4d0df3a8b15cfb53bd953e713e09fbb12957"},
+]
+
+[[package]]
 name = "pycparser"
-version = "2.21"
+version = "2.22"
 description = "C parser in Python"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.8"
 files = [
-    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
-    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
 
 [[package]]
 name = "pytest"
-version = "8.0.2"
+version = "8.1.1"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.0.2-py3-none-any.whl", hash = "sha256:edfaaef32ce5172d5466b5127b42e0d6d35ebbe4453f0e3505d96afd93f6b096"},
-    {file = "pytest-8.0.2.tar.gz", hash = "sha256:d4051d623a2e0b7e51960ba963193b09ce6daeb9759a451844a21e4ddedfc1bd"},
+    {file = "pytest-8.1.1-py3-none-any.whl", hash = "sha256:2a8386cfc11fa9d2c50ee7b2a57e7d898ef90470a7a34c4b949ff59662bb78b7"},
+    {file = "pytest-8.1.1.tar.gz", hash = "sha256:ac978141a75948948817d360297b7aae0fcb9d6ff6bc9ec6d514b85d5a65c044"},
 ]
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=1.3.0,<2.0"
+pluggy = ">=1.4,<2.0"
 
 [package.extras]
-testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+testing = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "pytest-cov"
@@ -847,13 +948,13 @@ files = [
 
 [[package]]
 name = "referencing"
-version = "0.33.0"
+version = "0.34.0"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "referencing-0.33.0-py3-none-any.whl", hash = "sha256:39240f2ecc770258f28b642dd47fd74bc8b02484de54e1882b74b35ebd779bd5"},
-    {file = "referencing-0.33.0.tar.gz", hash = "sha256:c775fedf74bc0f9189c2a3be1c12fd03e8c23f4d371dce795df44e06c5b412f7"},
+    {file = "referencing-0.34.0-py3-none-any.whl", hash = "sha256:d53ae300ceddd3169f1ffa9caf2cb7b769e92657e4fafb23d34b93679116dfd4"},
+    {file = "referencing-0.34.0.tar.gz", hash = "sha256:5773bd84ef41799a5a8ca72dc34590c041eb01bf9aa02632b4a973fb0181a844"},
 ]
 
 [package.dependencies]
@@ -883,13 +984,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "requests-oauthlib"
-version = "1.3.1"
+version = "2.0.0"
 description = "OAuthlib authentication support for Requests."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.4"
 files = [
-    {file = "requests-oauthlib-1.3.1.tar.gz", hash = "sha256:75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"},
-    {file = "requests_oauthlib-1.3.1-py2.py3-none-any.whl", hash = "sha256:2577c501a2fb8d05a304c09d090d6e47c306fef15809d102b327cf8364bddab5"},
+    {file = "requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9"},
+    {file = "requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36"},
 ]
 
 [package.dependencies]
@@ -1033,7 +1134,9 @@ files = []
 develop = true
 
 [package.dependencies]
+azure-storage-queue = "^12.9.0"
 django = "4.2"
+psycopg2-binary = "^2.9.9"
 
 [package.source]
 type = "directory"
@@ -1052,13 +1155,13 @@ files = [
 
 [[package]]
 name = "sniffio"
-version = "1.3.0"
+version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},
-    {file = "sniffio-1.3.0.tar.gz", hash = "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101"},
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
 ]
 
 [[package]]
@@ -1079,13 +1182,13 @@ test = ["pytest", "pytest-cov"]
 
 [[package]]
 name = "typing-extensions"
-version = "4.9.0"
+version = "4.11.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.9.0-py3-none-any.whl", hash = "sha256:af72aea155e91adfc61c3ae9e0e342dbc0cba726d6cba4b6c72c1f34e47291cd"},
-    {file = "typing_extensions-4.9.0.tar.gz", hash = "sha256:23478f88c37f27d76ac8aee6c905017a143b0b1b886c3c9f66bc2fd94f9f5783"},
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
 ]
 
 [[package]]

--- a/app/workers/poetry.lock
+++ b/app/workers/poetry.lock
@@ -635,6 +635,63 @@ requests-oauthlib = ">=0.5.0"
 async = ["aiodns", "aiohttp (>=3.0)"]
 
 [[package]]
+name = "mypy"
+version = "1.9.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f8a67616990062232ee4c3952f41c779afac41405806042a8126fe96e098419f"},
+    {file = "mypy-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d357423fa57a489e8c47b7c85dfb96698caba13d66e086b412298a1a0ea3b0ed"},
+    {file = "mypy-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49c87c15aed320de9b438ae7b00c1ac91cd393c1b854c2ce538e2a72d55df150"},
+    {file = "mypy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:48533cdd345c3c2e5ef48ba3b0d3880b257b423e7995dada04248725c6f77374"},
+    {file = "mypy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:4d3dbd346cfec7cb98e6cbb6e0f3c23618af826316188d587d1c1bc34f0ede03"},
+    {file = "mypy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:653265f9a2784db65bfca694d1edd23093ce49740b2244cde583aeb134c008f3"},
+    {file = "mypy-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3a3c007ff3ee90f69cf0a15cbcdf0995749569b86b6d2f327af01fd1b8aee9dc"},
+    {file = "mypy-1.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2418488264eb41f69cc64a69a745fad4a8f86649af4b1041a4c64ee61fc61129"},
+    {file = "mypy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:68edad3dc7d70f2f17ae4c6c1b9471a56138ca22722487eebacfd1eb5321d612"},
+    {file = "mypy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:85ca5fcc24f0b4aeedc1d02f93707bccc04733f21d41c88334c5482219b1ccb3"},
+    {file = "mypy-1.9.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aceb1db093b04db5cd390821464504111b8ec3e351eb85afd1433490163d60cd"},
+    {file = "mypy-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0235391f1c6f6ce487b23b9dbd1327b4ec33bb93934aa986efe8a9563d9349e6"},
+    {file = "mypy-1.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4d5ddc13421ba3e2e082a6c2d74c2ddb3979c39b582dacd53dd5d9431237185"},
+    {file = "mypy-1.9.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:190da1ee69b427d7efa8aa0d5e5ccd67a4fb04038c380237a0d96829cb157913"},
+    {file = "mypy-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:fe28657de3bfec596bbeef01cb219833ad9d38dd5393fc649f4b366840baefe6"},
+    {file = "mypy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e54396d70be04b34f31d2edf3362c1edd023246c82f1730bbf8768c28db5361b"},
+    {file = "mypy-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5e6061f44f2313b94f920e91b204ec600982961e07a17e0f6cd83371cb23f5c2"},
+    {file = "mypy-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a10926e5473c5fc3da8abb04119a1f5811a236dc3a38d92015cb1e6ba4cb9e"},
+    {file = "mypy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b685154e22e4e9199fc95f298661deea28aaede5ae16ccc8cbb1045e716b3e04"},
+    {file = "mypy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:5d741d3fc7c4da608764073089e5f58ef6352bedc223ff58f2f038c2c4698a89"},
+    {file = "mypy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:587ce887f75dd9700252a3abbc9c97bbe165a4a630597845c61279cf32dfbf02"},
+    {file = "mypy-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f88566144752999351725ac623471661c9d1cd8caa0134ff98cceeea181789f4"},
+    {file = "mypy-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61758fabd58ce4b0720ae1e2fea5cfd4431591d6d590b197775329264f86311d"},
+    {file = "mypy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e49499be624dead83927e70c756970a0bc8240e9f769389cdf5714b0784ca6bf"},
+    {file = "mypy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:571741dc4194b4f82d344b15e8837e8c5fcc462d66d076748142327626a1b6e9"},
+    {file = "mypy-1.9.0-py3-none-any.whl", hash = "sha256:a260627a570559181a9ea5de61ac6297aa5af202f06fd7ab093ce74e7181e43e"},
+    {file = "mypy-1.9.0.tar.gz", hash = "sha256:3cc5da0127e6a478cddd906068496a97a7618a21ce9b54bde5bf7e539c7af974"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "oauthlib"
 version = "3.2.2"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1119,4 +1176,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e1aa0833d057038f4a58f16f38654ce92545be1f2d713ead6c8cf96f3c393f97"
+content-hash = "5dd045a5034afe2fbb1c030557c8205bcc09d120eaa00c64d3decc022550522d"

--- a/app/workers/poetry.lock
+++ b/app/workers/poetry.lock
@@ -635,63 +635,6 @@ requests-oauthlib = ">=0.5.0"
 async = ["aiodns", "aiohttp (>=3.0)"]
 
 [[package]]
-name = "mypy"
-version = "1.9.0"
-description = "Optional static typing for Python"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "mypy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f8a67616990062232ee4c3952f41c779afac41405806042a8126fe96e098419f"},
-    {file = "mypy-1.9.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d357423fa57a489e8c47b7c85dfb96698caba13d66e086b412298a1a0ea3b0ed"},
-    {file = "mypy-1.9.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49c87c15aed320de9b438ae7b00c1ac91cd393c1b854c2ce538e2a72d55df150"},
-    {file = "mypy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:48533cdd345c3c2e5ef48ba3b0d3880b257b423e7995dada04248725c6f77374"},
-    {file = "mypy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:4d3dbd346cfec7cb98e6cbb6e0f3c23618af826316188d587d1c1bc34f0ede03"},
-    {file = "mypy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:653265f9a2784db65bfca694d1edd23093ce49740b2244cde583aeb134c008f3"},
-    {file = "mypy-1.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3a3c007ff3ee90f69cf0a15cbcdf0995749569b86b6d2f327af01fd1b8aee9dc"},
-    {file = "mypy-1.9.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2418488264eb41f69cc64a69a745fad4a8f86649af4b1041a4c64ee61fc61129"},
-    {file = "mypy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:68edad3dc7d70f2f17ae4c6c1b9471a56138ca22722487eebacfd1eb5321d612"},
-    {file = "mypy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:85ca5fcc24f0b4aeedc1d02f93707bccc04733f21d41c88334c5482219b1ccb3"},
-    {file = "mypy-1.9.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aceb1db093b04db5cd390821464504111b8ec3e351eb85afd1433490163d60cd"},
-    {file = "mypy-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0235391f1c6f6ce487b23b9dbd1327b4ec33bb93934aa986efe8a9563d9349e6"},
-    {file = "mypy-1.9.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4d5ddc13421ba3e2e082a6c2d74c2ddb3979c39b582dacd53dd5d9431237185"},
-    {file = "mypy-1.9.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:190da1ee69b427d7efa8aa0d5e5ccd67a4fb04038c380237a0d96829cb157913"},
-    {file = "mypy-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:fe28657de3bfec596bbeef01cb219833ad9d38dd5393fc649f4b366840baefe6"},
-    {file = "mypy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e54396d70be04b34f31d2edf3362c1edd023246c82f1730bbf8768c28db5361b"},
-    {file = "mypy-1.9.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:5e6061f44f2313b94f920e91b204ec600982961e07a17e0f6cd83371cb23f5c2"},
-    {file = "mypy-1.9.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a10926e5473c5fc3da8abb04119a1f5811a236dc3a38d92015cb1e6ba4cb9e"},
-    {file = "mypy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:b685154e22e4e9199fc95f298661deea28aaede5ae16ccc8cbb1045e716b3e04"},
-    {file = "mypy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:5d741d3fc7c4da608764073089e5f58ef6352bedc223ff58f2f038c2c4698a89"},
-    {file = "mypy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:587ce887f75dd9700252a3abbc9c97bbe165a4a630597845c61279cf32dfbf02"},
-    {file = "mypy-1.9.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:f88566144752999351725ac623471661c9d1cd8caa0134ff98cceeea181789f4"},
-    {file = "mypy-1.9.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61758fabd58ce4b0720ae1e2fea5cfd4431591d6d590b197775329264f86311d"},
-    {file = "mypy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:e49499be624dead83927e70c756970a0bc8240e9f769389cdf5714b0784ca6bf"},
-    {file = "mypy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:571741dc4194b4f82d344b15e8837e8c5fcc462d66d076748142327626a1b6e9"},
-    {file = "mypy-1.9.0-py3-none-any.whl", hash = "sha256:a260627a570559181a9ea5de61ac6297aa5af202f06fd7ab093ce74e7181e43e"},
-    {file = "mypy-1.9.0.tar.gz", hash = "sha256:3cc5da0127e6a478cddd906068496a97a7618a21ce9b54bde5bf7e539c7af974"},
-]
-
-[package.dependencies]
-mypy-extensions = ">=1.0.0"
-typing-extensions = ">=4.1.0"
-
-[package.extras]
-dmypy = ["psutil (>=4.0)"]
-install-types = ["pip"]
-mypyc = ["setuptools (>=50)"]
-reports = ["lxml"]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-description = "Type system extensions for programs checked with the mypy type checker."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
-]
-
-[[package]]
 name = "oauthlib"
 version = "3.2.2"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
@@ -1176,4 +1119,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5dd045a5034afe2fbb1c030557c8205bcc09d120eaa00c64d3decc022550522d"
+content-hash = "e1aa0833d057038f4a58f16f38654ce92545be1f2d713ead6c8cf96f3c393f97"

--- a/app/workers/pyproject.toml
+++ b/app/workers/pyproject.toml
@@ -19,6 +19,7 @@ python-dotenv = "^1.0.1"
 
 [tool.poetry.group.dev.dependencies]
 memory-profiler = "^0.61.0"
+mypy = "^1.9.0"
 
 
 [tool.poetry.group.test.dependencies]

--- a/app/workers/pyproject.toml
+++ b/app/workers/pyproject.toml
@@ -19,7 +19,6 @@ python-dotenv = "^1.0.1"
 
 [tool.poetry.group.dev.dependencies]
 memory-profiler = "^0.61.0"
-mypy = "^1.9.0"
 
 
 [tool.poetry.group.test.dependencies]

--- a/app/workers/pyproject.toml
+++ b/app/workers/pyproject.toml
@@ -19,6 +19,7 @@ python-dotenv = "^1.0.1"
 
 [tool.poetry.group.dev.dependencies]
 memory-profiler = "^0.61.0"
+psycopg2 = "^2.9.9"
 
 
 [tool.poetry.group.test.dependencies]

--- a/app/workers/shared_code/django_settings.py
+++ b/app/workers/shared_code/django_settings.py
@@ -10,6 +10,7 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
+    "mapping",
     "shared",
 ]
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ Please append a line to the changelog for each change made.
 
 ### Improvements
 - Added a `shared` library for the database models, enabling both the Django and Azure Functions to directly access the database.
-- Created new Azure Function MappingRules, which generates the reusable rules for a Scan Report table, when the CreateConcepts has finished.
+- Created new Azure Function MappingRules, which generates the mapping rules (from reuse or from vocabularies) for a Scan Report table, when the CreateConcepts has finished.
 ### Bugfixes
 - Fix reusing Concepts without a data dictionary.
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ Please append a line to the changelog for each change made.
 
 ### Improvements
 - Added a `shared` library for the database models, enabling both the Django and Azure Functions to directly access the database.
+- Created new Azure Function MappingRules, which generates the reusable rules for a Scan Report table, when the CreateConcepts has finished.
 ### Bugfixes
 - Fix reusing Concepts without a data dictionary.
 

--- a/sample-local.settings.json
+++ b/sample-local.settings.json
@@ -11,6 +11,7 @@
         "NLP_QUEUE_NAME":"nlpqueue-local",
         "UPLOAD_QUEUE_NAME": "uploadreports-local",
         "CREATE_CONCEPTS_QUEUE_NAME":"conceptqueue-local",
+        "MAPPING_RULES_QUEUE_NAME":"mapping-rules-queue-local",
         "PAGE_MAX_CHARS": "30000",
         "CHUNK_SIZE": "6"
     }


### PR DESCRIPTION
# Changes

Adds a new Azure Function `MappingRules`, that generates mapping rules when given a `table_id`.

The UX change is that reused mapping rules will now be generated when a user selects the Person Id and Date Event for that table, instead of using the "Refresh Rules" button.
This enables larger scan reports, as the workload is now serverless, and only happening on a table basis rather than a whole Scan Report. 

The UI has been updated with a notice to reflect this, and removing the "Refresh Rules" button entirely. The JSX changes are mostly Prettier working away.

The code to generate the rules is mostly lift and shift (added docs, types, tests), as we can now use the database directly in Azure functions.
I've moved this code into the shared package, with the intention of removing it from the CLI (which will use the new service), and the existing `services_rules.py`.

Closes #663 
Closes #612 

# Screenshots
![Screenshot 2024-04-12 at 11 38 49](https://github.com/Health-Informatics-UoN/CaRROT-Mapper/assets/1127507/7f2e4df7-396a-40f5-a463-ceb2a7b3a09c)

# Deployment

Needs the following environment variables added:
- [x] workers dev
- [x] workers test
- [x] workers prod

```
COCONNECT_DB_ENGINE
COCONNECT_DB_HOST
COCONNECT_DB_NAME
COCONNECT_DB_PASSWORD
COCONNECT_DB_PORT
COCONNECT_DB_USER
MAPPING_RULES_QUEUE_NAME
```
A new `MappingRules` queue for:
- [x] storage dev
- [x] storage test
- [x] storage prod

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
