### PR TITLE
Fix update table list of columns limit

### DIFF
--- a/app/api/api/paginations.py
+++ b/app/api/api/paginations.py
@@ -4,5 +4,5 @@ from rest_framework import pagination
 class CustomPagination(pagination.PageNumberPagination):
     page_size = 10
     page_size_query_param = "page_size"
-    max_page_size = 100
+    max_page_size = 50
     page_query_param = "p"

--- a/app/api/api/paginations.py
+++ b/app/api/api/paginations.py
@@ -4,5 +4,5 @@ from rest_framework import pagination
 class CustomPagination(pagination.PageNumberPagination):
     page_size = 10
     page_size_query_param = "page_size"
-    max_page_size = 50
+    max_page_size = 100
     page_query_param = "p"

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -2,6 +2,7 @@
 import { revalidatePath } from "next/cache";
 import request from "@/lib/api/request";
 import { redirect } from "next/navigation";
+import { fetchAllPages } from "@/lib/api/utils";
 
 const fetchKeys = {
   list: (filter?: string) =>
@@ -69,6 +70,17 @@ export async function getScanReportFields(
   } catch (error) {
     console.warn("Failed to fetch data.");
     return { count: 0, next: null, previous: null, results: [] };
+  }
+}
+
+export async function getAllScanReportFields(
+  filter: string | undefined,
+): Promise<ScanReportField[]> {
+  try {
+    return await fetchAllPages<ScanReportField>(fetchKeys.fields(filter));
+  } catch (error) {
+    console.warn("Failed to fetch data.");
+    return [];
   }
 }
 

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/update/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/update/page.tsx
@@ -26,7 +26,7 @@ interface UpdateTableProps {
 export default async function UpdateTable({
   params: { id, tableId },
 }: UpdateTableProps) {
-  const defaultPageSize = 100;
+  const defaultPageSize = 50;
   const defaultParams = {
     scan_report_table: tableId,
     fields: "name,id",

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/update/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/update/page.tsx
@@ -26,9 +26,11 @@ interface UpdateTableProps {
 export default async function UpdateTable({
   params: { id, tableId },
 }: UpdateTableProps) {
+  const defaultPageSize = 100;
   const defaultParams = {
     scan_report_table: tableId,
     fields: "name,id",
+    page_size: defaultPageSize,
   };
   const combinedParams = { ...defaultParams };
 
@@ -39,7 +41,7 @@ export default async function UpdateTable({
     (item: ScanReportField) => ({
       id: item.id,
       name: item.name,
-    })
+    }),
   );
   const scanReportsName = await getScanReport(id);
   const table = await getScanReportTable(tableId);

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/update/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/update/page.tsx
@@ -6,8 +6,8 @@ import {
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
 import {
+  getAllScanReportFields,
   getScanReport,
-  getScanReportFields,
   getScanReportPermissions,
   getScanReportTable,
 } from "@/api/scanreports";
@@ -36,13 +36,11 @@ export default async function UpdateTable({
 
   const query = objToQuery(combinedParams);
 
-  const scanReportsFields = await getScanReportFields(query);
-  const shortenFields = scanReportsFields.results.map(
-    (item: ScanReportField) => ({
-      id: item.id,
-      name: item.name,
-    }),
-  );
+  const scanReportsFields = await getAllScanReportFields(query);
+  const shortenFields = scanReportsFields.map((item: ScanReportField) => ({
+    id: item.id,
+    name: item.name,
+  }));
   const scanReportsName = await getScanReport(id);
   const table = await getScanReportTable(tableId);
   const permissions = await getScanReportPermissions(id);

--- a/app/next-client-app/lib/api/utils.ts
+++ b/app/next-client-app/lib/api/utils.ts
@@ -1,4 +1,4 @@
-import request from "@/lib/api/request";
+import request from "./request";
 
 /**
  * Fetches all pages of paginated data from the specified url.

--- a/app/next-client-app/lib/api/utils.ts
+++ b/app/next-client-app/lib/api/utils.ts
@@ -1,23 +1,25 @@
 import request from "@/lib/api/request";
 
 /**
- * Fetches all pages of paginated data from the specified initial URL.
+ * Fetches all pages of paginated data from the specified url.
  *
  * Iterates through paginated data until all pages are fetched and concatenated.
  *
  * @template T - The type of data to be fetched
- * @param {string} initialUrl - The initial URL to start fetching paginated data from
+ * @param {string} url - The url to fetch from
  * @returns {Promise<T[]>} - A promise that resolves to an array of all fetched data
  */
-export async function fetchAllPages<T>(initialUrl: string): Promise<T[]> {
-  let url: string | null = initialUrl;
+export async function fetchAllPages<T>(url: string): Promise<T[]> {
   let allResults: T[] = [];
+  let pageNumber = 1;
 
-  while (url) {
-    const data: PaginatedResponse<T> = await request(url);
+  while (true) {
+    const urlWithPage = `${url}&p=${pageNumber}`;
+    const data: PaginatedResponse<T> = await request(urlWithPage);
 
     allResults = allResults.concat(data.results);
-    url = data.next;
+    pageNumber++;
+    if (!data.next) break;
   }
 
   return allResults;

--- a/app/next-client-app/lib/api/utils.ts
+++ b/app/next-client-app/lib/api/utils.ts
@@ -1,0 +1,24 @@
+import request from "@/lib/api/request";
+
+/**
+ * Fetches all pages of paginated data from the specified initial URL.
+ *
+ * Iterates through paginated data until all pages are fetched and concatenated.
+ *
+ * @template T - The type of data to be fetched
+ * @param {string} initialUrl - The initial URL to start fetching paginated data from
+ * @returns {Promise<T[]>} - A promise that resolves to an array of all fetched data
+ */
+export async function fetchAllPages<T>(initialUrl: string): Promise<T[]> {
+  let url: string | null = initialUrl;
+  let allResults: T[] = [];
+
+  while (url) {
+    const data: PaginatedResponse<T> = await request(url);
+
+    allResults = allResults.concat(data.results);
+    url = data.next;
+  }
+
+  return allResults;
+}


### PR DESCRIPTION
# Changes

Fixes the number of fields shown to the user, this was broken as pagination to this endpoint was added. 

Adds a API util that enables fetching all results from an endpoint - and implemented this for a Scan Reports Fields.

Closes #763 

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
