### PR TITLE
Implementation of NextJS to Scan Report Details Page

### DIFF
--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -150,6 +150,10 @@ class ScanReportViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer
             "status",
             "created_at",
             "hidden",
+            "author",
+            "viewers",
+            "editors",
+            "visibility",
         )
 
     def get_parent_dataset(self, obj):

--- a/app/api/proxy/urls.py
+++ b/app/api/proxy/urls.py
@@ -23,6 +23,11 @@ urlpatterns = [
         name="scan-report-tables",
     ),
     re_path(
+        r"^scanreports/(?P<path>\d+/details)/$",
+        ProxyView.as_view(upstream=f"{settings.NEXTJS_URL}/scanreports/"),
+        name="scan-report-details",
+    ),
+    re_path(
         r"^scanreports/(?P<path>\d+/tables/\d+)/$",
         ProxyView.as_view(upstream=f"{settings.NEXTJS_URL}/scanreports/"),
         name="scan-report-fields",

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -7,8 +7,10 @@ const fetchKeys = {
   list: (filter?: string) =>
     filter ? `datasets_data_partners/?${filter}` : "datasets_data_partners/",
   dataset: (id: string) => `datasets/${id}/`,
-  datasetList: (dataPartnerId: string) =>
-    `datasets/?data_partner=${dataPartnerId}&hidden=false`,
+  datasetList: (dataPartnerId?: string) =>
+    dataPartnerId
+      ? `datasets/?data_partner=${dataPartnerId}&hidden=false`
+      : "datasets/",
   dataPartners: () => "datapartners/",
   users: () => "usersfilter/?is_active=true",
   projects: (dataset?: string) =>
@@ -50,7 +52,9 @@ export async function getDataSet(id: string): Promise<DataSetSRList> {
   }
 }
 
-export async function getDatasetList(filter: string): Promise<DataSetSRList[]> {
+export async function getDatasetList(
+  filter?: string
+): Promise<DataSetSRList[]> {
   try {
     return await request<DataSetSRList>(fetchKeys.datasetList(filter));
   } catch (error) {

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -152,19 +152,26 @@ export async function getScanReportField(
   }
 }
 
-export async function updateScanReport(id: number, field: string, value: any) {
+export async function updateScanReport(
+  id: number,
+  data: {},
+  needRedirect?: boolean
+) {
   try {
     await request(fetchKeys.update(id), {
       method: "PATCH",
       headers: {
         "Content-type": "application/json",
       },
-      body: JSON.stringify({ [field]: value }),
+      body: JSON.stringify(data),
     });
     revalidatePath("/scanreports/");
   } catch (error: any) {
     // Only return a response when there is an error
     return { errorMessage: error.message };
+  }
+  if (needRedirect) {
+    redirect(`/scanreports/`);
   }
 }
 

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -111,6 +111,10 @@ export async function getScanReport(id: string): Promise<ScanReportList> {
       status: "",
       created_at: new Date(),
       hidden: true,
+      visibility: "",
+      author: 0,
+      editors: [],
+      viewers: [],
     };
   }
 }

--- a/app/next-client-app/app/scanreports/[id]/details/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/details/page.tsx
@@ -5,15 +5,9 @@ import {
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import {
-  getDataPartners,
-  getDataSet,
-  getDataUsers,
-  getDatasetPermissions,
-  getProjects,
-} from "@/api/datasets";
+import { getDataUsers, getDatasetList } from "@/api/datasets";
 import { ScanReportDetailsForm } from "@/components/scanreports/ScanReportDetailsForm";
-import { getScanReport } from "@/api/scanreports";
+import { getScanReport, getScanReportPermissions } from "@/api/scanreports";
 
 interface ScanReportDetailsProps {
   params: {
@@ -25,11 +19,9 @@ export default async function ScanreportDetails({
   params: { id },
 }: ScanReportDetailsProps) {
   const scanreport = await getScanReport(id);
-  const dataset = await getDataSet(id);
-  const partners = await getDataPartners();
+  const datasetList = await getDatasetList();
   const users = await getDataUsers();
-  const projects = await getProjects();
-  const permissions = await getDatasetPermissions(id);
+  const permissions = await getScanReportPermissions(id);
 
   return (
     <div className="pt-10 px-16">
@@ -61,15 +53,14 @@ export default async function ScanreportDetails({
       <div className="flex justify-between mt-3">
         <h1 className="text-4xl font-semibold">Scan Report #{id} - Details</h1>
       </div>
-      {/* <div className="mt-4">
+      <div className="mt-4">
         <ScanReportDetailsForm
-          dataset={dataset}
-          dataPartners={partners}
+          scanreport={scanreport}
+          datasetList={datasetList}
           users={users}
-          projects={projects}
           permissions={permissions.permissions}
         />
-      </div> */}
+      </div>
     </div>
   );
 }

--- a/app/next-client-app/app/scanreports/[id]/details/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/details/page.tsx
@@ -51,7 +51,9 @@ export default async function ScanreportDetails({
         </Breadcrumb>
       </div>
       <div className="flex justify-between mt-3">
-        <h1 className="text-4xl font-semibold">Scan Report #{id} - Details</h1>
+        <h1 className="text-4xl font-semibold">
+          Details Page - Scan Report #{id}
+        </h1>
       </div>
       <div className="mt-4">
         <ScanReportDetailsForm

--- a/app/next-client-app/app/scanreports/[id]/details/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/details/page.tsx
@@ -5,7 +5,11 @@ import {
   BreadcrumbList,
   BreadcrumbSeparator,
 } from "@/components/ui/breadcrumb";
-import { getDataUsers, getDatasetList } from "@/api/datasets";
+import {
+  getDataUsers,
+  getDatasetList,
+  getDatasetPermissions,
+} from "@/api/datasets";
 import { ScanReportDetailsForm } from "@/components/scanreports/ScanReportDetailsForm";
 import { getScanReport, getScanReportPermissions } from "@/api/scanreports";
 
@@ -21,7 +25,14 @@ export default async function ScanreportDetails({
   const scanreport = await getScanReport(id);
   const datasetList = await getDatasetList();
   const users = await getDataUsers();
-  const permissions = await getScanReportPermissions(id);
+  const parent_dataset = datasetList.find(
+    (dataset) => dataset.name === scanreport.parent_dataset
+  );
+  const permissionsDS = await getDatasetPermissions(
+    parent_dataset?.id.toString() || ""
+  );
+  const permissionsSR = await getScanReportPermissions(id);
+  const isAuthor = permissionsSR.permissions.includes("IsAuthor");
 
   return (
     <div className="pt-10 px-16">
@@ -60,7 +71,8 @@ export default async function ScanreportDetails({
           scanreport={scanreport}
           datasetList={datasetList}
           users={users}
-          permissions={permissions.permissions}
+          permissions={permissionsDS.permissions}
+          isAuthor={isAuthor}
         />
       </div>
     </div>

--- a/app/next-client-app/app/scanreports/[id]/details/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/details/page.tsx
@@ -1,0 +1,75 @@
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import {
+  getDataPartners,
+  getDataSet,
+  getDataUsers,
+  getDatasetPermissions,
+  getProjects,
+} from "@/api/datasets";
+import { ScanReportDetailsForm } from "@/components/scanreports/ScanReportDetailsForm";
+import { getScanReport } from "@/api/scanreports";
+
+interface ScanReportDetailsProps {
+  params: {
+    id: string;
+  };
+}
+
+export default async function ScanreportDetails({
+  params: { id },
+}: ScanReportDetailsProps) {
+  const scanreport = await getScanReport(id);
+  const dataset = await getDataSet(id);
+  const partners = await getDataPartners();
+  const users = await getDataUsers();
+  const projects = await getProjects();
+  const permissions = await getDatasetPermissions(id);
+
+  return (
+    <div className="pt-10 px-16">
+      <div>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/">Home</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator>/</BreadcrumbSeparator>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/scanreports">Scan Reports</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator>/</BreadcrumbSeparator>
+            <BreadcrumbItem>
+              <BreadcrumbLink href={`/scanreports/${id}/`}>
+                {scanreport.dataset}
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator>/</BreadcrumbSeparator>
+            <BreadcrumbItem>
+              <BreadcrumbLink href={`/scanreports/${id}/details`}>
+                Details
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+      <div className="flex justify-between mt-3">
+        <h1 className="text-4xl font-semibold">Scan Report #{id} - Details</h1>
+      </div>
+      {/* <div className="mt-4">
+        <ScanReportDetailsForm
+          dataset={dataset}
+          dataPartners={partners}
+          users={users}
+          projects={projects}
+          permissions={permissions.permissions}
+        />
+      </div> */}
+    </div>
+  );
+}

--- a/app/next-client-app/components/HandleArchive.tsx
+++ b/app/next-client-app/components/HandleArchive.tsx
@@ -21,7 +21,7 @@ export const HandleArchive = async ({
       response = await archiveDataSets(id, !hidden);
       break;
     case "scanreports":
-      response = await updateScanReport(id, "hidden", !hidden);
+      response = await updateScanReport(id, { hidden: !hidden });
       break;
   }
   // Because the response only returned when there is an error

--- a/app/next-client-app/components/data-table/index.tsx
+++ b/app/next-client-app/components/data-table/index.tsx
@@ -54,7 +54,6 @@ export function DataTable<TData, TValue>({
   clickableRow = true,
   defaultPageSize,
 }: DataTableProps<TData, TValue>) {
-  const router = useRouter();
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({});
 

--- a/app/next-client-app/components/datasets/CreateDatasetForm.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetForm.tsx
@@ -89,6 +89,7 @@ export function CreateDatasetForm({
                 {error.split(" * ").map((err, index) => (
                   <li key={index}>* {err}</li>
                 ))}
+                <li>* Notice: The name of dataset should be unique *</li>
               </ul>
             </AlertDescription>
           </div>

--- a/app/next-client-app/components/datasets/DatasetForm.tsx
+++ b/app/next-client-app/components/datasets/DatasetForm.tsx
@@ -204,7 +204,7 @@ export function DatasetForm({
                 isDisabled={!canUpdate}
               />
             </div>
-            <div>
+            <div className="flex">
               <Button
                 type="submit"
                 className="px-4 py-2 bg-carrot text-white rounded text-lg"
@@ -212,6 +212,10 @@ export function DatasetForm({
               >
                 Save <Save className="ml-2" />
               </Button>
+              <Tooltips
+                content="You must be an admin of the this dataset
+                    to update its details."
+              />
             </div>
           </div>
         </Form>

--- a/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
+++ b/app/next-client-app/components/scanreports/CreateScanReportForm.tsx
@@ -244,7 +244,7 @@ export function CreateScanReportForm({
                   />
                 </div>
               </div>
-              <div className="mb-5">
+              <div className="mb-5 flex">
                 <Button
                   type="submit"
                   className="px-4 py-2 bg-carrot text-white rounded text-lg"
@@ -258,6 +258,7 @@ export function CreateScanReportForm({
                 >
                   Upload Scan Report <FileUp className="ml-2" />
                 </Button>
+                <Tooltips content="You must be either an admin or an editor of the parent dataset to add a new scan report to it." />
               </div>
             </div>
           </Form>

--- a/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
+++ b/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { updateDatasetDetails } from "@/api/datasets";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Save } from "lucide-react";
@@ -12,6 +11,7 @@ import { FindAndFormat, FormDataFilter } from "../form-components/FormikUtils";
 import { Tooltips } from "../Tooltips";
 import { FormikSelect } from "../form-components/FormikSelect";
 import { useState } from "react";
+import { updateScanReport } from "@/api/scanreports";
 
 interface FormData {
   name: string;
@@ -34,7 +34,8 @@ export function ScanReportDetailsForm({
   permissions: Permission[];
 }) {
   // Permissions
-  const canUpdate = permissions.includes("CanAdmin");
+  const canUpdate =
+    permissions.includes("CanEdit") || permissions.includes("CanAdmin");
   // State control for viewers fields
   const [publicVisibility, setPublicVisibility] = useState<boolean>(
     scanreport.visibility === "PUBLIC" ? true : false
@@ -45,7 +46,7 @@ export function ScanReportDetailsForm({
   const parentDatasetOptions = FormDataFilter<DataSetSRList>(datasetList);
   // Find the intial parent dataset and author which is required when adding Dataset
   const initialParentDataset = datasetList.find(
-    (dataset) => scanreport.parent_dataset === dataset.name
+    (dataset) => scanreport.parent_dataset === dataset.name // parent's dataset is unique (set by the models.py) so can be used to find the initial parent dataset here
   )!;
 
   const initialAuthor = users.find((user) => scanreport.author === user.id)!;
@@ -65,12 +66,17 @@ export function ScanReportDetailsForm({
       editors: data.editors || [],
       author: data.author,
     };
-    // const response = await updateDatasetDetails(dataset.id, submittingData);
-    // if (response) {
-    //   toast.error(`Update Dataset failed. Error: ${response.errorMessage}`);
-    // } else {
-    //   toast.success("Update Dataset successful!");
-    // }
+
+    const response = await updateScanReport(
+      scanreport.id,
+      submittingData,
+      true // "true" for the value "needRedirect"
+    );
+    if (response) {
+      toast.error(`Update Scan Report failed. Error: ${response.errorMessage}`);
+    } else {
+      toast.success("Update Scan Report successful!");
+    }
   };
 
   return (

--- a/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
+++ b/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
@@ -100,7 +100,7 @@ export function ScanReportDetailsForm({
               <h3 className="flex">
                 {" "}
                 Name
-                <Tooltips content="Name of the dataset." />
+                <Tooltips content="Name of the Scan Report." />
               </h3>
               <Input
                 placeholder={scanreport.dataset}
@@ -113,7 +113,10 @@ export function ScanReportDetailsForm({
             <div className="flex flex-col gap-2">
               <h3 className="flex">
                 Author{" "}
-                <Tooltips content="The data partner that owns the dataset." />
+                <Tooltips
+                  content="Authors of a Scan Report can edit Scan Report details."
+                  link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#authors"
+                />
               </h3>
               <FormikSelect
                 options={userOptions}
@@ -126,7 +129,10 @@ export function ScanReportDetailsForm({
             <div className="flex items-center space-x-3">
               <h3 className="flex">
                 Visibility
-                <Tooltips content="If a Dataset is PUBLIC, then all users with access to any project associated to the Dataset can see them." />
+                <Tooltips
+                  content="To see the contents of the Scan Report, the Scan Report must be PUBLIC, or users must be an author/editor/viewer of the Scan Report."
+                  link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#access-controls"
+                />
               </h3>
               <Switch
                 onCheckedChange={(checked) => {
@@ -152,7 +158,10 @@ export function ScanReportDetailsForm({
                 <h3 className="flex">
                   {" "}
                   Viewers
-                  <Tooltips content="All Dataset admins and editors also have Dataset viewer permissions." />
+                  <Tooltips
+                    content="Viewers of a Scan Report can perform read-only actions."
+                    link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#viewers"
+                  />
                 </h3>
                 <FormikSelect
                   options={userOptions}
@@ -167,7 +176,10 @@ export function ScanReportDetailsForm({
               <h3 className="flex">
                 {" "}
                 Editors
-                <Tooltips content="Dataset editors also have Scan Report editor permissions." />
+                <Tooltips
+                  content="Editors of a Scan Report can add/remove concepts, update tables and update fields."
+                  link="https://carrot4omop.ac.uk/Carrot-Mapper/projects-datasets-and-scanreports/#editors"
+                />
               </h3>
               <FormikSelect
                 options={userOptions}
@@ -181,7 +193,7 @@ export function ScanReportDetailsForm({
               <h3 className="flex">
                 {" "}
                 Dataset
-                <Tooltips content="The project that the dataset belongs to." />
+                <Tooltips content="The parent dataset of the Scan Report." />
               </h3>
               <FormikSelect
                 options={parentDatasetOptions}

--- a/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
+++ b/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
@@ -27,15 +27,16 @@ export function ScanReportDetailsForm({
   scanreport,
   users,
   permissions,
+  isAuthor,
 }: {
   datasetList: DataSetSRList[];
   scanreport: ScanReportList;
   users: User[];
   permissions: Permission[];
+  isAuthor: boolean;
 }) {
   // Permissions
-  const canUpdate =
-    permissions.includes("CanEdit") || permissions.includes("CanAdmin");
+  const canUpdate = permissions.includes("CanAdmin") || isAuthor;
   // State control for viewers fields
   const [publicVisibility, setPublicVisibility] = useState<boolean>(
     scanreport.visibility === "PUBLIC" ? true : false
@@ -203,7 +204,7 @@ export function ScanReportDetailsForm({
                 isDisabled={!canUpdate}
               />
             </div>
-            <div>
+            <div className="flex">
               <Button
                 type="submit"
                 className="px-4 py-2 bg-carrot text-white rounded text-lg"
@@ -211,6 +212,10 @@ export function ScanReportDetailsForm({
               >
                 Save <Save className="ml-2" />
               </Button>
+              <Tooltips
+                content="You must be the author of the scan report or an admin of the parent dataset
+                    to update the details of this dataset."
+              />
             </div>
           </div>
         </Form>

--- a/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
+++ b/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { updateDatasetDetails } from "@/api/datasets";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Save } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Form, Formik } from "formik";
+import { toast } from "sonner";
+import { FindAndFormat, FormDataFilter } from "../form-components/FormikUtils";
+import { Tooltips } from "../Tooltips";
+import { FormikSelect } from "../form-components/FormikSelect";
+import { useState } from "react";
+
+interface FormData {
+  name: string;
+  visibility: string;
+  dataPartner: number;
+  viewers: number[];
+  editors: number[];
+  admins: number[];
+  projects: number[];
+}
+
+export function ScanReportDetailsForm({
+  dataset,
+  dataPartners,
+  projects,
+  users,
+  permissions,
+}: {
+  dataset: DataSetSRList;
+  dataPartners: DataPartner[];
+  users: User[];
+  projects: Project[];
+  permissions: Permission[];
+}) {
+  // Permissions
+  const canUpdate = permissions.includes("CanAdmin");
+  // State control for viewers fields
+  const [publicVisibility, setPublicVisibility] = useState<boolean>(
+    dataset.visibility === "PUBLIC" ? true : false
+  );
+
+  // Making options suitable for React Select
+  const userOptions = FormDataFilter<User>(users);
+  const partnerOptions = FormDataFilter<DataPartner>(dataPartners);
+  const projectOptions = FormDataFilter<Project>(projects);
+  // Find the intial data partner which is required when adding Dataset
+  const initialPartner = dataPartners.find(
+    (partner) => dataset.data_partner === partner.id
+  )!;
+  // Find and make initial data suitable for React select
+  const initialPartnerFilter = FormDataFilter<DataPartner>(initialPartner);
+  const initialViewersFilter = FindAndFormat<User>(users, dataset.viewers);
+  const initialEditorsFilter = FindAndFormat<User>(users, dataset.editors);
+  const initialAdminsFilter = FindAndFormat<User>(users, dataset.admins);
+  const initialProjectFilter = FindAndFormat<Project>(
+    projects,
+    dataset.projects
+  );
+
+  const handleSubmit = async (data: FormData) => {
+    const submittingData = {
+      name: data.name,
+      visibility: data.visibility,
+      data_partner: data.dataPartner,
+      viewers: data.viewers || [],
+      admins: data.admins || [],
+      editors: data.editors || [],
+      projects: data.projects || [],
+    };
+    const response = await updateDatasetDetails(dataset.id, submittingData);
+    if (response) {
+      toast.error(`Update Dataset failed. Error: ${response.errorMessage}`);
+    } else {
+      toast.success("Update Dataset successful!");
+    }
+  };
+
+  return (
+    <Formik
+      initialValues={{
+        name: dataset.name,
+        visibility: dataset.visibility,
+        viewers: initialViewersFilter.map((viewer) => viewer.value),
+        editors: initialEditorsFilter.map((editor) => editor.value),
+        dataPartner: initialPartnerFilter[0].value,
+        admins: initialAdminsFilter.map((admin) => admin.value),
+        projects: initialProjectFilter.map((project) => project.value),
+      }}
+      onSubmit={(data) => {
+        handleSubmit(data);
+      }}
+    >
+      {({ values, handleChange, handleSubmit }) => (
+        <Form className="w-full" onSubmit={handleSubmit}>
+          <div className="flex flex-col gap-3 text-lg">
+            <div className="flex items-center space-x-3">
+              <h3 className="flex">
+                {" "}
+                Name
+                <Tooltips content="Name of the dataset." />
+              </h3>
+              <Input
+                placeholder={dataset.name}
+                onChange={handleChange}
+                name="name"
+                disabled={!canUpdate}
+                className="text-lg text-carrot"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <h3 className="flex">
+                Data Partner{" "}
+                <Tooltips content="The data partner that owns the dataset." />
+              </h3>
+              <FormikSelect
+                options={partnerOptions}
+                name="dataPartner"
+                placeholder="Choose an Data Partner"
+                isMulti={false}
+                isDisabled={!canUpdate}
+              />
+            </div>
+            <div className="flex items-center space-x-3">
+              <h3 className="flex">
+                Visibility
+                <Tooltips content="If a Dataset is PUBLIC, then all users with access to any project associated to the Dataset can see them." />
+              </h3>
+              <Switch
+                onCheckedChange={(checked) => {
+                  handleChange({
+                    target: {
+                      name: "visibility",
+                      value: checked ? "PUBLIC" : "RESTRICTED",
+                    },
+                  });
+                  setPublicVisibility(checked);
+                }}
+                defaultChecked={dataset.visibility === "PUBLIC" ? true : false}
+                disabled={!canUpdate}
+              />
+              <Label className="text-lg">
+                {values.visibility === "PUBLIC" ? "PUBLIC" : "RESTRICTED"}
+              </Label>
+            </div>
+            {!publicVisibility && (
+              <div className="flex flex-col gap-2">
+                <h3 className="flex">
+                  {" "}
+                  Viewers
+                  <Tooltips content="All Dataset admins and editors also have Dataset viewer permissions." />
+                </h3>
+                <FormikSelect
+                  options={userOptions}
+                  name="viewers"
+                  placeholder="Choose viewers"
+                  isMulti={true}
+                  isDisabled={!canUpdate}
+                />
+              </div>
+            )}
+            <div className="flex flex-col gap-2">
+              <h3 className="flex">
+                {" "}
+                Editors
+                <Tooltips content="Dataset editors also have Scan Report editor permissions." />
+              </h3>
+              <FormikSelect
+                options={userOptions}
+                name="editors"
+                placeholder="Choose editors"
+                isMulti={true}
+                isDisabled={!canUpdate}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <h3 className="flex">
+                {" "}
+                Admins
+                <Tooltips content="All Dataset admins also have Dataset editor permissions. Dataset admins also have Scan Report editor permissions." />
+              </h3>
+              <FormikSelect
+                options={userOptions}
+                name="admins"
+                placeholder="Choose admins"
+                isMulti={true}
+                isDisabled={!canUpdate}
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <h3 className="flex">
+                {" "}
+                Project
+                <Tooltips content="The project that the dataset belongs to." />
+              </h3>
+              <FormikSelect
+                options={projectOptions}
+                name="projects"
+                placeholder="Choose projects"
+                isMulti={true}
+                isDisabled={!canUpdate}
+              />
+            </div>
+            <div>
+              <Button
+                type="submit"
+                className="px-4 py-2 bg-carrot text-white rounded text-lg"
+                disabled={!canUpdate}
+              >
+                Save <Save className="ml-2" />
+              </Button>
+            </div>
+          </div>
+        </Form>
+      )}
+    </Formik>
+  );
+}

--- a/app/next-client-app/components/scanreports/ScanReportStatus.tsx
+++ b/app/next-client-app/components/scanreports/ScanReportStatus.tsx
@@ -19,16 +19,16 @@ export function ScanReportStatus({ row }: { row: Row<ScanReportList> }) {
 
   const handleChangeStatus = async (newStatus: string) => {
     try {
-      await updateScanReport(id, "status", newStatus);
+      await updateScanReport(id, { status: newStatus });
       const newStatusText =
         statusOptions.find((option) => option.value === newStatus)?.label ?? "";
       toast.success(
-        `Scan Report ${dataset} status has changed to ${newStatusText}.`,
+        `Scan Report ${dataset} status has changed to ${newStatusText}.`
       );
     } catch (error) {
       const errorObj = JSON.parse((error as ApiError).message);
       toast.error(
-        `Scan Report ${dataset} status change has failed: ${errorObj.detail}.`,
+        `Scan Report ${dataset} status change has failed: ${errorObj.detail}.`
       );
       console.error(error);
     }

--- a/app/next-client-app/types/permissions.ts
+++ b/app/next-client-app/types/permissions.ts
@@ -1,4 +1,4 @@
-type Permission = "CanView" | "CanEdit" | "CanAdmin";
+type Permission = "CanView" | "CanEdit" | "CanAdmin" | "IsAuthor";
 
 interface PermissionsResponse {
   permissions: Permission[];

--- a/app/next-client-app/types/scanreport.ts
+++ b/app/next-client-app/types/scanreport.ts
@@ -6,6 +6,10 @@ interface ScanReportList {
   status: string;
   created_at: Date;
   hidden: boolean;
+  visibility: string;
+  author: number;
+  viewers: number[];
+  editors: number[];
 }
 
 interface ScanReportTable {


### PR DESCRIPTION
# Changes
This PR implemented NextJS to build the Scan Report Details view. It also added 
- The IsAuthor checking class in permissions.py to check if the user is the author of the current scan report or not.
- Some tooltips for Save buttons in other forms to clarify the permissions
- Add a notice to add a new Dataset which has to have a unique name which will relate to finding Scan report details
- Make the data sent to the PATCH endpoint of updating Scan Report to be an abstract object

Closes #749 

# Screenshots

- General view
![Screenshot 2024-07-11 at 12 23 39](https://github.com/Health-Informatics-UoN/Carrot-Mapper/assets/119530400/b2d60cec-5299-450e-a213-d3800cb31972)


# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
