### PR TITLE
Add a Scan Report permissions API 

### DIFF
--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -60,6 +60,11 @@ urlpatterns = [
         r"scanreports/<int:pk>/download/",
         views.DownloadScanReportViewSet.as_view({"get": "list"}),
     ),
+    path(
+        "scan-reports/<int:pk>/permissions/",
+        views.ScanReportPermissionView.as_view(),
+        name="scan-report-permissions",
+    ),
     path("projects/", views.ProjectListView.as_view(), name="project_list"),
     path(
         "projects/<int:pk>/",

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -61,7 +61,7 @@ urlpatterns = [
         views.DownloadScanReportViewSet.as_view({"get": "list"}),
     ),
     path(
-        "scan-reports/<int:pk>/permissions/",
+        "scanreports/<int:pk>/permissions/",
         views.ScanReportPermissionView.as_view(),
         name="scan-report-permissions",
     ),

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -1184,9 +1184,11 @@ class DownloadScanReportViewSet(viewsets.ViewSet):
 
 
 class ScanReportPermissionView(APIView):
+    """
+    API for permissions a user has on a specific scan report.
+    """
 
     def get(self, request, pk):
-
         permissions = get_user_permissions_on_scan_report(request, pk)
 
         return Response({"permissions": permissions}, status=status.HTTP_200_OK)

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -1185,10 +1185,8 @@ class DownloadScanReportViewSet(viewsets.ViewSet):
 
 class ScanReportPermissionView(APIView):
 
-    def get(self, request, scan_report_id):
-        user = request.user
+    def get(self, request, pk):
 
-        # Logic to get the list of permissions for the user on the scan report
-        permissions = get_user_permissions_on_scan_report(user, scan_report_id)
+        permissions = get_user_permissions_on_scan_report(request, pk)
 
         return Response({"permissions": permissions}, status=status.HTTP_200_OK)

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -50,7 +50,13 @@ from django.core.exceptions import PermissionDenied
 from django.db.models.query_utils import Q
 from django.http import HttpResponse, JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
-from mapping.permissions import CanAdmin, CanEdit, CanView, CanViewProject
+from mapping.permissions import (
+    CanAdmin,
+    CanEdit,
+    CanView,
+    CanViewProject,
+    get_user_permissions_on_scan_report,
+)
 from mapping.services_rules import get_mapping_rules_list
 from rest_framework import generics, status, viewsets
 from rest_framework.filters import OrderingFilter
@@ -1175,3 +1181,14 @@ class DownloadScanReportViewSet(viewsets.ViewSet):
         response["Content-Disposition"] = f'attachment; filename="{blob_name}"'
 
         return response
+
+
+class ScanReportPermissionView(APIView):
+
+    def get(self, request, scan_report_id):
+        user = request.user
+
+        # Logic to get the list of permissions for the user on the scan report
+        permissions = get_user_permissions_on_scan_report(user, scan_report_id)
+
+        return Response({"permissions": permissions}, status=status.HTTP_200_OK)

--- a/app/api/mapping/permissions.py
+++ b/app/api/mapping/permissions.py
@@ -305,3 +305,21 @@ class CanAdmin(permissions.BasePermission):
         if is_az_function_user(request.user):
             return True
         return is_admin(obj, request)
+
+
+def get_user_permissions_on_scan_report(request, scan_report_id):
+    try:
+        scan_report = ScanReport.objects.get(id=scan_report_id)
+        permissions = []
+
+        # Check permissions using the custom permission classes
+        if CanView().has_object_permission(request, None, scan_report):
+            permissions.append("CanView")
+        if CanEdit().has_object_permission(request, None, scan_report):
+            permissions.append("CanEdit")
+        if CanAdmin().has_object_permission(request, None, scan_report):
+            permissions.append("CanAdmin")
+
+        return permissions
+    except ScanReport.DoesNotExist:
+        return []

--- a/app/api/mapping/permissions.py
+++ b/app/api/mapping/permissions.py
@@ -308,11 +308,21 @@ class CanAdmin(permissions.BasePermission):
 
 
 def get_user_permissions_on_scan_report(request, scan_report_id):
+    """
+    Retrieve the list of permissions a user has on a specific scan report.
+
+    Args:
+        request (HttpRequest): The HTTP request object containing the authenticated user.
+        scan_report_id (int): The primary key of the scan report.
+
+    Returns:
+        list: A list of permission strings the user has on the scan report.
+              Returns an empty list if the scan report does not exist or if the user has no permissions.
+    """
     try:
         scan_report = ScanReport.objects.get(id=scan_report_id)
         permissions = []
 
-        # Check permissions using the custom permission classes
         if CanView().has_object_permission(request, None, scan_report):
             permissions.append("CanView")
         if CanEdit().has_object_permission(request, None, scan_report):

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -8,10 +8,11 @@ const fetchKeys = {
   tables: (filter?: string) => `v2/scanreporttables/?${filter}`,
   scanReport: (id: string) => `v2/scanreports/${id}/`,
   update: (id: number) => `scanreports/${id}/`,
+  permissions: (id: number) => `scanreports/${id}/permissions/`,
 };
 
 export async function getScanReportsTables(
-  filter: string | undefined
+  filter: string | undefined,
 ): Promise<ScanReportTables> {
   try {
     return await request<ScanReportTables>(fetchKeys.tables(filter));
@@ -23,13 +24,22 @@ export async function getScanReportsTables(
 }
 
 export async function getScanReports(
-  filter: string | undefined
+  filter: string | undefined,
 ): Promise<ScanReport> {
   try {
     return await request<ScanReport>(fetchKeys.list(filter));
   } catch (error) {
     console.warn("Failed to fetch data.");
     return { count: 0, next: null, previous: null, results: [] };
+  }
+}
+
+export async function getScanReportPermissions(id: number): Promise<{}> {
+  try {
+    return await request<[]>(fetchKeys.permissions(id));
+  } catch (error) {
+    console.warn("Failed to fetch data.");
+    return { permissions: [] };
   }
 }
 

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -34,9 +34,14 @@ export async function getScanReports(
   }
 }
 
+/**
+ * Get the current users permissions for a Scan Report.
+ * @param id The Id of the Scan Report
+ * @returns A object with a list of the users permissions.
+ */
 export async function getScanReportPermissions(id: number): Promise<{}> {
   try {
-    return await request<[]>(fetchKeys.permissions(id));
+    return await request<PermissionsResponse>(fetchKeys.permissions(id));
   } catch (error) {
     console.warn("Failed to fetch data.");
     return { permissions: [] };

--- a/app/next-client-app/types/permissions.ts
+++ b/app/next-client-app/types/permissions.ts
@@ -1,0 +1,5 @@
+type Permission = "CanView" | "CanEdit" | "CanAdmin";
+
+interface PermissionsResponse {
+  permissions: Permission[];
+}


### PR DESCRIPTION
# Changes

Add a Permissions endpoint for a specific Scan Report - allowing the Next client to be able to access that users permissions for a Scan Report. 

This is purely to enable the Next client to optionally render depending on permissions. 
