### PR TITLE
Delete scanreport backend

### DIFF
--- a/app/api/mapping/services.py
+++ b/app/api/mapping/services.py
@@ -1,7 +1,8 @@
+import csv
 import os
 from io import StringIO
+
 from azure.storage.blob import BlobServiceClient
-import csv
 from django.http.response import HttpResponse
 
 
@@ -46,3 +47,17 @@ def download_data_dictionary_blob(blob_name, container="data-dictionaries"):
     response["Content-Disposition"] = f'attachment; filename="{blob_name}"'
 
     return response
+
+
+def delete_blob(blob_name, container):
+    try:
+        blob_service_client = BlobServiceClient.from_connection_string(
+            os.environ.get("STORAGE_CONN_STRING")
+        )
+        container_client = blob_service_client.get_container_client(container)
+        blob_dict_client = container_client.get_blob_client(blob_name)
+        # Delete the blob
+        blob_dict_client.delete_blob()
+        return True
+    except Exception as e:
+        return e


### PR DESCRIPTION
# Changes
Closes #729 
- Added delete method to the scanreport v2 endpoint.
- Added method to delete scan report and data dictionary files in blob storage.

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
