### PR TITLE
Fix fetching Concepts to be conditional

### DIFF
--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -80,6 +80,11 @@ router.register(
     views.ScanReportConceptFilterViewSet,
     basename="scanreportconceptsfilter",
 )
+router.register(
+    r"v2/scanreportconceptsfilter",
+    views.ScanReportConceptFilterViewSetV2,
+    basename="v2scanreportconceptsfilter",
+)
 
 router.register(
     r"classificationsystems",

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -8,6 +8,9 @@ router.register(r"omop/concepts", views.ConceptViewSet, basename="concepts")
 router.register(
     r"omop/conceptsfilter", views.ConceptFilterViewSet, basename="conceptsfilter"
 )
+router.register(
+    r"v2/omop/conceptsfilter", views.ConceptFilterViewSetV2, basename="v2conceptsfilter"
+)
 
 router.register(r"omop/vocabularies", views.VocabularyViewSet, basename="vocabularies")
 router.register(

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -126,6 +126,18 @@ class ConceptFilterViewSet(viewsets.ReadOnlyModelViewSet):
     }
 
 
+class ConceptFilterViewSetV2(viewsets.ReadOnlyModelViewSet):
+    queryset = Concept.objects.all()
+    serializer_class = ConceptSerializer
+    filter_backends = [DjangoFilterBackend]
+    pagination_class = CustomPagination
+    filterset_fields = {
+        "concept_id": ["in", "exact"],
+        "concept_code": ["in", "exact"],
+        "vocabulary_id": ["in", "exact"],
+    }
+
+
 class VocabularyViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = Vocabulary.objects.all()
     serializer_class = VocabularySerializer

--- a/app/next-client-app/api/concepts.ts
+++ b/app/next-client-app/api/concepts.ts
@@ -1,6 +1,6 @@
 "use server";
 import request from "@/lib/api/request";
-import { revalidatePath } from "next/cache";
+import { fetchAllPages } from "@/lib/api/utils";
 
 const fetchKeys = {
   conceptFilter: (filter: string) =>
@@ -8,15 +8,15 @@ const fetchKeys = {
   addConcept: "v2/scanreportconcept/",
   deleteConcept: (conceptId: number) => `scanreportconcepts/${conceptId}`,
   scanreportConcepts: (filter?: string) =>
-    `scanreportconceptsfilter/?${filter}`,
+    `v2/scanreportconceptsfilter/?${filter}`,
 };
 
 export async function getScanReportConcepts(
-  filter: string
+  filter: string | undefined,
 ): Promise<ScanReportConcept[]> {
   try {
-    return await request<ScanReportConcept[]>(
-      fetchKeys.scanreportConcepts(filter)
+    return await fetchAllPages<ScanReportConcept>(
+      fetchKeys.scanreportConcepts(filter),
     );
   } catch (error) {
     console.warn("Failed to fetch data.");

--- a/app/next-client-app/api/concepts.ts
+++ b/app/next-client-app/api/concepts.ts
@@ -4,7 +4,7 @@ import { fetchAllPages } from "@/lib/api/utils";
 
 const fetchKeys = {
   conceptFilter: (filter: string) =>
-    `omop/conceptsfilter/?concept_id__in=${filter}`,
+    `v2/omop/conceptsfilter/?concept_id__in=${filter}`,
   addConcept: "v2/scanreportconcept/",
   deleteConcept: (conceptId: number) => `scanreportconcepts/${conceptId}`,
   scanreportConcepts: (filter?: string) =>
@@ -24,9 +24,11 @@ export async function getAllScanReportConcepts(
   }
 }
 
-export async function getConceptFilters(filter: string): Promise<Concept[]> {
+export async function getAllConceptsFiltered(
+  filter: string,
+): Promise<Concept[]> {
   try {
-    return await request<Concept[]>(fetchKeys.conceptFilter(filter));
+    return await fetchAllPages<Concept>(fetchKeys.conceptFilter(filter));
   } catch (error) {
     console.warn("Failed to fetch data.");
     return [];

--- a/app/next-client-app/api/concepts.ts
+++ b/app/next-client-app/api/concepts.ts
@@ -11,7 +11,7 @@ const fetchKeys = {
     `v2/scanreportconceptsfilter/?${filter}`,
 };
 
-export async function getScanReportConcepts(
+export async function getAllScanReportConcepts(
   filter: string | undefined,
 ): Promise<ScanReportConcept[]> {
   try {

--- a/app/next-client-app/app/scanreports/[id]/layout.tsx
+++ b/app/next-client-app/app/scanreports/[id]/layout.tsx
@@ -1,0 +1,30 @@
+import { getScanReportPermissions } from "@/api/scanreports";
+import { Forbidden } from "@/components/core/Forbidden";
+
+export default async function ScanReportLayout({
+  params,
+  children,
+}: Readonly<{
+  params: { id: string };
+  children: React.ReactNode;
+}>) {
+  const permissions = await getScanReportPermissions(params.id);
+  const requiredPermissions: Permission[] = ["CanAdmin", "CanEdit", "CanView"];
+
+  if (
+    !requiredPermissions.some((permission) =>
+      permissions.permissions.includes(permission),
+    )
+  ) {
+    return (
+      <div className="pt-10 px-16">
+        <Forbidden />
+      </div>
+    );
+  }
+  return (
+    <>
+      <div>{children}</div>
+    </>
+  );
+}

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
@@ -14,7 +14,10 @@ import {
 } from "@/api/scanreports";
 import { objToQuery } from "@/lib/client-utils";
 import { FilterParameters } from "@/types/filter";
-import { getConceptFilters, getAllScanReportConcepts } from "@/api/concepts";
+import {
+  getAllConceptsFiltered,
+  getAllScanReportConcepts,
+} from "@/api/concepts";
 import { ButtonsRow } from "@/components/scanreports/ButtonsRow";
 import { ConceptDataTable } from "@/components/concepts/ConceptDataTable";
 import { columns } from "./columns";
@@ -56,7 +59,7 @@ export default async function ScanReportsValue({
       : [];
   const conceptsFilter =
     scanReportsConcepts.length > 0
-      ? await getConceptFilters(
+      ? await getAllConceptsFiltered(
           scanReportsConcepts?.map((item) => item.concept).join(","),
         )
       : [];

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
@@ -46,15 +46,18 @@ export default async function ScanReportsValue({
   const permissions = await getScanReportPermissions(id);
   const scanReportsValues = await getScanReportValues(query);
 
-  const scanReportsConcepts = await getScanReportConcepts(
-    `object_id__in=${scanReportsValues.results
-      .map((item) => item.id)
-      .join(",")}`
-  );
+  const scanReportsConcepts =
+    scanReportsValues.count > 0
+      ? await getScanReportConcepts(
+          `object_id__in=${scanReportsValues.results
+            .map((item) => item.id)
+            .join(",")}`,
+        )
+      : [];
   const conceptsFilter =
     scanReportsConcepts.length > 0
       ? await getConceptFilters(
-          scanReportsConcepts?.map((item) => item.concept).join(",")
+          scanReportsConcepts?.map((item) => item.concept).join(","),
         )
       : [];
 

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/api/scanreports";
 import { objToQuery } from "@/lib/client-utils";
 import { FilterParameters } from "@/types/filter";
-import { getConceptFilters, getScanReportConcepts } from "@/api/concepts";
+import { getConceptFilters, getAllScanReportConcepts } from "@/api/concepts";
 import { ButtonsRow } from "@/components/scanreports/ButtonsRow";
 import { ConceptDataTable } from "@/components/concepts/ConceptDataTable";
 import { columns } from "./columns";
@@ -48,7 +48,7 @@ export default async function ScanReportsValue({
 
   const scanReportsConcepts =
     scanReportsValues.results.length > 0
-      ? await getScanReportConcepts(
+      ? await getAllScanReportConcepts(
           `object_id__in=${scanReportsValues.results
             .map((item) => item.id)
             .join(",")}`,

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
@@ -47,7 +47,7 @@ export default async function ScanReportsValue({
   const scanReportsValues = await getScanReportValues(query);
 
   const scanReportsConcepts =
-    scanReportsValues.count > 0
+    scanReportsValues.results.length > 0
       ? await getScanReportConcepts(
           `object_id__in=${scanReportsValues.results
             .map((item) => item.id)

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/page.tsx
@@ -14,7 +14,10 @@ import {
 } from "@/api/scanreports";
 import { objToQuery } from "@/lib/client-utils";
 import { FilterParameters } from "@/types/filter";
-import { getConceptFilters, getAllScanReportConcepts } from "@/api/concepts";
+import {
+  getAllConceptsFiltered,
+  getAllScanReportConcepts,
+} from "@/api/concepts";
 import { ButtonsRow } from "@/components/scanreports/ButtonsRow";
 import { ConceptDataTable } from "@/components/concepts/ConceptDataTable";
 
@@ -54,7 +57,7 @@ export default async function ScanReportsField({
 
   const conceptsFilter =
     scanReportsConcepts.length > 0
-      ? await getConceptFilters(
+      ? await getAllConceptsFiltered(
           scanReportsConcepts?.map((item) => item.concept).join(","),
         )
       : [];

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/page.tsx
@@ -43,15 +43,19 @@ export default async function ScanReportsField({
   const tableName = await getScanReportTable(tableId);
   const permissions = await getScanReportPermissions(id);
 
-  const scanReportsConcepts = await getScanReportConcepts(
-    `object_id__in=${scanReportsFields.results
-      .map((item) => item.id)
-      .join(",")}`
-  );
+  const scanReportsConcepts =
+    scanReportsFields.count > 0
+      ? await getScanReportConcepts(
+          `object_id__in=${scanReportsFields.results
+            .map((item) => item.id)
+            .join(",")}`,
+        )
+      : [];
+
   const conceptsFilter =
     scanReportsConcepts.length > 0
       ? await getConceptFilters(
-          scanReportsConcepts?.map((item) => item.concept).join(",")
+          scanReportsConcepts?.map((item) => item.concept).join(","),
         )
       : [];
 

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/page.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/api/scanreports";
 import { objToQuery } from "@/lib/client-utils";
 import { FilterParameters } from "@/types/filter";
-import { getConceptFilters, getScanReportConcepts } from "@/api/concepts";
+import { getConceptFilters, getAllScanReportConcepts } from "@/api/concepts";
 import { ButtonsRow } from "@/components/scanreports/ButtonsRow";
 import { ConceptDataTable } from "@/components/concepts/ConceptDataTable";
 
@@ -45,7 +45,7 @@ export default async function ScanReportsField({
 
   const scanReportsConcepts =
     scanReportsFields.results.length > 0
-      ? await getScanReportConcepts(
+      ? await getAllScanReportConcepts(
           `object_id__in=${scanReportsFields.results
             .map((item) => item.id)
             .join(",")}`,

--- a/app/next-client-app/app/scanreports/[id]/tables/[tableId]/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/tables/[tableId]/page.tsx
@@ -44,7 +44,7 @@ export default async function ScanReportsField({
   const permissions = await getScanReportPermissions(id);
 
   const scanReportsConcepts =
-    scanReportsFields.count > 0
+    scanReportsFields.results.length > 0
       ? await getScanReportConcepts(
           `object_id__in=${scanReportsFields.results
             .map((item) => item.id)

--- a/app/next-client-app/components/concepts/add-concept.tsx
+++ b/app/next-client-app/components/concepts/add-concept.tsx
@@ -1,6 +1,6 @@
 import {
   addConcept,
-  getConceptFilters,
+  getAllConceptsFiltered,
   getAllScanReportConcepts,
 } from "@/api/concepts";
 import { getScanReportField } from "@/api/scanreports";
@@ -51,7 +51,7 @@ export default function AddConcept({
         const newConcepts = await getAllScanReportConcepts(
           `object_id=${rowId}`,
         );
-        const filteredConcepts = await getConceptFilters(
+        const filteredConcepts = await getAllConceptsFiltered(
           newConcepts?.map((item) => item.concept).join(","),
         );
         // Filter the concept and concept filter

--- a/app/next-client-app/components/concepts/add-concept.tsx
+++ b/app/next-client-app/components/concepts/add-concept.tsx
@@ -1,7 +1,7 @@
 import {
   addConcept,
   getConceptFilters,
-  getScanReportConcepts,
+  getAllScanReportConcepts,
 } from "@/api/concepts";
 import { getScanReportField } from "@/api/scanreports";
 import { Button } from "@/components/ui/button";
@@ -48,16 +48,18 @@ export default function AddConcept({
       if (response) {
         toast.error(`Adding concept failed. ${response.errorMessage}`);
       } else {
-        const newConcepts = await getScanReportConcepts(`object_id=${rowId}`);
+        const newConcepts = await getAllScanReportConcepts(
+          `object_id=${rowId}`,
+        );
         const filteredConcepts = await getConceptFilters(
-          newConcepts?.map((item) => item.concept).join(",")
+          newConcepts?.map((item) => item.concept).join(","),
         );
         // Filter the concept and concept filter
         const newConcept = newConcepts.filter(
-          (c) => c.concept == conceptCode
+          (c) => c.concept == conceptCode,
         )[0];
         const filteredConcept = filteredConcepts.filter(
-          (c) => c.concept_id == conceptCode
+          (c) => c.concept_id == conceptCode,
         )[0];
 
         addSR(newConcept, filteredConcept);

--- a/app/next-client-app/components/core/Forbidden.tsx
+++ b/app/next-client-app/components/core/Forbidden.tsx
@@ -1,0 +1,15 @@
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export function Forbidden() {
+  return (
+    <Alert variant="destructive">
+      <ExclamationTriangleIcon className="h-4 w-4" />
+      <AlertTitle>Error</AlertTitle>
+      <AlertDescription>
+        You do not have permission to access this resource.
+      </AlertDescription>
+    </Alert>
+  );
+}


### PR DESCRIPTION
# Changes

Fixes fetching Scan Report Concepts at Scan Reports Fields/Values page level, to be conditional based on if fields/values exist. 
The issue was that if no fields/values existed, Concepts would still be fetched without the filtering, resulting in long running queries. A few of these in succession (for example, through revalidation) could slow the API down to a halt.

Additionally adding pagination to the endpoints used, and therefore updating the client to fetch all pages where necessary.
We will probably now upgrade any unpaginated endpoint to a `v2` with pagination, this is a general concern across every endpoint.

Additionally adds a Forbidden layout - if the user does not have permission to see the Scan Report.

Related #761 

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
