### PR TITLE
Add allowedOrigins to be an array

### DIFF
--- a/app/next-client-app/next.config.js
+++ b/app/next-client-app/next.config.js
@@ -2,7 +2,7 @@
 
 // Local BACKEND_ORIGIN="127.0.0.1:8000"
 // Allows for multiple allowedOrigins in one environment
-const allowedOrigins = process.env.BACKEND_ORIGIN.split(",");
+const allowedOrigins = process.env.BACKEND_ORIGIN?.split(",");
 
 const nextConfig = {
   output: "standalone",

--- a/app/next-client-app/next.config.js
+++ b/app/next-client-app/next.config.js
@@ -1,9 +1,14 @@
 /** @type {import('next').NextConfig} */
+
+// Local BACKEND_ORIGIN="127.0.0.1:8000"
+// Allows for multiple allowedOrigins in one environment
+const allowedOrigins = process.env.BACKEND_ORIGIN.split(",");
+
 const nextConfig = {
   output: "standalone",
   experimental: {
     serverActions: {
-      allowedOrigins: [process.env.BACKEND_ORIGIN], // Using BACKEND_ORIGIN="127.0.0.1:8000" in .env of NextJS app worked for me locally, to implement PATCH method
+      allowedOrigins: allowedOrigins,
     },
   },
 };


### PR DESCRIPTION
# Changes

Enables `allowedOrigins` to be an array, for example allowing for subdomains, as well as parents. `x.carrot.ac.uk` and `carrot.ac.uk`

Relates #734 