### PR TITLE
Adding dataset bug fix

### DIFF
--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -574,6 +574,12 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         fields = "__all__"
 
 
+class DatasetViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = "__all__"
+
+
 class DatasetViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = Dataset

--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -577,13 +577,13 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         fields = "__all__"
 
 
-class DatasetViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
+class DatasetViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = Dataset
         fields = "__all__"
 
 
-class DatasetViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+class DatasetViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = Dataset
         fields = (

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -18,6 +18,7 @@ from api.serializers import (
     DatasetAndDataPartnerViewSerializer,
     DatasetEditSerializer,
     DatasetViewSerializer,
+    DatasetViewSerializerV2,
     DomainSerializer,
     DrugStrengthSerializer,
     GetRulesAnalysis,
@@ -619,7 +620,7 @@ class DatasetAndDataPartnerListView(generics.ListAPIView):
 
 
 class DatasetCreateView(generics.CreateAPIView):
-    serializer_class = DatasetViewSerializer
+    serializer_class = DatasetViewSerializerV2
     queryset = Dataset.objects.all()
 
     def perform_create(self, serializer):

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -587,7 +587,7 @@ class DatasetListView(generics.ListAPIView):
     API view to show all datasets.
     """
 
-    serializer_class = DatasetViewSerializer
+    serializer_class = DatasetViewSerializerV2
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
         "id": ["in"],
@@ -674,7 +674,7 @@ class DatasetAndDataPartnerListView(generics.ListAPIView):
 
 
 class DatasetCreateView(generics.CreateAPIView):
-    serializer_class = DatasetViewSerializerV2
+    serializer_class = DatasetViewSerializer
     queryset = Dataset.objects.all()
 
     def perform_create(self, serializer):
@@ -695,7 +695,7 @@ class DatasetRetrieveView(generics.RetrieveAPIView):
     This view should return a single dataset from an id
     """
 
-    serializer_class = DatasetViewSerializer
+    serializer_class = DatasetViewSerializerV2
     permission_classes = [CanView | CanAdmin | CanEdit]
 
     def get_queryset(self):


### PR DESCRIPTION
# Changes

This PR adds a fix for the Adding Dataset. 
When modifying the API for Updating the Dataset details, changes there accidentally made the API for creating a new Data set break. This PR fixed it now by adding a V2 Serialiser. This will be combined in the future with the Adding New Dataset API, potentially.

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
