### PR TITLE
Update deployments workflow app-names

### DIFF
--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -130,7 +130,7 @@ jobs:
         uses: Azure/functions-action@v1.5.1
         id: fa
         with:
-          app-name: 'ccom-funcs-prod'
+          app-name: ${{ secrets.AZURE_FUNCTIONS_NAME }}
           slot-name: 'production'
           package: ${{ github.workspace }}/functionsapp
           publish-profile: ${{ secrets.AZURE_FUNCAPP_PUBLISH_PROFILE  }}
@@ -148,7 +148,7 @@ jobs:
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: 'ccom'
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           slot-name: 'production'
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           images: 'ccomreg.azurecr.io/${{ secrets.REGISTRY_USERNAME_DEV }}/latest:${{ github.sha }}'
@@ -171,6 +171,6 @@ jobs:
       - name: Deploy to Azure WebApp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: 'ccom-next'
+          app-name: ${{ secrets.AZURE_WEBAPP_NEXT_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_NEXT_PUBLISH_PROFILE }}
           package: ${{ github.workspace }}/frontendwebapp

--- a/.github/workflows/deploy.production.yml
+++ b/.github/workflows/deploy.production.yml
@@ -130,7 +130,7 @@ jobs:
         uses: Azure/functions-action@v1.5.1
         id: fa
         with:
-          app-name: ${{ secrets.AZURE_FUNCTIONS_NAME }}
+          app-name: ${{ vars.AZURE_FUNCTIONS_NAME }}
           slot-name: 'production'
           package: ${{ github.workspace }}/functionsapp
           publish-profile: ${{ secrets.AZURE_FUNCAPP_PUBLISH_PROFILE  }}
@@ -148,7 +148,7 @@ jobs:
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          app-name: ${{ vars.AZURE_WEBAPP_NAME }}
           slot-name: 'production'
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           images: 'ccomreg.azurecr.io/${{ secrets.REGISTRY_USERNAME_DEV }}/latest:${{ github.sha }}'
@@ -171,6 +171,6 @@ jobs:
       - name: Deploy to Azure WebApp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ secrets.AZURE_WEBAPP_NEXT_NAME }}
+          app-name: ${{ vars.AZURE_WEBAPP_NEXT_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_NEXT_PUBLISH_PROFILE }}
           package: ${{ github.workspace }}/frontendwebapp

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,7 @@ jobs:
         uses: Azure/functions-action@v1.5.1
         id: fa
         with:
-          app-name: 'ccom-funcs-dev'
+          app-name: ${{ secrets.AZURE_FUNCTIONS_NAME }}
           slot-name: 'production'
           package: ${{ github.workspace }}/functionsapp
           publish-profile: ${{ secrets.AZURE_FUNCAPP_PUBLISH_PROFILE  }}
@@ -150,7 +150,7 @@ jobs:
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: 'ccom-dev'
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           images: 'ccomreg.azurecr.io/${{ secrets.REGISTRY_USERNAME_DEV }}/latest:${{ github.sha }}'
 
@@ -172,7 +172,7 @@ jobs:
       - name: Deploy to Azure WebApp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: 'ccom-next-dev'
+          app-name: ${{ secrets.AZURE_WEBAPP_NEXT_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_NEXT_PUBLISH_PROFILE }}
           package: ${{ github.workspace }}/frontendwebapp
 
@@ -193,7 +193,7 @@ jobs:
         uses: Azure/functions-action@v1.5.1
         id: fa
         with:
-          app-name: 'ccom-funcs-test'
+          app-name: ${{ secrets.AZURE_FUNCTIONS_NAME }}
           slot-name: 'production'
           package: ${{ github.workspace }}/functionsapp
           publish-profile: ${{ secrets.AZURE_FUNCAPP_PUBLISH_PROFILE  }}
@@ -211,7 +211,7 @@ jobs:
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: 'ccom-test'
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           images: 'ccomreg.azurecr.io/${{ secrets.REGISTRY_USERNAME_DEV }}/latest:${{ github.sha }}'
 
@@ -233,6 +233,6 @@ jobs:
       - name: Deploy to Azure WebApp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: 'ccom-next-test'
+          app-name: ${{ secrets.AZURE_WEBAPP_NEXT_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_NEXT_PUBLISH_PROFILE }}
           package: ${{ github.workspace }}/frontendwebapp

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,7 @@ jobs:
         uses: Azure/functions-action@v1.5.1
         id: fa
         with:
-          app-name: ${{ secrets.AZURE_FUNCTIONS_NAME }}
+          app-name: ${{ vars.AZURE_FUNCTIONS_NAME }}
           slot-name: 'production'
           package: ${{ github.workspace }}/functionsapp
           publish-profile: ${{ secrets.AZURE_FUNCAPP_PUBLISH_PROFILE  }}
@@ -150,7 +150,7 @@ jobs:
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          app-name: ${{ vars.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           images: 'ccomreg.azurecr.io/${{ secrets.REGISTRY_USERNAME_DEV }}/latest:${{ github.sha }}'
 
@@ -172,7 +172,7 @@ jobs:
       - name: Deploy to Azure WebApp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ secrets.AZURE_WEBAPP_NEXT_NAME }}
+          app-name: ${{ vars.AZURE_WEBAPP_NEXT_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_NEXT_PUBLISH_PROFILE }}
           package: ${{ github.workspace }}/frontendwebapp
 
@@ -193,7 +193,7 @@ jobs:
         uses: Azure/functions-action@v1.5.1
         id: fa
         with:
-          app-name: ${{ secrets.AZURE_FUNCTIONS_NAME }}
+          app-name: ${{ vars.AZURE_FUNCTIONS_NAME }}
           slot-name: 'production'
           package: ${{ github.workspace }}/functionsapp
           publish-profile: ${{ secrets.AZURE_FUNCAPP_PUBLISH_PROFILE  }}
@@ -211,7 +211,7 @@ jobs:
         id: deploy-to-webapp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          app-name: ${{ vars.AZURE_WEBAPP_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
           images: 'ccomreg.azurecr.io/${{ secrets.REGISTRY_USERNAME_DEV }}/latest:${{ github.sha }}'
 
@@ -233,6 +233,6 @@ jobs:
       - name: Deploy to Azure WebApp
         uses: azure/webapps-deploy@v2
         with:
-          app-name: ${{ secrets.AZURE_WEBAPP_NEXT_NAME }}
+          app-name: ${{ vars.AZURE_WEBAPP_NEXT_NAME }}
           publish-profile: ${{ secrets.AZURE_WEBAPP_NEXT_PUBLISH_PROFILE }}
           package: ${{ github.workspace }}/frontendwebapp

--- a/app/api/templates/base.html
+++ b/app/api/templates/base.html
@@ -87,6 +87,12 @@
         {% endfor %}
     {% endif %}
     <br/>
+    {% if 'carrot.ac.uk' not in request.build_absolute_uri %}
+    <div class="alert alert-danger" role="alert">
+        <h1>Carrot has moved!</h1>
+        Please ensure you are using the <strong><a href="https://carrot.ac.uk">carrot.ac.uk</a></strong> domain, as features will not work on <strong>ccom.azurewebsites.net</strong>.
+    </div>
+    {% endif %}
     {% block body %}{% endblock %}
 </main>
 

--- a/app/api/templates/base.html
+++ b/app/api/templates/base.html
@@ -87,12 +87,6 @@
         {% endfor %}
     {% endif %}
     <br/>
-    {% if 'carrot.ac.uk' not in request.build_absolute_uri %}
-    <div class="alert alert-danger" role="alert">
-        <h1>Carrot has moved!</h1>
-        Please ensure you are using the <strong><a href="https://carrot.ac.uk">carrot.ac.uk</a></strong> domain, as features will not work on <strong>ccom.azurewebsites.net</strong>.
-    </div>
-    {% endif %}
     {% block body %}{% endblock %}
 </main>
 


### PR DESCRIPTION
# Changes

Updates the deployment workflow for dev, test, and production, to all take their application names from the environment variables, rather than hardcoded.

This enables us to deploy to the Carrot domain, related #734 
The problem is - we need to redirect the `azurewebsites.net` urls to `x.carrot.ac.uk`.

The plan:

- [x] Add the environment variables to the Github config
- [ ] Deploy the application code to new app services (hence enabling the name change here).
- [x] Attach the domains to these app services.
- [ ] Deploy a 301 redirect to the old app services, to their effective new environment domains.

