### PR TITLE
Add missing "viewers" field for dataset details and new dataset forms 

### DIFF
--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -18,6 +18,7 @@ import { createDataset } from "@/api/datasets";
 interface FormData {
   name: string;
   visibility: string;
+  viewers: number[];
   editors: number[];
   admins: number[];
   dataPartner: number;
@@ -37,6 +38,8 @@ export function CreateDatasetForm({
   setDialogOpened: (dialogOpened: boolean) => void;
   setReloadDataset?: (reloadDataset: boolean) => void;
 }) {
+  const [publicVisibility, setPublicVisibility] = useState<boolean>(true);
+
   const partnerOptions = FormDataFilter<DataPartner>(dataPartnerList || []);
   const projectOptions = FormDataFilter<Project>(projectList || []);
   const [error, setError] = useState<string | null>(null);
@@ -46,6 +49,7 @@ export function CreateDatasetForm({
       name: data.name,
       visibility: data.visibility,
       data_partner: data.dataPartner,
+      viewers: data.viewers || [],
       admins: data.admins || [],
       editors: data.editors || [],
       projects: data.projects || [],
@@ -93,6 +97,7 @@ export function CreateDatasetForm({
       <Formik
         initialValues={{
           dataPartner: dataPartnerID ? dataPartnerID : 0,
+          viewers: [],
           editors: [],
           admins: [],
           visibility: "PUBLIC",
@@ -132,7 +137,7 @@ export function CreateDatasetForm({
                 <h3 className="flex">
                   {" "}
                   Dataset Name
-                  <Tooltips content="Name of the new Dataset" />
+                  <Tooltips content="Name of the new Dataset." />
                 </h3>
                 <Input
                   onChange={handleChange}
@@ -159,6 +164,48 @@ export function CreateDatasetForm({
                   required={true}
                 />
               </div>
+              <div className="flex items-center space-x-3">
+                <h3 className="flex">
+                  Visibility
+                  <Tooltips
+                    content="If a Dataset is PUBLIC, then all users with access to any project associated to the Dataset will have Dataset viewer permissions."
+                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
+                  />
+                </h3>
+                <Switch
+                  onCheckedChange={(checked) => {
+                    handleChange({
+                      target: {
+                        name: "visibility",
+                        value: checked ? "PUBLIC" : "RESTRICTED",
+                      },
+                    });
+                    setPublicVisibility(checked);
+                  }}
+                  defaultChecked
+                />
+                <Label className="text-lg">
+                  {values.visibility === "PUBLIC" ? "PUBLIC" : "RESTRICTED"}
+                </Label>
+              </div>
+              {!publicVisibility && (
+                <div className="flex flex-col gap-2">
+                  <h3 className="flex">
+                    {" "}
+                    Viewers
+                    <Tooltips
+                      content="All Dataset admins and editors also have Dataset viewer permissions."
+                      link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
+                    />
+                  </h3>
+                  <FormikSelectUsers
+                    name="viewers"
+                    placeholder="Choose Viewers"
+                    isMulti={true}
+                    isDisabled={values.projects === 0}
+                  />
+                </div>
+              )}
               <div className="flex flex-col gap-2">
                 <h3 className="flex">
                   {" "}
@@ -190,29 +237,6 @@ export function CreateDatasetForm({
                   isMulti={true}
                   isDisabled={values.projects === 0}
                 />
-              </div>
-              <div className="flex items-center space-x-3">
-                <h3 className="flex">
-                  Visibility
-                  <Tooltips
-                    content="Setting the visibility of the new Dataset."
-                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
-                  />
-                </h3>
-                <Switch
-                  onCheckedChange={(checked) =>
-                    handleChange({
-                      target: {
-                        name: "visibility",
-                        value: checked ? "PUBLIC" : "RESTRICTED",
-                      },
-                    })
-                  }
-                  defaultChecked
-                />
-                <Label className="text-lg">
-                  {values.visibility === "PUBLIC" ? "PUBLIC" : "RESTRICTED"}
-                </Label>
               </div>
               <div className="mb-5">
                 <Button

--- a/app/next-client-app/components/datasets/DatasetForm.tsx
+++ b/app/next-client-app/components/datasets/DatasetForm.tsx
@@ -151,7 +151,7 @@ export function DatasetForm({
                 <h3 className="flex">
                   {" "}
                   Viewers
-                  <Tooltips content="All Dataset admins and editors also have Dataset viewer permissions. If a Dataset is PUBLIC, then all users with access to any project associated to the Dataset will have Dataset viewer permissions." />
+                  <Tooltips content="All Dataset admins and editors also have Dataset viewer permissions." />
                 </h3>
                 <FormikSelect
                   options={userOptions}

--- a/app/next-client-app/components/datasets/DatasetForm.tsx
+++ b/app/next-client-app/components/datasets/DatasetForm.tsx
@@ -11,11 +11,13 @@ import { toast } from "sonner";
 import { FindAndFormat, FormDataFilter } from "../form-components/FormikUtils";
 import { Tooltips } from "../Tooltips";
 import { FormikSelect } from "../form-components/FormikSelect";
+import { useState } from "react";
 
 interface FormData {
   name: string;
   visibility: string;
   dataPartner: number;
+  viewers: number[];
   editors: number[];
   admins: number[];
   projects: number[];
@@ -34,17 +36,24 @@ export function DatasetForm({
   projects: Project[];
   permissions: Permission[];
 }) {
+  // Permissions
   const canUpdate = permissions.includes("CanAdmin");
+  // State control for viewers fields
+  const [publicVisibility, setPublicVisibility] = useState<boolean>(
+    dataset.visibility === "PUBLIC" ? true : false
+  );
+
   // Making options suitable for React Select
   const userOptions = FormDataFilter<User>(users);
   const partnerOptions = FormDataFilter<DataPartner>(dataPartners);
   const projectOptions = FormDataFilter<Project>(projects);
-  // Fin the intial data partner which is required when adding Dataset
+  // Find the intial data partner which is required when adding Dataset
   const initialPartner = dataPartners.find(
     (partner) => dataset.data_partner === partner.id
   )!;
   // Find and make initial data suitable for React select
   const initialPartnerFilter = FormDataFilter<DataPartner>(initialPartner);
+  const initialViewersFilter = FindAndFormat<User>(users, dataset.viewers);
   const initialEditorsFilter = FindAndFormat<User>(users, dataset.editors);
   const initialAdminsFilter = FindAndFormat<User>(users, dataset.admins);
   const initialProjectFilter = FindAndFormat<Project>(
@@ -57,6 +66,7 @@ export function DatasetForm({
       name: data.name,
       visibility: data.visibility,
       data_partner: data.dataPartner,
+      viewers: data.viewers || [],
       admins: data.admins || [],
       editors: data.editors || [],
       projects: data.projects || [],
@@ -74,6 +84,7 @@ export function DatasetForm({
       initialValues={{
         name: dataset.name,
         visibility: dataset.visibility,
+        viewers: initialViewersFilter.map((viewer) => viewer.value),
         editors: initialEditorsFilter.map((editor) => editor.value),
         dataPartner: initialPartnerFilter[0].value,
         admins: initialAdminsFilter.map((admin) => admin.value),
@@ -100,27 +111,6 @@ export function DatasetForm({
                 className="text-lg text-carrot"
               />
             </div>
-            <div className="flex items-center space-x-3">
-              <h3 className="flex">
-                Visibility
-                <Tooltips content="If a Dataset is PUBLIC, then all users with access to any project associated to the Dataset can see them." />
-              </h3>
-              <Switch
-                onCheckedChange={(checked) =>
-                  handleChange({
-                    target: {
-                      name: "visibility",
-                      value: checked ? "PUBLIC" : "RESTRICTED",
-                    },
-                  })
-                }
-                defaultChecked={dataset.visibility === "PUBLIC" ? true : false}
-                disabled={!canUpdate}
-              />
-              <Label className="text-lg">
-                {values.visibility === "PUBLIC" ? "PUBLIC" : "RESTRICTED"}
-              </Label>
-            </div>
             <div className="flex flex-col gap-2">
               <h3 className="flex">
                 Data Partner{" "}
@@ -134,6 +124,44 @@ export function DatasetForm({
                 isDisabled={!canUpdate}
               />
             </div>
+            <div className="flex items-center space-x-3">
+              <h3 className="flex">
+                Visibility
+                <Tooltips content="If a Dataset is PUBLIC, then all users with access to any project associated to the Dataset can see them." />
+              </h3>
+              <Switch
+                onCheckedChange={(checked) => {
+                  handleChange({
+                    target: {
+                      name: "visibility",
+                      value: checked ? "PUBLIC" : "RESTRICTED",
+                    },
+                  });
+                  setPublicVisibility(checked);
+                }}
+                defaultChecked={dataset.visibility === "PUBLIC" ? true : false}
+                disabled={!canUpdate}
+              />
+              <Label className="text-lg">
+                {values.visibility === "PUBLIC" ? "PUBLIC" : "RESTRICTED"}
+              </Label>
+            </div>
+            {!publicVisibility && (
+              <div className="flex flex-col gap-2">
+                <h3 className="flex">
+                  {" "}
+                  Viewers
+                  <Tooltips content="All Dataset admins and editors also have Dataset viewer permissions. If a Dataset is PUBLIC, then all users with access to any project associated to the Dataset will have Dataset viewer permissions." />
+                </h3>
+                <FormikSelect
+                  options={userOptions}
+                  name="viewers"
+                  placeholder="Choose viewers"
+                  isMulti={true}
+                  isDisabled={!canUpdate}
+                />
+              </div>
+            )}
             <div className="flex flex-col gap-2">
               <h3 className="flex">
                 {" "}
@@ -143,7 +171,7 @@ export function DatasetForm({
               <FormikSelect
                 options={userOptions}
                 name="editors"
-                placeholder="Choose an editor"
+                placeholder="Choose editors"
                 isMulti={true}
                 isDisabled={!canUpdate}
               />
@@ -157,7 +185,7 @@ export function DatasetForm({
               <FormikSelect
                 options={userOptions}
                 name="admins"
-                placeholder="Choose an admin"
+                placeholder="Choose admins"
                 isMulti={true}
                 isDisabled={!canUpdate}
               />
@@ -171,7 +199,7 @@ export function DatasetForm({
               <FormikSelect
                 options={projectOptions}
                 name="projects"
-                placeholder="Choose a project"
+                placeholder="Choose projects"
                 isMulti={true}
                 isDisabled={!canUpdate}
               />


### PR DESCRIPTION
# Changes

This PR added the "Viewers" field for the dataset details and new dataset forms. This field, which wasn't made in previous PRs, will appear when users choose the RESTRICTED visibility mode, allowing users to add viewers to the dataset.

Closes #788 


# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
