### PR TITLE
Delete scanreport frontend

### DIFF
--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -402,12 +402,12 @@ class ScanReportListViewSetV2(ScanReportListViewSet):
 
     def perform_destroy(self, instance):
         try:
-            delete_blob(instance.name, "scanreports")
+            delete_blob(instance.name, "scan-reports")
         except Exception as e:
             raise Exception(f"Error deleting scan report: {e}")
         if instance.data_dictionary:
             try:
-                delete_blob(instance.data_dictionary, "data-dictionaries")
+                delete_blob(instance.data_dictionary.name, "data-dictionaries")
             except Exception as e:
                 raise Exception(f"Error deleting data dictionary: {e}")
         instance.delete()

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -9,7 +9,7 @@ const fetchKeys = {
   tables: (filter?: string) => `v2/scanreporttables/?${filter}`,
   fields: (filter?: string) => `v2/scanreportfields/?${filter}`,
   values: (filter?: string) => `v2/scanreportvalues/?${filter}`,
-  scanReport: (id: string) => `v2/scanreports/${id}/`,
+  scanReport: (id: string | number) => `v2/scanreports/${id}/`,
   tableName: (id: string) => `scanreporttables/${id}/`,
   fieldName: (id: string | null) => `scanreportfields/${id}/`,
   update: (id: number) => `scanreports/${id}/`,
@@ -18,11 +18,11 @@ const fetchKeys = {
 };
 
 export async function getScanReportsTables(
-  filter: string | undefined
+  filter: string | undefined,
 ): Promise<PaginatedResponse<ScanReportTable>> {
   try {
     return await request<PaginatedResponse<ScanReportTable>>(
-      fetchKeys.tables(filter)
+      fetchKeys.tables(filter),
     );
   } catch (error) {
     console.warn("Failed to fetch data.");
@@ -31,11 +31,11 @@ export async function getScanReportsTables(
 }
 
 export async function getScanReports(
-  filter: string | undefined
+  filter: string | undefined,
 ): Promise<PaginatedResponse<ScanReportList>> {
   try {
     return await request<PaginatedResponse<ScanReportList>>(
-      fetchKeys.list(filter)
+      fetchKeys.list(filter),
     );
   } catch (error) {
     console.warn("Failed to fetch data.");
@@ -49,7 +49,7 @@ export async function getScanReports(
  * @returns A object with a list of the users permissions.
  */
 export async function getScanReportPermissions(
-  id: string
+  id: string,
 ): Promise<PermissionsResponse> {
   try {
     return await request<PermissionsResponse>(fetchKeys.permissions(id));
@@ -60,11 +60,11 @@ export async function getScanReportPermissions(
 }
 
 export async function getScanReportFields(
-  filter: string | undefined
+  filter: string | undefined,
 ): Promise<PaginatedResponse<ScanReportField>> {
   try {
     return await request<PaginatedResponse<ScanReportField>>(
-      fetchKeys.fields(filter)
+      fetchKeys.fields(filter),
     );
   } catch (error) {
     console.warn("Failed to fetch data.");
@@ -73,11 +73,11 @@ export async function getScanReportFields(
 }
 
 export async function getScanReportValues(
-  filter: string | undefined
+  filter: string | undefined,
 ): Promise<PaginatedResponse<ScanReportValue>> {
   try {
     return await request<PaginatedResponse<ScanReportValue>>(
-      fetchKeys.values(filter)
+      fetchKeys.values(filter),
     );
   } catch (error) {
     console.warn("Failed to fetch data.");
@@ -121,7 +121,7 @@ export async function getScanReportTable(id: string): Promise<ScanReportTable> {
 }
 
 export async function getScanReportField(
-  id: string | null
+  id: string | null,
 ): Promise<ScanReportField | null> {
   if (id === null) {
     return null;
@@ -151,13 +151,27 @@ export async function updateScanReport(id: number, field: string, value: any) {
   }
 }
 
+export async function deleteScanReport(id: number) {
+  try {
+    await request(fetchKeys.scanReport(id), {
+      method: "DELETE",
+      headers: {
+        "Content-type": "application/json",
+      },
+    });
+    revalidatePath("/scanreports/");
+  } catch (error: any) {
+    return { errorMessage: error.message };
+  }
+}
+
 export async function updateScanReportTable(
   id: number,
   field_1: string,
   value_1: number | null,
   field_2: string,
   value_2: number | null,
-  scanreportID: number
+  scanreportID: number,
 ) {
   try {
     await request(fetchKeys.updateTable(id), {

--- a/app/next-client-app/app/scanreports/[id]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/page.tsx
@@ -18,6 +18,8 @@ import { objToQuery } from "@/lib/client-utils";
 import { FilterParameters } from "@/types/filter";
 import { DataTableFilter } from "@/components/data-table/DataTableFilter";
 import { BookText, ChevronRight, Download } from "lucide-react";
+import { TrashIcon } from "@radix-ui/react-icons";
+import DeleteDialog from "@/components/scanreports/DeleteDialog";
 
 interface ScanReportsTableProps {
   params: {
@@ -92,6 +94,13 @@ export default async function ScanReportsTable({
             </a>
             <Download className="ml-2 size-4" />
           </Button>
+          <DeleteDialog id={Number(id)} details>
+            <Button variant={"outline"} className="text-red-400">
+              Delete Scan Report
+              <TrashIcon className="ml-2 size-4" />
+            </Button>
+          </DeleteDialog>
+
           {/* TODO: This has been broken #459, needs API fixes. */}
           {/* <Button variant={"outline"}>
             <a href={`/api/scanreports/${id}/download/`} download>

--- a/app/next-client-app/app/scanreports/columns.tsx
+++ b/app/next-client-app/app/scanreports/columns.tsx
@@ -34,6 +34,7 @@ import { useState } from "react";
 import { DialogDescription } from "@radix-ui/react-dialog";
 import { deleteScanReport } from "@/api/scanreports";
 import { toast } from "sonner";
+import DeleteDialog from "@/components/scanreports/DeleteDialog";
 
 export const columns: ColumnDef<ScanReportList>[] = [
   {
@@ -134,57 +135,7 @@ export const columns: ColumnDef<ScanReportList>[] = [
     enableHiding: false,
     cell: ({ row }) => {
       const { id, hidden, dataset } = row.original;
-      const [isDeleteDialogOpen, setDeleteDialogOpen] =
-        useState<boolean>(false);
-
-      const DeleteDialog = () => {
-        const handleDelete = async () => {
-          const response = await deleteScanReport(id);
-          if (response) {
-            toast.error(
-              `Failed to delete Scan Report! ${response.errorMessage}`,
-            );
-          } else {
-            toast.success("Scan Report successfully deleted");
-          }
-          setDeleteDialogOpen(false);
-        };
-
-        return (
-          <Dialog
-            open={isDeleteDialogOpen}
-            onOpenChange={() => setDeleteDialogOpen(false)}
-          >
-            <DialogContent>
-              <DialogHeader className="text-start">
-                <DialogTitle>Delete Scan Report</DialogTitle>
-                <DialogDescription>
-                  Are you sure you want to delete this Scan Report? This will:
-                </DialogDescription>
-                <ul className="text-gray-800 list-disc pl-4 pt-2">
-                  <li>Delete the Scan Report</li>
-                  <li>Delete the Scan Report file, and data dictionary</li>
-                  <li>
-                    Delete the rules, and will not allow them to be reused
-                  </li>
-                  <li>
-                    If any rules have been reused in any other Scan Reports,
-                    they will not be deleted
-                  </li>
-                </ul>
-              </DialogHeader>
-              <DialogFooter className="flex-col space-y-2 sm:space-y-0 sm:space-x-2">
-                <Button variant="destructive" onClick={handleDelete}>
-                  Delete
-                </Button>
-                <DialogClose asChild>
-                  <Button className="bg-black text-white">Cancel</Button>
-                </DialogClose>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        );
-      };
+      const [isOpen, setOpen] = useState<boolean>(false);
 
       return (
         <>
@@ -223,12 +174,12 @@ export const columns: ColumnDef<ScanReportList>[] = [
                 </DropdownMenuItem>
               </Link>
               <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => setDeleteDialogOpen(true)}>
+              <DropdownMenuItem onClick={() => setOpen(true)}>
                 Delete <TrashIcon className="ml-auto" />
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          <DeleteDialog />
+          <DeleteDialog id={id} isOpen={isOpen} setOpen={setOpen} />
         </>
       );
     },

--- a/app/next-client-app/app/scanreports/columns.tsx
+++ b/app/next-client-app/app/scanreports/columns.tsx
@@ -12,6 +12,7 @@ import {
   DotsHorizontalIcon,
   EyeNoneIcon,
   EyeOpenIcon,
+  TrashIcon,
 } from "@radix-ui/react-icons";
 import Link from "next/link";
 import { ColumnDef } from "@tanstack/react-table";
@@ -21,6 +22,18 @@ import { ChevronRight } from "lucide-react";
 import { ScanReportStatus } from "@/components/scanreports/ScanReportStatus";
 import { format } from "date-fns/format";
 import { HandleArchive } from "@/components/HandleArchive";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useState } from "react";
+import { DialogDescription } from "@radix-ui/react-dialog";
+import { deleteScanReport } from "@/api/scanreports";
+import { toast } from "sonner";
 
 export const columns: ColumnDef<ScanReportList>[] = [
   {
@@ -121,44 +134,102 @@ export const columns: ColumnDef<ScanReportList>[] = [
     enableHiding: false,
     cell: ({ row }) => {
       const { id, hidden, dataset } = row.original;
+      const [isDeleteDialogOpen, setDeleteDialogOpen] =
+        useState<boolean>(false);
+
+      const DeleteDialog = () => {
+        const handleDelete = async () => {
+          const response = await deleteScanReport(id);
+          if (response) {
+            toast.error(
+              `Failed to delete Scan Report! ${response.errorMessage}`,
+            );
+          } else {
+            toast.success("Scan Report successfully deleted");
+          }
+          setDeleteDialogOpen(false);
+        };
+
+        return (
+          <Dialog
+            open={isDeleteDialogOpen}
+            onOpenChange={() => setDeleteDialogOpen(false)}
+          >
+            <DialogContent>
+              <DialogHeader className="text-start">
+                <DialogTitle>Delete Scan Report</DialogTitle>
+                <DialogDescription>
+                  Are you sure you want to delete this Scan Report? This will:
+                </DialogDescription>
+                <ul className="text-gray-800 list-disc pl-4 pt-2">
+                  <li>Delete the Scan Report</li>
+                  <li>Delete the Scan Report file, and data dictionary</li>
+                  <li>
+                    Delete the rules, and will not allow them to be reused
+                  </li>
+                  <li>
+                    If any rules have been reused in any other Scan Reports,
+                    they will not be deleted
+                  </li>
+                </ul>
+              </DialogHeader>
+              <DialogFooter className="flex-col space-y-2 sm:space-y-0 sm:space-x-2">
+                <Button variant="destructive" onClick={handleDelete}>
+                  Delete
+                </Button>
+                <DialogClose asChild>
+                  <Button className="bg-black text-white">Cancel</Button>
+                </DialogClose>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        );
+      };
 
       return (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm">
-              <DotsHorizontalIcon className="size-4" aria-hidden="true" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem
-              onClick={() =>
-                HandleArchive({
-                  id: id,
-                  hidden: hidden,
-                  ObjName: dataset,
-                  type: "scanreports",
-                })
-              }
-            >
-              {hidden ? "Unarchive" : "Archive"}
-              {hidden ? (
-                <EyeOpenIcon className="ml-auto" />
-              ) : (
-                <EyeNoneIcon className="ml-auto" />
-              )}
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <Link
-              href={`/scanreports/${id}/details/`}
-              style={{ textDecoration: "none", color: "black" }}
-              prefetch={false}
-            >
-              <DropdownMenuItem>
-                Details <Pencil2Icon className="ml-auto" />
+        <>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="sm">
+                <DotsHorizontalIcon className="size-4" aria-hidden="true" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem
+                onClick={() =>
+                  HandleArchive({
+                    id: id,
+                    hidden: hidden,
+                    ObjName: dataset,
+                    type: "scanreports",
+                  })
+                }
+              >
+                {hidden ? "Unarchive" : "Archive"}
+                {hidden ? (
+                  <EyeOpenIcon className="ml-auto" />
+                ) : (
+                  <EyeNoneIcon className="ml-auto" />
+                )}
               </DropdownMenuItem>
-            </Link>
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <DropdownMenuSeparator />
+              <Link
+                href={`/scanreports/${id}/details/`}
+                style={{ textDecoration: "none", color: "black" }}
+                prefetch={false}
+              >
+                <DropdownMenuItem>
+                  Details <Pencil2Icon className="ml-auto" />
+                </DropdownMenuItem>
+              </Link>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => setDeleteDialogOpen(true)}>
+                Delete <TrashIcon className="ml-auto" />
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <DeleteDialog />
+        </>
       );
     },
   },

--- a/app/next-client-app/components/scanreports/DeleteDialog.tsx
+++ b/app/next-client-app/components/scanreports/DeleteDialog.tsx
@@ -1,0 +1,78 @@
+"use client";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../ui/dialog";
+import { toast } from "sonner";
+import { Button } from "../ui/button";
+import { deleteScanReport } from "@/api/scanreports";
+import { DialogTrigger } from "@radix-ui/react-dialog";
+import { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+
+interface DeleteDialogProps {
+  id: number;
+  details?: boolean;
+  isOpen?: boolean;
+  setOpen?: (isOpen: boolean) => void;
+  children?: ReactNode | ReactNode[];
+}
+
+const DeleteDialog = ({
+  id,
+  details = false,
+  isOpen,
+  setOpen = () => {},
+  children,
+}: DeleteDialogProps) => {
+  const router = useRouter();
+
+  const handleDelete = async () => {
+    const response = await deleteScanReport(id);
+    if (response) {
+      toast.error(`Failed to delete Scan Report! ${response.errorMessage}`);
+    } else {
+      toast.success("Scan Report successfully deleted");
+    }
+    setOpen(false);
+    if (details) router.push("/scanreports/");
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={() => setOpen(false)}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent>
+        <DialogHeader className="text-start">
+          <DialogTitle>Delete Scan Report</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to delete this Scan Report? This will:
+          </DialogDescription>
+          <ul className="text-gray-500 list-disc pl-4 pt-2">
+            <li>Delete the Scan Report</li>
+            <li>Delete the Scan Report file, and data dictionary</li>
+            <li>Delete the rules, and will not allow them to be reused</li>
+            <li>
+              If any rules have been reused in any other Scan Reports, they will
+              not be deleted
+            </li>
+          </ul>
+        </DialogHeader>
+        <DialogFooter className="flex-col space-y-2 sm:space-y-0 sm:space-x-2">
+          <Button variant="destructive" onClick={handleDelete}>
+            Delete
+          </Button>
+          <DialogClose asChild>
+            <Button className="bg-black text-white">Cancel</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default DeleteDialog;

--- a/app/next-client-app/components/ui/dialog.tsx
+++ b/app/next-client-app/components/ui/dialog.tsx
@@ -88,7 +88,7 @@ const DialogTitle = React.forwardRef<
   <DialogPrimitive.Title
     ref={ref}
     className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
+      "text-xl font-semibold leading-none tracking-tight",
       className,
     )}
     {...props}

--- a/app/next-client-app/components/ui/dialog.tsx
+++ b/app/next-client-app/components/ui/dialog.tsx
@@ -102,7 +102,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    className={cn("text-md text-slate-500 dark:text-slate-400", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
# Changes

Closes #730 
- Added scan report delete API method.
- Added delete action and delete confirmation modal to index page.
- Added delete button and delete confirmation modal to scan report details page.

# Screenshots

- Delete action on scan report page

<img width="162" alt="Screenshot 2024-06-11 at 16 52 43" src="https://github.com/Health-Informatics-UoN/Carrot-Mapper/assets/94780632/0f69e41d-1d5d-42ce-a5d5-392debc2072f">

- Delete confirmation modal

<img width="1438" alt="Screenshot 2024-06-11 at 16 53 07" src="https://github.com/Health-Informatics-UoN/Carrot-Mapper/assets/94780632/b7e08c73-384b-4dc9-acd3-ca51b531a359">

- Delete button on `details` page

<img width="505" alt="Screenshot 2024-06-11 at 18 30 34" src="https://github.com/Health-Informatics-UoN/Carrot-Mapper/assets/94780632/04ce2f47-7af6-467e-a894-397c1a60d425">

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
