### PR TITLE
Add Scan Report permissions

### DIFF
--- a/app/api/api/filters.py
+++ b/app/api/api/filters.py
@@ -1,0 +1,145 @@
+from django.db.models.query_utils import Q
+from rest_framework import filters
+from shared.data.models import VisibilityChoices
+
+
+class CanAccessScanReportFilterBackend(filters.BaseFilterBackend):
+    """
+    Filter that only allows users to see Scan Reports they are allowed to view, edit, or admin.
+
+    """
+
+    # Each model type needs a different relationship to get the Scan Report / Dataset permissions.
+    RELATIONSHIP_MAPPING = {
+        "scanreport": "",
+        "scanreporttable": "scan_report__",
+        "scanreportfield": "scan_report_table__scan_report__",
+        "scanreportvalue": "scan_report_field__scan_report_table__scan_report__",
+    }
+
+    def filter_queryset(self, request, queryset, view):
+        """
+        Filters the queryset based on visibility and permissions related to datasets and scan reports.
+
+        Args:
+            - request: The request object.
+            - queryset: The queryset to be filtered based on visibility and permissions.
+
+        Returns:
+            - A filtered queryset based on the specified visibility and permission conditions.
+        """
+
+        model = queryset.model.__name__.lower()
+        relationship = self.RELATIONSHIP_MAPPING.get(model, "")
+
+        dataset_visibility = f"{relationship}parent_dataset__visibility"
+        scan_report_visibility = f"{relationship}visibility"
+        scan_report_viewers = f"{relationship}viewers"
+        scan_report_editors = f"{relationship}editors"
+        scan_report_author = f"{relationship}author"
+        dataset_viewers = f"{relationship}parent_dataset__viewers"
+        dataset_editors = f"{relationship}parent_dataset__editors"
+        dataset_admins = f"{relationship}parent_dataset__admins"
+
+        return queryset.filter(
+            Q(
+                # parent dataset and SR are public
+                **{dataset_visibility: VisibilityChoices.PUBLIC},
+                **{scan_report_visibility: VisibilityChoices.PUBLIC},
+            )
+            |
+            # parent dataset is public but SR restricted checks
+            Q(
+                # parent dataset is public
+                # SR is restricted and user is in SR viewers
+                **{dataset_visibility: VisibilityChoices.PUBLIC},
+                **{scan_report_viewers: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            | Q(
+                # parent dataset is public
+                # SR is restricted and user is in SR editors
+                **{dataset_visibility: VisibilityChoices.PUBLIC},
+                **{scan_report_editors: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            | Q(
+                # parent dataset is public
+                # SR is restricted and user is SR author
+                **{dataset_visibility: VisibilityChoices.PUBLIC},
+                **{scan_report_author: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            | Q(
+                # parent dataset is public
+                # SR is restricted and user is in parent dataset editors
+                **{dataset_visibility: VisibilityChoices.PUBLIC},
+                **{dataset_editors: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            | Q(
+                # parent dataset is public
+                # SR is restricted and user is in parent dataset admins
+                **{dataset_visibility: VisibilityChoices.PUBLIC},
+                **{dataset_admins: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            # parent dataset and SR are restricted checks
+            | Q(
+                # parent dataset and SR are restricted
+                # user is in SR viewers
+                **{dataset_visibility: VisibilityChoices.RESTRICTED},
+                **{scan_report_viewers: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            | Q(
+                # parent dataset and SR are restricted
+                # user is in SR editors
+                **{dataset_visibility: VisibilityChoices.RESTRICTED},
+                **{scan_report_editors: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            | Q(
+                # parent dataset and SR are restricted
+                # user is SR author
+                **{dataset_visibility: VisibilityChoices.RESTRICTED},
+                **{scan_report_author: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            | Q(
+                # parent dataset and SR are restricted
+                # user is in parent dataset admins
+                **{dataset_visibility: VisibilityChoices.RESTRICTED},
+                **{dataset_admins: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            | Q(
+                # parent dataset and SR are restricted
+                # user is in parent dataset editors
+                **{dataset_visibility: VisibilityChoices.RESTRICTED},
+                **{dataset_editors: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.RESTRICTED},
+            )
+            # parent dataset is restricted but SR is public checks
+            | Q(
+                # parent dataset is restricted and SR public
+                # user is in parent dataset editors
+                **{dataset_visibility: VisibilityChoices.RESTRICTED},
+                **{dataset_editors: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.PUBLIC},
+            )
+            | Q(
+                # parent dataset is restricted and SR public
+                # user is in parent dataset admins
+                **{dataset_visibility: VisibilityChoices.RESTRICTED},
+                **{dataset_admins: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.PUBLIC},
+            )
+            | Q(
+                # parent dataset is restricted and SR public
+                # user is in parent dataset viewers
+                **{dataset_visibility: VisibilityChoices.RESTRICTED},
+                **{dataset_viewers: request.user.id},
+                **{scan_report_visibility: VisibilityChoices.PUBLIC},
+            )
+        ).distinct()

--- a/app/api/api/filters.py
+++ b/app/api/api/filters.py
@@ -3,7 +3,7 @@ from rest_framework import filters
 from shared.data.models import VisibilityChoices
 
 
-class CanAccessScanReportFilterBackend(filters.BaseFilterBackend):
+class ScanReportAccessFilter(filters.BaseFilterBackend):
     """
     Filter that only allows users to see Scan Reports they are allowed to view, edit, or admin.
 

--- a/app/api/api/filters.py
+++ b/app/api/api/filters.py
@@ -40,6 +40,7 @@ class ScanReportAccessFilter(filters.BaseFilterBackend):
         dataset_viewers = f"{relationship}parent_dataset__viewers"
         dataset_editors = f"{relationship}parent_dataset__editors"
         dataset_admins = f"{relationship}parent_dataset__admins"
+        project_members = f"{relationship}parent_dataset__project__members"
 
         return queryset.filter(
             Q(
@@ -141,5 +142,7 @@ class ScanReportAccessFilter(filters.BaseFilterBackend):
                 **{dataset_visibility: VisibilityChoices.RESTRICTED},
                 **{dataset_viewers: request.user.id},
                 **{scan_report_visibility: VisibilityChoices.PUBLIC},
-            )
+            ),
+            # Must always be a member of the project.
+            **{project_members: request.user.id},
         ).distinct()

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -68,35 +68,6 @@ router.register(
     basename="v2scanreportvalues",
 )
 router.register(
-    r"scanreportfilter",
-    views.ScanReportFilterViewSet,
-    basename="scanreportfilter",
-)
-
-router.register(
-    r"scanreportactiveconceptfilter",
-    views.ScanReportActiveConceptFilterViewSet,
-    basename="scanreportactiveconceptfilter",
-)
-
-
-router.register(
-    r"scanreportvaluesfilterscanreport",
-    views.ScanReportValuesFilterViewSetScanReport,
-    basename="scanreportvaluesfilterscanreport",
-)
-router.register(
-    r"scanreportvaluesfilterscanreporttable",
-    views.ScanReportValuesFilterViewSetScanReportTable,
-    basename="scanreportvaluesfilterscanreporttable",
-)
-
-router.register(
-    r"scanreportvaluepks", views.ScanReportValuePKViewSet, basename="scanreportvaluepks"
-)
-
-
-router.register(
     r"scanreportconcepts", views.ScanReportConceptViewSet, basename="scanreportconcepts"
 )
 router.register(

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -896,53 +896,6 @@ class ScanReportConceptFilterViewSet(viewsets.ModelViewSet):
     }
 
 
-class ScanReportActiveConceptFilterViewSet(viewsets.ModelViewSet):
-    """
-    This returns details of ScanReportConcepts that have the given content_type and are
-    in ScanReports that are "active" - that is, not hidden, with unhidden parent
-    dataset, and marked with status "Mapping Complete".
-    This is only retrievable by AZ_FUNCTION_USER.
-    """
-
-    serializer_class = ScanReportConceptSerializer
-    filter_backends = [DjangoFilterBackend]
-
-    def get_queryset(self):
-        if self.request.user.username != os.getenv("AZ_FUNCTION_USER"):
-            raise PermissionDenied(
-                "You do not have permission to access this resource."
-            )
-
-        content_type_str = self.request.GET["content_type"]
-        content_type = ContentType.objects.get(model=content_type_str)
-
-        if content_type_str == "scanreportfield":
-            # ScanReportField
-            # we have SRCs of content_type "field", grab all SRFields in active SRs,
-            # and then filter ScanReportConcepts by those object_ids
-            field_ids = ScanReportField.objects.filter(
-                scan_report_table__scan_report__hidden=False,
-                scan_report_table__scan_report__parent_dataset__hidden=False,
-                scan_report_table__scan_report__status="COMPLET",
-            ).values_list("id", flat=True)
-            return ScanReportConcept.objects.filter(
-                content_type=content_type, object_id__in=field_ids
-            )
-        elif content_type_str == "scanreportvalue":
-            # ScanReportValue
-            # we have SRCs of content_type "value", grab all SRValues in active SRs,
-            # and then filter ScanReportConcepts by those object_ids
-            value_ids = ScanReportValue.objects.filter(
-                scan_report_field__scan_report_table__scan_report__hidden=False,
-                scan_report_field__scan_report_table__scan_report__parent_dataset__hidden=False,
-                scan_report_field__scan_report_table__scan_report__status="COMPLET",
-            ).values_list("id", flat=True)
-            return ScanReportConcept.objects.filter(
-                content_type=content_type, object_id__in=value_ids
-            )
-        return None
-
-
 class ClassificationSystemViewSet(viewsets.ModelViewSet):
     queryset = ClassificationSystem.objects.all()
     serializer_class = ClassificationSystemSerializer
@@ -1157,18 +1110,6 @@ class ScanReportValueViewSetV2(ScanReportValueViewSet):
         return super().get_serializer_class()
 
 
-class ScanReportFilterViewSet(viewsets.ModelViewSet):
-    queryset = ScanReport.objects.all()
-    serializer_class = ScanReportViewSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = {
-        "id": ["in", "exact"],
-        "status": ["in", "exact"],
-        "hidden": ["in", "exact"],
-        "parent_dataset__hidden": ["in", "exact"],
-    }
-
-
 class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):
     serializer_class = ScanReportValueViewSerializer
     filter_backends = [DjangoFilterBackend]
@@ -1179,17 +1120,6 @@ class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):
             scan_report_field__scan_report_table__scan_report=self.request.GET[
                 "scan_report"
             ]
-        )
-
-
-class ScanReportValuesFilterViewSetScanReportTable(viewsets.ModelViewSet):
-    serializer_class = ScanReportValueViewSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["scan_report_field__scan_report_table"]
-
-    def get_queryset(self):
-        return ScanReportValue.objects.filter(
-            scan_report_field__scan_report_table=self.request.GET["scan_report_table"]
         )
 
 
@@ -1280,22 +1210,6 @@ class CountStatsScanReportTableField(APIView):
             }
             jsonrecords.append(scanreportfield_content)
         return Response(jsonrecords)
-
-
-# This custom ModelViewSet returns all ScanReportValues for a given ScanReport
-# It also removes all conceptIDs which == -1, leaving only those SRVs with a
-# concept_id which has been looked up with omop_helpers
-class ScanReportValuePKViewSet(viewsets.ModelViewSet):
-    serializer_class = ScanReportValueViewSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["scan_report_field__scan_report_table__scan_report"]
-
-    def get_queryset(self):
-        return ScanReportValue.objects.filter(
-            scan_report_field__scan_report_table__scan_report=self.request.GET[
-                "scan_report"
-            ]
-        ).exclude(conceptID=-1)
 
 
 class GetContentTypeID(APIView):

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -4,6 +4,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 import requests
+from api.filters import ScanReportAccessFilter
 from api.paginations import CustomPagination
 from api.serializers import (
     ClassificationSystemSerializer,
@@ -558,7 +559,7 @@ class DatasetDeleteView(generics.DestroyAPIView):
 
 class ScanReportTableViewSet(viewsets.ModelViewSet):
     queryset = ScanReportTable.objects.all()
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filter_backends = [DjangoFilterBackend, OrderingFilter, ScanReportAccessFilter]
     ordering_fields = ["name", "person_id", "event_date"]
     filterset_fields = {
         "scan_report": ["in", "exact"],
@@ -658,7 +659,7 @@ class ScanReportTableViewSetV2(ScanReportTableViewSet):
         "name": ["in", "icontains"],
         "id": ["in", "exact"],
     }
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filter_backends = [DjangoFilterBackend, OrderingFilter, ScanReportAccessFilter]
     ordering_fields = ["name", "person_id", "date_event"]
     pagination_class = CustomPagination
 
@@ -674,7 +675,7 @@ class ScanReportTableViewSetV2(ScanReportTableViewSet):
 
 class ScanReportFieldViewSet(viewsets.ModelViewSet):
     queryset = ScanReportField.objects.all()
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, ScanReportAccessFilter]
     filterset_fields = {
         "scan_report_table": ["in", "exact"],
         "name": ["in", "exact"],
@@ -718,7 +719,7 @@ class ScanReportFieldViewSetV2(ScanReportFieldViewSet):
         "scan_report_table": ["in", "exact"],
         "name": ["in", "icontains"],
     }
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filter_backends = [DjangoFilterBackend, OrderingFilter, ScanReportAccessFilter]
     ordering_fields = ["name", "description_column", "type_column"]
     pagination_class = CustomPagination
     ordering = "name"
@@ -1096,7 +1097,7 @@ class MappingRuleFilterViewSet(viewsets.ModelViewSet):
 
 class ScanReportValueViewSet(viewsets.ModelViewSet):
     queryset = ScanReportValue.objects.all()
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, ScanReportAccessFilter]
     filterset_fields = {
         "scan_report_field": ["in", "exact"],
         "value": ["in", "exact"],
@@ -1142,7 +1143,7 @@ class ScanReportValueViewSetV2(ScanReportValueViewSet):
         "scan_report_field": ["in", "exact"],
         "value": ["in", "icontains"],
     }
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filter_backends = [DjangoFilterBackend, OrderingFilter, ScanReportAccessFilter]
     ordering_fields = ["value", "value_description", "frequency"]
     pagination_class = CustomPagination
 

--- a/app/api/poetry.lock
+++ b/app/api/poetry.lock
@@ -400,6 +400,23 @@ files = [
 Django = ">=4.2"
 
 [[package]]
+name = "django-filter-stubs"
+version = "0.1.3"
+description = "PEP-484 stubs for django-filter"
+optional = false
+python-versions = "*"
+files = [
+    {file = "django-filter-stubs-0.1.3.tar.gz", hash = "sha256:8b03ef8c304024672c3ebc99b72b59fb6f9d6c1a2b3b16a5100bf11a1577bc8b"},
+    {file = "django_filter_stubs-0.1.3-py3-none-any.whl", hash = "sha256:b683e8ddb92a1e1456a53dc299963ae4a5768f8d3cc3318dbef06c4b7d943336"},
+]
+
+[package.dependencies]
+django-stubs = ">=1.3.0"
+djangorestframework-stubs = ">=0.4.0"
+mypy = ">=0.750"
+typing-extensions = ">=3.7.4"
+
+[[package]]
 name = "django-revproxy"
 version = "0.12.0"
 description = "Yet another Django reverse proxy application"
@@ -606,6 +623,63 @@ files = [
 
 [package.dependencies]
 six = "*"
+
+[[package]]
+name = "mypy"
+version = "1.10.1"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e36f229acfe250dc660790840916eb49726c928e8ce10fbdf90715090fe4ae02"},
+    {file = "mypy-1.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:51a46974340baaa4145363b9e051812a2446cf583dfaeba124af966fa44593f7"},
+    {file = "mypy-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:901c89c2d67bba57aaaca91ccdb659aa3a312de67f23b9dfb059727cce2e2e0a"},
+    {file = "mypy-1.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0cd62192a4a32b77ceb31272d9e74d23cd88c8060c34d1d3622db3267679a5d9"},
+    {file = "mypy-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:a2cbc68cb9e943ac0814c13e2452d2046c2f2b23ff0278e26599224cf164e78d"},
+    {file = "mypy-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bd6f629b67bb43dc0d9211ee98b96d8dabc97b1ad38b9b25f5e4c4d7569a0c6a"},
+    {file = "mypy-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1bbb3a6f5ff319d2b9d40b4080d46cd639abe3516d5a62c070cf0114a457d84"},
+    {file = "mypy-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8edd4e9bbbc9d7b79502eb9592cab808585516ae1bcc1446eb9122656c6066f"},
+    {file = "mypy-1.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6166a88b15f1759f94a46fa474c7b1b05d134b1b61fca627dd7335454cc9aa6b"},
+    {file = "mypy-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:5bb9cd11c01c8606a9d0b83ffa91d0b236a0e91bc4126d9ba9ce62906ada868e"},
+    {file = "mypy-1.10.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d8681909f7b44d0b7b86e653ca152d6dff0eb5eb41694e163c6092124f8246d7"},
+    {file = "mypy-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:378c03f53f10bbdd55ca94e46ec3ba255279706a6aacaecac52ad248f98205d3"},
+    {file = "mypy-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bacf8f3a3d7d849f40ca6caea5c055122efe70e81480c8328ad29c55c69e93e"},
+    {file = "mypy-1.10.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:701b5f71413f1e9855566a34d6e9d12624e9e0a8818a5704d74d6b0402e66c04"},
+    {file = "mypy-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c4c2992f6ea46ff7fce0072642cfb62af7a2484efe69017ed8b095f7b39ef31"},
+    {file = "mypy-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:604282c886497645ffb87b8f35a57ec773a4a2721161e709a4422c1636ddde5c"},
+    {file = "mypy-1.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37fd87cab83f09842653f08de066ee68f1182b9b5282e4634cdb4b407266bade"},
+    {file = "mypy-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8addf6313777dbb92e9564c5d32ec122bf2c6c39d683ea64de6a1fd98b90fe37"},
+    {file = "mypy-1.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5cc3ca0a244eb9a5249c7c583ad9a7e881aa5d7b73c35652296ddcdb33b2b9c7"},
+    {file = "mypy-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:1b3a2ffce52cc4dbaeee4df762f20a2905aa171ef157b82192f2e2f368eec05d"},
+    {file = "mypy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fe85ed6836165d52ae8b88f99527d3d1b2362e0cb90b005409b8bed90e9059b3"},
+    {file = "mypy-1.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2ae450d60d7d020d67ab440c6e3fae375809988119817214440033f26ddf7bf"},
+    {file = "mypy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6be84c06e6abd72f960ba9a71561c14137a583093ffcf9bbfaf5e613d63fa531"},
+    {file = "mypy-1.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2189ff1e39db399f08205e22a797383613ce1cb0cb3b13d8bcf0170e45b96cc3"},
+    {file = "mypy-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:97a131ee36ac37ce9581f4220311247ab6cba896b4395b9c87af0675a13a755f"},
+    {file = "mypy-1.10.1-py3-none-any.whl", hash = "sha256:71d8ac0b906354ebda8ef1673e5fde785936ac1f29ff6987c7483cfbd5a4235a"},
+    {file = "mypy-1.10.1.tar.gz", hash = "sha256:1f8f492d7db9e3593ef42d4f115f04e556130f2819ad33ab84551403e97dd4c0"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
 
 [[package]]
 name = "openpyxl"
@@ -961,4 +1035,4 @@ brotli = ["brotli"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e89cb4321105a59e2f6bb65c7adc401a43b02e7b6bdfa5b8b2e4d41d63e77d4a"
+content-hash = "eb4a1e104663267e71f437caffc3e6bb4524f4b8d5b69598ca05aa7b9369da59"

--- a/app/api/pyproject.toml
+++ b/app/api/pyproject.toml
@@ -34,6 +34,7 @@ pytest-django = "^4.8.0"
 [tool.poetry.group.dev.dependencies]
 django-stubs = "^5.0.2"
 djangorestframework-stubs = "^3.15.0"
+django-filter-stubs = "^0.1.3"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
# Changes

Adds a permissions filter to Scan Reports, tables, fields, and values views. 
These permissions are based on the existing in `permissions.py`

Related #776 

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
