### PR TITLE
Delete Django view queries

### DIFF
--- a/app/api/mapping/views.py
+++ b/app/api/mapping/views.py
@@ -117,15 +117,8 @@ class ScanReportListView(ListView):
         return context
 
     def get_queryset(self):
-        search_term = self.request.GET.get("filter", None)
-        qs = super().get_queryset()
-        if search_term == "archived":
-            qs = qs.filter(hidden=True)
-            self.filterset = "Archived"
-        else:
-            qs = qs.filter(hidden=False)
-            self.filterset = "Active"
-        return qs
+        # No data is passed to the view, it is all API fetched.
+        return ScanReport.objects.none()
 
 
 @method_decorator(login_required, name="dispatch")
@@ -161,19 +154,8 @@ class StructuralMappingTableListView(ListView):
             return redirect(request.path)
 
     def get_queryset(self):
-        qs = super().get_queryset()
-        search_term = self.kwargs.get("pk")
-
-        if search_term is not None:
-            qs = qs.filter(scan_report__id=search_term).order_by(
-                "concept",
-                "omop_field__table",
-                "omop_field__field",
-                "source_table__name",
-                "source_field__name",
-            )
-
-        return qs
+        # No data is passed to the view, it is all API fetched.
+        return MappingRule.objects.none()
 
 
 def modify_filename(filename, dt, rand):

--- a/app/api/mapping/views.py
+++ b/app/api/mapping/views.py
@@ -88,33 +88,6 @@ def update_scanreport_table_page(request, sr, pk):
 @method_decorator(login_required, name="dispatch")
 class ScanReportListView(ListView):
     model = ScanReport
-    # order the scanreports now so the latest is first in the table
-    ordering = ["-created_at"]
-
-    # handle and post methods
-    # so far just handle a post when a button to click to hide/show a report
-    def post(self, request, *args, **kwargs):
-        # obtain the scanreport id from the buttont that is clicked
-        _id = request.POST.get("scanreport_id")
-        if _id is not None:
-            # obtain the scan report based on this id
-            report = ScanReport.objects.get(pk=_id)
-            # switch hidden True -> False, or False -> True, if clicked
-            report.hidden = not report.hidden
-            # update the model
-            report.save()
-        # return to the same page
-        return redirect(request.META["HTTP_REFERER"])
-
-    def get_context_data(self, **kwargs):
-        # Call the base implementation first to get a context
-        context = super().get_context_data(**kwargs)
-        # add the current user to the context
-        # this is needed so the hide/show buttons can be only turned on
-        # by whoever created the report
-        context["current_user"] = self.request.user
-        context["filterset"] = self.filterset
-        return context
 
     def get_queryset(self):
         # No data is passed to the view, it is all API fetched.

--- a/app/api/mapping/views.py
+++ b/app/api/mapping/views.py
@@ -154,8 +154,19 @@ class StructuralMappingTableListView(ListView):
             return redirect(request.path)
 
     def get_queryset(self):
-        # No data is passed to the view, it is all API fetched.
-        return MappingRule.objects.none()
+        qs = super().get_queryset()
+        search_term = self.kwargs.get("pk")
+
+        if search_term is not None:
+            qs = qs.filter(scan_report__id=search_term).order_by(
+                "concept",
+                "omop_field__table",
+                "omop_field__field",
+                "source_table__name",
+                "source_field__name",
+            )
+
+        return qs
 
 
 def modify_filename(filename, dt, rand):


### PR DESCRIPTION
# Changes

Deletes Django view query in `ScanReportListView`. The view fetches the data by API anyway, and this page is the most frequently used and takes too long to load. So at least removing one DB query will help a small bit, but also make it clearer that this is just not used.

Closes #685 

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
