### PR TITLE
Add Create New Dataset Dialog

### DIFF
--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -580,6 +580,12 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 class DatasetViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = Dataset
+        fields = "__all__"
+
+
+class DatasetViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
         fields = (
             "id",
             "name",

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -23,6 +23,7 @@ from api.serializers import (
     DatasetAndDataPartnerViewSerializer,
     DatasetEditSerializer,
     DatasetViewSerializer,
+    DatasetViewSerializerV2,
     DomainSerializer,
     DrugStrengthSerializer,
     GetRulesAnalysis,
@@ -586,7 +587,7 @@ class DatasetListView(generics.ListAPIView):
     API view to show all datasets.
     """
 
-    serializer_class = DatasetViewSerializer
+    serializer_class = DatasetViewSerializerV2
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
         "id": ["in"],
@@ -673,7 +674,7 @@ class DatasetAndDataPartnerListView(generics.ListAPIView):
 
 
 class DatasetCreateView(generics.CreateAPIView):
-    serializer_class = DatasetViewSerializer
+    serializer_class = DatasetViewSerializerV2
     queryset = Dataset.objects.all()
 
     def perform_create(self, serializer):
@@ -694,7 +695,7 @@ class DatasetRetrieveView(generics.RetrieveAPIView):
     This view should return a single dataset from an id
     """
 
-    serializer_class = DatasetViewSerializer
+    serializer_class = DatasetViewSerializerV2
     permission_classes = [CanView | CanAdmin | CanEdit]
 
     def get_queryset(self):

--- a/app/api/config/urls.py
+++ b/app/api/config/urls.py
@@ -1,23 +1,12 @@
 import os
 
 from django.contrib import admin
-from django.urls import include, path, re_path
-from revproxy.views import ProxyView
-from django.conf import settings
+from django.urls import include, path
 
 urlpatterns = [
     (
         path("", include("proxy.urls"))
         if os.environ.get("ENABLE_PROXY", "False").lower() == "true"
-        else None
-    ),
-    (
-        re_path(
-            r"^scanreports/(?P<path>create)/$",
-            ProxyView.as_view(upstream=f"{settings.NEXTJS_URL}/scanreports"),
-            name="scan-report-create",
-        )
-        if os.environ.get("ENABLE_SCAN_REPORT_CREATE", "False").lower() == "true"
         else None
     ),
     path("api/", include("api.urls")),

--- a/app/api/proxy/urls.py
+++ b/app/api/proxy/urls.py
@@ -8,6 +8,11 @@ from revproxy.views import ProxyView
 urlpatterns = [
     # /scanreports/ and escape any further paths
     re_path(
+        r"^scanreports/(?P<path>create)/$",
+        ProxyView.as_view(upstream=f"{settings.NEXTJS_URL}/scanreports"),
+        name="scan-report-create",
+    ),
+    re_path(
         r"^scanreports/(?P<path>(?!create))$",
         ProxyView.as_view(upstream=f"{settings.NEXTJS_URL}/scanreports"),
         name="scan-report-list",

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -132,6 +132,9 @@ export async function createDataset(data: {}) {
   try {
     await request(fetchKeys.createDataset, {
       method: "POST",
+      headers: {
+        "Content-type": "application/json",
+      },
       body: JSON.stringify(data),
     });
   } catch (error: any) {

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -15,7 +15,7 @@ const fetchKeys = {
     dataset ? `projects/?dataset=${dataset}` : "projects/",
   updateDataset: (id: number) => `datasets/update/${id}/`,
   permissions: (id: string) => `dataset/${id}/permissions/`,
-  createDataset: "datasets/create/",
+  create: "datasets/create/",
 };
 
 export async function getDataSets(
@@ -130,7 +130,7 @@ export async function getDatasetPermissions(
 
 export async function createDataset(data: {}) {
   try {
-    await request(fetchKeys.createDataset, {
+    await request(fetchKeys.create, {
       method: "POST",
       headers: {
         "Content-type": "application/json",

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -15,6 +15,7 @@ const fetchKeys = {
     dataset ? `projects/?dataset=${dataset}` : "projects/",
   updateDataset: (id: number) => `datasets/update/${id}/`,
   permissions: (id: string) => `dataset/${id}/permissions/`,
+  createDataset: "datasets/create/",
 };
 
 export async function getDataSets(
@@ -125,4 +126,16 @@ export async function getDatasetPermissions(
     console.warn("Failed to fetch data.");
     return { permissions: [] };
   }
+}
+
+export async function createDataset(data: {}) {
+  try {
+    await request(fetchKeys.createDataset, {
+      method: "POST",
+      body: JSON.stringify(data),
+    });
+  } catch (error: any) {
+    return { errorMessage: error.message };
+  }
+  redirect(`/datasets/`);
 }

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -137,7 +137,7 @@ export async function createDataset(data: {}) {
       },
       body: JSON.stringify(data),
     });
-    revalidatePath("/scanreports/create/");
+    revalidatePath("");
   } catch (error: any) {
     return { errorMessage: error.message };
   }

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -137,8 +137,8 @@ export async function createDataset(data: {}) {
       },
       body: JSON.stringify(data),
     });
+    revalidatePath("/scanreports/create/");
   } catch (error: any) {
     return { errorMessage: error.message };
   }
-  redirect(`/datasets/`);
 }

--- a/app/next-client-app/app/datasets/page.tsx
+++ b/app/next-client-app/app/datasets/page.tsx
@@ -7,11 +7,12 @@ import {
 } from "@/components/ui/breadcrumb";
 import { DataTable } from "@/components/data-table";
 import { columns } from "./columns";
-import { getDataSets } from "@/api/datasets";
+import { getDataPartners, getDataSets, getProjects } from "@/api/datasets";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { objToQuery } from "@/lib/client-utils";
 import { DataTableFilter } from "@/components/data-table/DataTableFilter";
 import { FilterParameters } from "@/types/filter";
+import { CreateDatasetDialog } from "@/components/datasets/CreateDatasetDialog";
 
 interface DataSetListProps {
   searchParams?: FilterParameters;
@@ -24,6 +25,8 @@ export default async function DataSets({ searchParams }: DataSetListProps) {
   };
   const combinedParams = { ...defaultParams, ...searchParams };
 
+  const projects = await getProjects();
+  const dataPartnerList = await getDataPartners();
   const query = objToQuery(combinedParams);
   const dataset = await getDataSets(query);
   const filter = <DataTableFilter filter="name" />;
@@ -46,41 +49,51 @@ export default async function DataSets({ searchParams }: DataSetListProps) {
       <div className="flex justify-between mt-3">
         <h1 className="text-4xl font-semibold">Dataset List</h1>
       </div>
-      <div className="my-5">
-        <Tabs
-          defaultValue={
-            (searchParams as any)?.hidden
-              ? (searchParams as any)?.hidden === "true"
-                ? "archived"
+      <div className="my-5 justify-between">
+        <div>
+          <Tabs
+            defaultValue={
+              (searchParams as any)?.hidden
+                ? (searchParams as any)?.hidden === "true"
+                  ? "archived"
+                  : "active"
                 : "active"
-              : "active"
-          }
-        >
-          <TabsList>
-            <a href="?hidden=false" className="h-full">
-              <TabsTrigger value="active">Active Datasets</TabsTrigger>
-            </a>
-            <a href="?hidden=true" className="h-full">
-              <TabsTrigger value="archived">Archived Datasets</TabsTrigger>
-            </a>
-          </TabsList>
-          <TabsContent value="active">
-            <DataTable
-              columns={columns}
-              data={dataset.results}
-              count={dataset.count}
-              Filter={filter}
-            />
-          </TabsContent>
-          <TabsContent value="archived">
-            <DataTable
-              columns={columns}
-              data={dataset.results}
-              count={dataset.count}
-              Filter={filter}
-            />
-          </TabsContent>
-        </Tabs>
+            }
+          >
+            <div className="flex justify-between items-center">
+              <TabsList>
+                <a href="?hidden=false" className="h-full">
+                  <TabsTrigger value="active">Active Datasets</TabsTrigger>
+                </a>
+                <a href="?hidden=true" className="h-full">
+                  <TabsTrigger value="archived">Archived Datasets</TabsTrigger>
+                </a>
+              </TabsList>
+              <div>
+                <CreateDatasetDialog
+                  projects={projects}
+                  dataPartnerList={dataPartnerList}
+                />
+              </div>
+            </div>
+            <TabsContent value="active">
+              <DataTable
+                columns={columns}
+                data={dataset.results}
+                count={dataset.count}
+                Filter={filter}
+              />
+            </TabsContent>
+            <TabsContent value="archived">
+              <DataTable
+                columns={columns}
+                data={dataset.results}
+                count={dataset.count}
+                Filter={filter}
+              />
+            </TabsContent>
+          </Tabs>
+        </div>
       </div>
     </div>
   );

--- a/app/next-client-app/app/scanreports/create/page.tsx
+++ b/app/next-client-app/app/scanreports/create/page.tsx
@@ -5,11 +5,12 @@ import {
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { getDataPartners } from "@/api/datasets";
+import { getDataPartners, getProjects } from "@/api/datasets";
 import { CreateScanReportForm } from "@/components/scanreports/CreateScanReportForm";
 
 export default async function ScanReports() {
   const partners = await getDataPartners();
+  const projects = await getProjects();
 
   return (
     <div className="pt-10 px-16">
@@ -36,7 +37,7 @@ export default async function ScanReports() {
         <h1 className="text-4xl font-semibold">New Scan Report</h1>
       </div>
       <div className="mt-4">
-        <CreateScanReportForm dataPartners={partners} />
+        <CreateScanReportForm dataPartners={partners} projects={projects} />
       </div>
     </div>
   );

--- a/app/next-client-app/components/Tooltips.tsx
+++ b/app/next-client-app/components/Tooltips.tsx
@@ -17,7 +17,7 @@ export function Tooltips({
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger>
+        <TooltipTrigger asChild>
           <InfoIcon className="ml-1 size-4 text-carrot" />
         </TooltipTrigger>
         <TooltipContent>

--- a/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
@@ -42,7 +42,7 @@ export function CreateDatasetDialog({
         {description && (
           <DialogDescription className="justify-center items-center text-center">
             {" "}
-            Notice: Data Partner is set as the choosen Data Partner in the
+            Notice: Data Partner is set as the chosen Data Partner in the
             previous form.
           </DialogDescription>
         )}

--- a/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
@@ -29,7 +29,7 @@ export function CreateDatasetDialog({
     <Dialog open={dialogOpened} onOpenChange={setDialogOpened}>
       <DialogTrigger asChild>
         <Button variant={"outline"} className="ml-4 flex">
-          Create a New Dataset <Plus className="ml-2 h-4 w-4" />
+          New Dataset <Plus className="ml-2 h-4 w-4" />
         </Button>
       </DialogTrigger>
       <DialogContent className="w-full">
@@ -37,10 +37,10 @@ export function CreateDatasetDialog({
           <DialogTitle>Create a New Dataset</DialogTitle>
         </DialogHeader>
         {description && (
-          <DialogDescription>
+          <DialogDescription className="justify-center items-center text-center">
             {" "}
-            Data Partner is set as the choosen Data Partner in the previous
-            form.
+            Notice: Data Partner is set as the choosen Data Partner in the
+            previous form.
           </DialogDescription>
         )}
         <CreateDatasetForm

--- a/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "../ui/button";
+import { Plus } from "lucide-react";
+import { CreateDatasetForm } from "./CreateDatasetForm";
+import { DialogDescription } from "@radix-ui/react-dialog";
+import { useState } from "react";
+
+export function CreateDatasetDialog({
+  dataPartnerID,
+  projects,
+  dataPartnerList,
+  description,
+}: {
+  dataPartnerID?: number;
+  projects: Project[];
+  dataPartnerList?: DataPartner[];
+  description?: boolean;
+}) {
+  const [dialogOpened, setDialogOpened] = useState(false);
+  return (
+    <Dialog open={dialogOpened} onOpenChange={setDialogOpened}>
+      <DialogTrigger asChild>
+        <Button variant={"outline"} className="ml-4 flex">
+          Create a New Dataset <Plus className="ml-2 h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="w-full">
+        <DialogHeader>
+          <DialogTitle>Create a New Dataset</DialogTitle>
+        </DialogHeader>
+        {description && (
+          <DialogDescription>
+            {" "}
+            Data Partner is set as the choosen Data Partner in the previous
+            form.
+          </DialogDescription>
+        )}
+        <CreateDatasetForm
+          projectList={projects}
+          dataPartnerID={dataPartnerID}
+          dataPartnerList={dataPartnerList}
+          setDialogOpened={setDialogOpened}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
@@ -18,13 +18,16 @@ export function CreateDatasetDialog({
   projects,
   dataPartnerList,
   description,
+  setReloadDataset,
 }: {
   dataPartnerID?: number;
   projects: Project[];
   dataPartnerList?: DataPartner[];
   description?: boolean;
+  setReloadDataset: (reloadDataset: boolean) => void;
 }) {
   const [dialogOpened, setDialogOpened] = useState(false);
+
   return (
     <Dialog open={dialogOpened} onOpenChange={setDialogOpened}>
       <DialogTrigger asChild>
@@ -48,6 +51,7 @@ export function CreateDatasetDialog({
           dataPartnerID={dataPartnerID}
           dataPartnerList={dataPartnerList}
           setDialogOpened={setDialogOpened}
+          setReloadDataset={setReloadDataset}
         />
       </DialogContent>
     </Dialog>

--- a/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
@@ -24,7 +24,7 @@ export function CreateDatasetDialog({
   projects: Project[];
   dataPartnerList?: DataPartner[];
   description?: boolean;
-  setReloadDataset: (reloadDataset: boolean) => void;
+  setReloadDataset?: (reloadDataset: boolean) => void;
 }) {
   const [dialogOpened, setDialogOpened] = useState(false);
 

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -58,6 +58,7 @@ export function CreateDatasetForm({
       toast.success("New Dataset created!");
       setError(null);
       setDialogOpened(false);
+      window.location.reload();
     }
   };
 

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -59,10 +59,15 @@ export function CreateDatasetForm({
     } else {
       toast.success("New Dataset created!");
       setError(null);
+      setDialogOpened(false);
+      // When a new dataset created, close the dialog then reload the dataset options
       if (setReloadDataset) {
         setReloadDataset(true);
+        // After 1s, set reloadDataset to false again, in order to add again the other datasets, if needed
+        setTimeout(() => {
+          setReloadDataset(false);
+        }, 1000);
       }
-      setDialogOpened(false);
     }
   };
 

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -78,7 +78,7 @@ export function CreateDatasetForm({
           <div>
             <AlertTitle className="flex items-center">
               <AlertCircle className="h-4 w-4 mr-2" />
-              Upload New Scan Report Failed. Error:
+              Add New Dataset Failed. Error:
             </AlertTitle>
             <AlertDescription>
               <ul>

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { AlertCircle, FileUp, Plus } from "lucide-react";
+import { AlertCircle, Plus } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Form, Formik } from "formik";
@@ -10,7 +10,6 @@ import { toast } from "sonner";
 import { FormDataFilter } from "../form-components/FormikUtils";
 import { Tooltips } from "../Tooltips";
 import { FormikSelect } from "../form-components/FormikSelect";
-import { FormikSelectDataset } from "../form-components/FormikSelectDataset";
 import { FormikSelectEditors } from "../form-components/FormikSelectEditors";
 import { createScanReport } from "@/api/scanreports";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -22,7 +21,7 @@ interface FormData {
   editors: number[];
   admins: number[];
   dataPartner: number;
-  project: number;
+  projects: number;
 }
 
 export function CreateDatasetForm({
@@ -83,7 +82,7 @@ export function CreateDatasetForm({
           admins: [],
           visibility: "PUBLIC",
           name: "",
-          project: 0,
+          projects: 0,
         }}
         onSubmit={(data) => {
           toast.info("Creating Dataset ...");
@@ -135,7 +134,7 @@ export function CreateDatasetForm({
                 </h3>
                 <FormikSelect
                   options={projectOptions}
-                  name="project"
+                  name="projects"
                   placeholder="Select Project"
                   isMulti={true}
                   isDisabled={false}
@@ -155,7 +154,7 @@ export function CreateDatasetForm({
                   name="editors"
                   placeholder="Choose Editors"
                   isMulti={true}
-                  isDisabled={values.project === 0}
+                  isDisabled={values.projects === 0}
                 />
               </div>
               <div className="flex flex-col gap-2">
@@ -171,7 +170,7 @@ export function CreateDatasetForm({
                   name="admins"
                   placeholder="Choose Admins"
                   isMulti={true}
-                  isDisabled={values.project === 0}
+                  isDisabled={values.projects === 0}
                 />
               </div>
               <div className="flex items-center space-x-3">
@@ -204,7 +203,7 @@ export function CreateDatasetForm({
                   disabled={
                     values.dataPartner === 0 ||
                     values.name === "" ||
-                    values.project === 0
+                    values.projects === 0
                   }
                 >
                   Add Dataset

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -35,7 +35,7 @@ export function CreateDatasetForm({
   dataPartnerList?: DataPartner[];
   projectList: Project[];
   setDialogOpened: (dialogOpened: boolean) => void;
-  setReloadDataset: (reloadDataset: boolean) => void;
+  setReloadDataset?: (reloadDataset: boolean) => void;
 }) {
   const partnerOptions = FormDataFilter<DataPartner>(dataPartnerList || []);
   const projectOptions = FormDataFilter<Project>(projectList || []);
@@ -59,8 +59,10 @@ export function CreateDatasetForm({
     } else {
       toast.success("New Dataset created!");
       setError(null);
+      if (setReloadDataset) {
+        setReloadDataset(true);
+      }
       setDialogOpened(false);
-      setReloadDataset(true);
     }
   };
 

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { AlertCircle, FileUp, Plus } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Form, Formik } from "formik";
+import { toast } from "sonner";
+import { FormDataFilter } from "../form-components/FormikUtils";
+import { Tooltips } from "../Tooltips";
+import { FormikSelect } from "../form-components/FormikSelect";
+import { FormikSelectDataset } from "../form-components/FormikSelectDataset";
+import { FormikSelectEditors } from "../form-components/FormikSelectEditors";
+import { createScanReport } from "@/api/scanreports";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useState } from "react";
+
+interface FormData {
+  name: string;
+  visibility: string;
+  editors: number[];
+  admins: number[];
+  dataPartner: number;
+  project: number;
+}
+
+export function CreateDatasetForm({
+  dataPartnerID,
+  dataPartnerList,
+  projectList,
+}: {
+  dataPartnerID?: number;
+  dataPartnerList?: DataPartner[];
+  projectList: Project[];
+}) {
+  const partnerOptions = FormDataFilter<DataPartner>(dataPartnerList || []);
+  const projectOptions = FormDataFilter<Project>(projectList || []);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (data: FormData) => {
+    const formData = new FormData();
+    formData.append("dataset", data.name);
+    formData.append("visibility", data.visibility);
+    data.editors.forEach((editor) => {
+      formData.append("editors", editor.toString());
+    });
+
+    const response = await createScanReport(formData);
+
+    if (response) {
+      setError(response.errorMessage);
+      toast.error("Add New Dataset failed. Fix the error(s) first");
+    } else {
+      toast.success("New Dataset created!");
+      setError(null);
+    }
+  };
+
+  return (
+    <>
+      {error && (
+        <Alert variant="destructive" className="mb-3">
+          <div>
+            <AlertTitle className="flex items-center">
+              <AlertCircle className="h-4 w-4 mr-2" />
+              Upload New Scan Report Failed. Error:
+            </AlertTitle>
+            <AlertDescription>
+              <ul>
+                {error.split(" * ").map((err, index) => (
+                  <li key={index}>* {err}</li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </div>
+        </Alert>
+      )}
+      <Formik
+        initialValues={{
+          dataPartner: dataPartnerID ? dataPartnerID : 0,
+          editors: [],
+          admins: [],
+          visibility: "PUBLIC",
+          name: "",
+          project: 0,
+        }}
+        onSubmit={(data) => {
+          toast.info("Creating Dataset ...");
+          handleSubmit(data);
+        }}
+      >
+        {({ values, handleChange, handleSubmit, setFieldValue }) => (
+          <Form className="w-full" onSubmit={handleSubmit}>
+            <div className="flex flex-col gap-3 text-lg">
+              {!dataPartnerID && (
+                <>
+                  <div className="flex flex-col gap-2">
+                    <h3 className="flex">
+                      Data Partner{" "}
+                      <Tooltips
+                        content="The Data Partner that owns the Dataset of the new Scan Report."
+                        link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
+                      />
+                    </h3>
+                    <FormikSelect
+                      options={partnerOptions}
+                      name="dataPartner"
+                      placeholder="Choose a Data Partner"
+                      isMulti={false}
+                      isDisabled={false}
+                      required={true}
+                    />
+                  </div>
+                </>
+              )}
+              <div className="flex flex-col gap-2">
+                <h3 className="flex">
+                  {" "}
+                  Dataset Name
+                  <Tooltips content="Name of the new Dataset" />
+                </h3>
+                <Input
+                  onChange={handleChange}
+                  name="name"
+                  className="text-lg text-carrot"
+                  required
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <h3 className="flex items-center">
+                  {" "}
+                  Project
+                  <Tooltips content="" link="" />
+                </h3>
+                <FormikSelect
+                  options={projectOptions}
+                  name="project"
+                  placeholder="Select Project"
+                  isMulti={true}
+                  isDisabled={false}
+                  required={true}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <h3 className="flex">
+                  {" "}
+                  Editors
+                  <Tooltips
+                    content="Dataset admins and editors also have Scan Report editor permissions."
+                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#scan-report-roles"
+                  />
+                </h3>
+                <FormikSelectEditors
+                  name="editors"
+                  placeholder="Choose Editors"
+                  isMulti={true}
+                  isDisabled={values.project === 0}
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <h3 className="flex">
+                  {" "}
+                  Admins
+                  <Tooltips
+                    content="Dataset admins and editors also have Scan Report editor permissions."
+                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#scan-report-roles"
+                  />
+                </h3>
+                <FormikSelectEditors
+                  name="admins"
+                  placeholder="Choose Admins"
+                  isMulti={true}
+                  isDisabled={values.project === 0}
+                />
+              </div>
+              <div className="flex items-center space-x-3">
+                <h3 className="flex">
+                  Visibility
+                  <Tooltips
+                    content="Setting the visibility of the new Scan Report"
+                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
+                  />
+                </h3>
+                <Switch
+                  onCheckedChange={(checked) =>
+                    handleChange({
+                      target: {
+                        name: "visibility",
+                        value: checked ? "PUBLIC" : "RESTRICTED",
+                      },
+                    })
+                  }
+                  defaultChecked
+                />
+                <Label className="text-lg">
+                  {values.visibility === "PUBLIC" ? "PUBLIC" : "RESTRICTED"}
+                </Label>
+              </div>
+              <div className="mb-5">
+                <Button
+                  type="submit"
+                  className="px-4 py-2 bg-carrot text-white rounded text-lg"
+                  disabled={
+                    values.dataPartner === 0 ||
+                    values.name === "" ||
+                    values.project === 0
+                  }
+                >
+                  Add Dataset
+                  <Plus className="ml-2" />
+                </Button>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </>
+  );
+}

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -92,7 +92,7 @@ export function CreateDatasetForm({
           handleSubmit(data);
         }}
       >
-        {({ values, handleChange, handleSubmit, setFieldValue }) => (
+        {({ values, handleChange, handleSubmit }) => (
           <Form className="w-full" onSubmit={handleSubmit}>
             <div className="flex flex-col gap-3 text-lg">
               {!dataPartnerID && (

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { AlertCircle, Plus } from "lucide-react";
+import { AlertCircle, SquarePlus } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Form, Formik } from "formik";
@@ -10,10 +10,11 @@ import { toast } from "sonner";
 import { FormDataFilter } from "../form-components/FormikUtils";
 import { Tooltips } from "../Tooltips";
 import { FormikSelect } from "../form-components/FormikSelect";
-import { FormikSelectEditors } from "../form-components/FormikSelectEditors";
 import { createScanReport } from "@/api/scanreports";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useState } from "react";
+import { FormikSelectUsers } from "../form-components/FormikSelectUsers";
+import { createDataset } from "@/api/datasets";
 
 interface FormData {
   name: string;
@@ -38,14 +39,16 @@ export function CreateDatasetForm({
   const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async (data: FormData) => {
-    const formData = new FormData();
-    formData.append("dataset", data.name);
-    formData.append("visibility", data.visibility);
-    data.editors.forEach((editor) => {
-      formData.append("editors", editor.toString());
-    });
+    const submittingData = {
+      name: data.name,
+      visibility: data.visibility,
+      data_partner: data.dataPartner,
+      admins: data.admins || [],
+      editors: data.editors || [],
+      projects: data.projects || [],
+    };
 
-    const response = await createScanReport(formData);
+    const response = await createDataset(submittingData);
 
     if (response) {
       setError(response.errorMessage);
@@ -150,7 +153,7 @@ export function CreateDatasetForm({
                     link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#scan-report-roles"
                   />
                 </h3>
-                <FormikSelectEditors
+                <FormikSelectUsers
                   name="editors"
                   placeholder="Choose Editors"
                   isMulti={true}
@@ -166,7 +169,7 @@ export function CreateDatasetForm({
                     link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#scan-report-roles"
                   />
                 </h3>
-                <FormikSelectEditors
+                <FormikSelectUsers
                   name="admins"
                   placeholder="Choose Admins"
                   isMulti={true}
@@ -177,7 +180,7 @@ export function CreateDatasetForm({
                 <h3 className="flex">
                   Visibility
                   <Tooltips
-                    content="Setting the visibility of the new Scan Report"
+                    content="Setting the visibility of the new Dataset."
                     link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
                   />
                 </h3>
@@ -206,8 +209,8 @@ export function CreateDatasetForm({
                     values.projects === 0
                   }
                 >
-                  Add Dataset
-                  <Plus className="ml-2" />
+                  Create Dataset
+                  <SquarePlus className="ml-2" />
                 </Button>
               </div>
             </div>

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -10,7 +10,6 @@ import { toast } from "sonner";
 import { FormDataFilter } from "../form-components/FormikUtils";
 import { Tooltips } from "../Tooltips";
 import { FormikSelect } from "../form-components/FormikSelect";
-import { createScanReport } from "@/api/scanreports";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useState } from "react";
 import { FormikSelectUsers } from "../form-components/FormikSelectUsers";
@@ -29,10 +28,12 @@ export function CreateDatasetForm({
   dataPartnerID,
   dataPartnerList,
   projectList,
+  setDialogOpened,
 }: {
   dataPartnerID?: number;
   dataPartnerList?: DataPartner[];
   projectList: Project[];
+  setDialogOpened: (dialogOpened: boolean) => void;
 }) {
   const partnerOptions = FormDataFilter<DataPartner>(dataPartnerList || []);
   const projectOptions = FormDataFilter<Project>(projectList || []);
@@ -56,6 +57,7 @@ export function CreateDatasetForm({
     } else {
       toast.success("New Dataset created!");
       setError(null);
+      setDialogOpened(false);
     }
   };
 

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -29,11 +29,13 @@ export function CreateDatasetForm({
   dataPartnerList,
   projectList,
   setDialogOpened,
+  setReloadDataset,
 }: {
   dataPartnerID?: number;
   dataPartnerList?: DataPartner[];
   projectList: Project[];
   setDialogOpened: (dialogOpened: boolean) => void;
+  setReloadDataset: (reloadDataset: boolean) => void;
 }) {
   const partnerOptions = FormDataFilter<DataPartner>(dataPartnerList || []);
   const projectOptions = FormDataFilter<Project>(projectList || []);
@@ -58,7 +60,7 @@ export function CreateDatasetForm({
       toast.success("New Dataset created!");
       setError(null);
       setDialogOpened(false);
-      window.location.reload();
+      setReloadDataset(true);
     }
   };
 

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -137,13 +137,16 @@ export function CreateDatasetForm({
               <div className="flex flex-col gap-2">
                 <h3 className="flex items-center">
                   {" "}
-                  Project
-                  <Tooltips content="" link="" />
+                  Projects
+                  <Tooltips
+                    content="A Project is the highest-level object. A single Dataset may live in more than one Project."
+                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/"
+                  />
                 </h3>
                 <FormikSelect
                   options={projectOptions}
                   name="projects"
-                  placeholder="Select Project"
+                  placeholder="Select Projects"
                   isMulti={true}
                   isDisabled={false}
                   required={true}
@@ -155,7 +158,7 @@ export function CreateDatasetForm({
                   Editors
                   <Tooltips
                     content="Dataset admins and editors also have Scan Report editor permissions."
-                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#scan-report-roles"
+                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
                   />
                 </h3>
                 <FormikSelectUsers
@@ -171,7 +174,7 @@ export function CreateDatasetForm({
                   Admins
                   <Tooltips
                     content="Dataset admins and editors also have Scan Report editor permissions."
-                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#scan-report-roles"
+                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
                   />
                 </h3>
                 <FormikSelectUsers

--- a/app/next-client-app/components/form-components/FormikSelectDataset.tsx
+++ b/app/next-client-app/components/form-components/FormikSelectDataset.tsx
@@ -128,12 +128,14 @@ export const FormikSelectDataset = ({
   isMulti,
   isDisabled,
   required,
+  reloadDataset,
 }: {
   name: string;
   placeholder: string;
   isMulti: boolean;
   isDisabled: boolean;
   required?: boolean;
+  reloadDataset?: boolean;
 }) => {
   const {
     values: { dataPartner },
@@ -143,13 +145,13 @@ export const FormikSelectDataset = ({
 
   useEffect(() => {
     const fetchData = async () => {
-      if (dataPartner !== 0) {
+      if (dataPartner !== 0 || reloadDataset) {
         const dataset = await fetchDataset(dataPartner.toString());
         setOptions(dataset);
       }
     };
     fetchData();
-  }, [dataPartner]);
+  }, [dataPartner, reloadDataset]);
 
   return (
     <Field name={name}>

--- a/app/next-client-app/components/form-components/FormikSelectUsers.tsx
+++ b/app/next-client-app/components/form-components/FormikSelectUsers.tsx
@@ -20,11 +20,13 @@ type Option = Object & {
 };
 
 async function fetchProjectMembers(selectedProjects: number[]) {
-  const projects = await getProjects();
-  // const filterProjects = projects.filter((project) => project.id === selectedProjects)
+  const allProjects = await getProjects();
+  const filterProjects = allProjects.filter((project) =>
+    selectedProjects.includes(project.id)
+  );
   const users = await getDataUsers();
   const membersIds = new Set<number>();
-  projects.forEach((project) => {
+  filterProjects.forEach((project) => {
     project.members.forEach((memberId) => {
       membersIds.add(memberId);
     });

--- a/app/next-client-app/components/form-components/FormikSelectUsers.tsx
+++ b/app/next-client-app/components/form-components/FormikSelectUsers.tsx
@@ -19,8 +19,9 @@ type Option = Object & {
   label: string | undefined;
 };
 
-async function fetchProjectMembers() {
+async function fetchProjectMembers(selectedProjects: number[]) {
   const projects = await getProjects();
+  // const filterProjects = projects.filter((project) => project.id === selectedProjects)
   const users = await getDataUsers();
   const membersIds = new Set<number>();
   projects.forEach((project) => {
@@ -112,20 +113,20 @@ export const FormikSelectUsers = ({
   isDisabled: boolean;
 }) => {
   const {
-    values: { project },
+    values: { projects },
   } = useFormikContext<FormikValues>();
 
   const [editors, setOptions] = useState<Option[]>([]);
 
   useEffect(() => {
     const fetchData = async () => {
-      if (project !== 0) {
-        const editors = await fetchProjectMembers();
+      if (projects !== 0) {
+        const editors = await fetchProjectMembers(projects);
         setOptions(editors);
       }
     };
     fetchData();
-  }, [project]);
+  }, [projects]);
 
   return (
     <Field name={name}>

--- a/app/next-client-app/components/form-components/FormikSelectUsers.tsx
+++ b/app/next-client-app/components/form-components/FormikSelectUsers.tsx
@@ -1,0 +1,144 @@
+import {
+  Field,
+  FieldInputProps,
+  FieldProps,
+  FormikProps,
+  FormikValues,
+  useField,
+  useFormikContext,
+} from "formik";
+import Select from "react-select";
+import makeAnimated from "react-select/animated";
+import config from "@/tailwind.config";
+import { getDataUsers, getProjects } from "@/api/datasets";
+import { useEffect, useState } from "react";
+import { FindAndFormat } from "./FormikUtils";
+
+type Option = Object & {
+  value: number;
+  label: string | undefined;
+};
+
+async function fetchProjectMembers() {
+  const projects = await getProjects();
+  const users = await getDataUsers();
+  const membersIds = new Set<number>();
+  projects.forEach((project) => {
+    project.members.forEach((memberId) => {
+      membersIds.add(memberId);
+    });
+  });
+  const membersArray = Array.from(membersIds);
+  return FindAndFormat(users, membersArray);
+}
+
+const CustomSelect = ({
+  field,
+  form,
+  isMulti = false,
+  options,
+  placeholder,
+  isDisabled,
+}: {
+  options?: Option[];
+  placeholder: string;
+  isMulti: boolean;
+  field: FieldInputProps<any>;
+  form: FormikProps<any>;
+  isDisabled: boolean;
+}) => {
+  const animatedComponents = makeAnimated();
+  const onChange = (newValue: any, actionMeta: any) => {
+    const selectedValues = isMulti
+      ? (newValue as Option[]).map((option) => option.value)
+      : (newValue as Option).value;
+
+    form.setFieldValue(field.name, selectedValues);
+  };
+
+  const selected = () => {
+    return options
+      ? options.filter((option: Option) =>
+          Array.isArray(field.value)
+            ? field.value.includes(option.value)
+            : field.value === option.value
+        )
+      : [];
+  };
+
+  return (
+    <Select
+      name={field.name}
+      value={selected()}
+      onChange={onChange}
+      placeholder={placeholder}
+      options={options}
+      isMulti={isMulti}
+      className="w-full"
+      isDisabled={isDisabled}
+      components={animatedComponents}
+      styles={{
+        multiValueLabel: (base) => ({
+          ...base,
+          fontSize: "17px",
+          backgroundColor: `${config.theme.extend.colors.carrot.DEFAULT}`, // Can't import directly "carrot" color here
+          color: "white",
+        }),
+        multiValueRemove: (base) => ({
+          ...base,
+          backgroundColor: `${config.theme.extend.colors.carrot.DEFAULT}`,
+          color: "white",
+          fontSize: "17px",
+        }),
+        singleValue: (base) => ({
+          ...base,
+          fontSize: "17px",
+          color: `${config.theme.extend.colors.carrot.DEFAULT}`,
+        }),
+      }}
+    />
+  );
+};
+
+export const FormikSelectUsers = ({
+  name,
+  placeholder,
+  isMulti,
+  isDisabled,
+}: {
+  name: string;
+  placeholder: string;
+  isMulti: boolean;
+  isDisabled: boolean;
+}) => {
+  const {
+    values: { project },
+  } = useFormikContext<FormikValues>();
+
+  const [editors, setOptions] = useState<Option[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (project !== 0) {
+        const editors = await fetchProjectMembers();
+        setOptions(editors);
+      }
+    };
+    fetchData();
+  }, [project]);
+
+  return (
+    <Field name={name}>
+      {({ field, form }: FieldProps<any>) => (
+        <CustomSelect
+          field={field}
+          form={form}
+          isMulti={isMulti}
+          options={editors}
+          placeholder={placeholder}
+          isDisabled={isDisabled}
+        />
+      )}
+    </Field>
+  );
+};

--- a/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
+++ b/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
@@ -35,6 +35,7 @@ export function CreateScanReportForm({
 }) {
   const [error, setError] = useState<string | null>(null);
   const partnerOptions = FormDataFilter<DataPartner>(dataPartners);
+  const [reloadDataset, setReloadDataset] = useState(false);
 
   const handleSubmit = async (data: FormData) => {
     const formData = new FormData();
@@ -129,6 +130,7 @@ export function CreateScanReportForm({
                       projects={projects}
                       dataPartnerID={values.dataPartner}
                       description={true}
+                      setReloadDataset={setReloadDataset}
                     />
                   )}
                 </h3>
@@ -138,6 +140,7 @@ export function CreateScanReportForm({
                   isMulti={false}
                   isDisabled={values.dataPartner === 0}
                   required={true}
+                  reloadDataset={reloadDataset}
                 />
               </div>
               <div className="flex flex-col gap-2">

--- a/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
+++ b/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
@@ -136,11 +136,11 @@ export function CreateScanReportForm({
                   {values.dataPartner !== 0 && (
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button className="ml-4 flex">
+                        <Button className="ml-4 text-lg flex">
                           Create a New Dataset <Plus className="ml-2 h-4 w-4" />
                         </Button>
                       </DialogTrigger>
-                      <DialogContent className="w-full h-[800px]">
+                      <DialogContent className="w-full">
                         <DialogHeader>
                           <DialogTitle>Create a New Dataset</DialogTitle>
                         </DialogHeader>
@@ -180,7 +180,7 @@ export function CreateScanReportForm({
                 <h3 className="flex">
                   {" "}
                   Scan Report Name
-                  <Tooltips content="Name of the new Scan Report" />
+                  <Tooltips content="Name of the new Scan Report." />
                 </h3>
                 <Input
                   onChange={handleChange}
@@ -193,7 +193,7 @@ export function CreateScanReportForm({
                 <h3 className="flex">
                   Visibility
                   <Tooltips
-                    content="Setting the visibility of the new Scan Report"
+                    content="Setting the visibility of the new Scan Report."
                     link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
                   />
                 </h3>

--- a/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
+++ b/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
@@ -15,16 +15,7 @@ import { FormikSelectEditors } from "../form-components/FormikSelectEditors";
 import { createScanReport } from "@/api/scanreports";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useState } from "react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { CreateDatasetForm } from "../datasets/CreateDatasetForm";
+import { CreateDatasetDialog } from "../datasets/CreateDatasetDialog";
 
 interface FormData {
   name: string;
@@ -134,22 +125,11 @@ export function CreateScanReportForm({
                     link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
                   />
                   {values.dataPartner !== 0 && (
-                    <Dialog>
-                      <DialogTrigger asChild>
-                        <Button className="ml-4 flex">
-                          Create a New Dataset <Plus className="ml-2 h-4 w-4" />
-                        </Button>
-                      </DialogTrigger>
-                      <DialogContent className="w-full">
-                        <DialogHeader>
-                          <DialogTitle>Create a New Dataset</DialogTitle>
-                        </DialogHeader>
-                        <CreateDatasetForm
-                          projectList={projects}
-                          dataPartnerID={values.dataPartner}
-                        />
-                      </DialogContent>
-                    </Dialog>
+                    <CreateDatasetDialog
+                      projects={projects}
+                      dataPartnerID={values.dataPartner}
+                      description={true}
+                    />
                   )}
                 </h3>
                 <FormikSelectDataset

--- a/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
+++ b/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
@@ -136,7 +136,7 @@ export function CreateScanReportForm({
                   {values.dataPartner !== 0 && (
                     <Dialog>
                       <DialogTrigger asChild>
-                        <Button className="ml-4 text-lg flex">
+                        <Button className="ml-4 flex">
                           Create a New Dataset <Plus className="ml-2 h-4 w-4" />
                         </Button>
                       </DialogTrigger>

--- a/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
+++ b/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
@@ -2,7 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { AlertCircle, FileUp } from "lucide-react";
+import { AlertCircle, FileUp, Plus } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Form, Formik } from "formik";
@@ -15,6 +15,16 @@ import { FormikSelectEditors } from "../form-components/FormikSelectEditors";
 import { createScanReport } from "@/api/scanreports";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { CreateDatasetForm } from "../datasets/CreateDatasetForm";
 
 interface FormData {
   name: string;
@@ -27,8 +37,10 @@ interface FormData {
 
 export function CreateScanReportForm({
   dataPartners,
+  projects,
 }: {
   dataPartners: DataPartner[];
+  projects: Project[];
 }) {
   const [error, setError] = useState<string | null>(null);
   const partnerOptions = FormDataFilter<DataPartner>(dataPartners);
@@ -114,13 +126,31 @@ export function CreateScanReportForm({
                 />
               </div>
               <div className="flex flex-col gap-2">
-                <h3 className="flex">
+                <h3 className="flex items-center">
                   {" "}
                   Dataset
                   <Tooltips
                     content="The Dataset to add the new Scan Report to."
                     link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
                   />
+                  {values.dataPartner !== 0 && (
+                    <Dialog>
+                      <DialogTrigger asChild>
+                        <Button className="ml-4 flex">
+                          Create a New Dataset <Plus className="ml-2 h-4 w-4" />
+                        </Button>
+                      </DialogTrigger>
+                      <DialogContent className="w-full h-[800px]">
+                        <DialogHeader>
+                          <DialogTitle>Create a New Dataset</DialogTitle>
+                        </DialogHeader>
+                        <CreateDatasetForm
+                          projectList={projects}
+                          dataPartnerID={values.dataPartner}
+                        />
+                      </DialogContent>
+                    </Dialog>
+                  )}
                 </h3>
                 <FormikSelectDataset
                   name="dataset"

--- a/app/next-client-app/components/ui/dialog.tsx
+++ b/app/next-client-app/components/ui/dialog.tsx
@@ -22,7 +22,7 @@ const DialogOverlay = React.forwardRef<
     ref={ref}
     className={cn(
       "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className,
+      className
     )}
     {...props}
   />
@@ -38,8 +38,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-slate-800 dark:bg-slate-950",
-        className,
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-2xl translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-slate-800 dark:bg-slate-950",
+        className
       )}
       {...props}
     >
@@ -60,7 +60,7 @@ const DialogHeader = ({
   <div
     className={cn(
       "flex flex-col space-y-1.5 text-center sm:text-left",
-      className,
+      className
     )}
     {...props}
   />
@@ -74,7 +74,7 @@ const DialogFooter = ({
   <div
     className={cn(
       "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className,
+      className
     )}
     {...props}
   />
@@ -89,7 +89,7 @@ const DialogTitle = React.forwardRef<
     ref={ref}
     className={cn(
       "text-xl font-semibold leading-none tracking-tight",
-      className,
+      className
     )}
     {...props}
   />


### PR DESCRIPTION
# Changes

This PR added the ShadCN dialog to create a new dataset on the Create Scan Report and Dataset List pages.

Closes #774 
Closes #651 

# Screenshots
- On the New Scan report page
![Screenshot 2024-07-04 at 09 29 53](https://github.com/Health-Informatics-UoN/Carrot-Mapper/assets/119530400/983421c1-c478-4e96-877a-301e5cc558ef)

- On the Dataset list page
![Screenshot 2024-07-04 at 09 30 08](https://github.com/Health-Informatics-UoN/Carrot-Mapper/assets/119530400/e30c7d68-c4f5-4eec-8b12-a0380bfb711b)


# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
