### PR TITLE
Fixes for pagination and others.

### DIFF
--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -136,11 +136,10 @@ class ConceptFilterViewSet(viewsets.ReadOnlyModelViewSet):
 
 
 class ConceptFilterViewSetV2(viewsets.ReadOnlyModelViewSet):
-    queryset = Concept.objects.all()
+    queryset = Concept.objects.all().order_by("concept_id")
     serializer_class = ConceptSerializer
     filter_backends = [DjangoFilterBackend]
     pagination_class = CustomPagination
-    ordering = "concept_id"
     filterset_fields = {
         "concept_id": ["in", "exact"],
         "concept_code": ["in", "exact"],
@@ -1080,10 +1079,9 @@ class ScanReportConceptFilterViewSet(viewsets.ModelViewSet):
 
 
 class ScanReportConceptFilterViewSetV2(viewsets.ModelViewSet):
-    queryset = ScanReportConcept.objects.all()
+    queryset = ScanReportConcept.objects.all().order_by("id")
     serializer_class = ScanReportConceptSerializer
     pagination_class = CustomPagination
-    ordering = "id"
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {
         "concept__concept_id": ["in", "exact"],

--- a/app/api/config/settings.py
+++ b/app/api/config/settings.py
@@ -172,7 +172,7 @@ REST_FRAMEWORK = {
 
 STATIC_URL = "/static/"
 
-LOGIN_REDIRECT_URL = "/"
+LOGIN_REDIRECT_URL = "/scanreports/"
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # NLP API KEY

--- a/app/api/pyproject.toml
+++ b/app/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "api"
-version = "2.2.5"
+version = "2.2.9"
 description = "Web app for Carrot-Mapper"
 authors = ["Sam Cox <sam.cox@nottingham.ac.uk>", "Philip Quinlan <philip.quinlan@nottingham.ac.uk>"]
 license = "MIT"

--- a/app/next-client-app/app/scanreports/[id]/mapping_rules/get-file.tsx
+++ b/app/next-client-app/app/scanreports/[id]/mapping_rules/get-file.tsx
@@ -30,7 +30,8 @@ export function GetFile({
       if (type === "image/svg+xml") {
         data = await getMapDiagram(scanreportId, query, "svg");
       } else if (type === "application/json") {
-        data = await getMapDiagram(scanreportId, query, "json");
+        const resp = await getMapDiagram(scanreportId, query, "json");
+        data = JSON.stringify(resp);
       } else {
         data = await getMapDiagram(scanreportId, query, "csv");
       }

--- a/app/next-client-app/app/scanreports/[id]/mapping_rules/page.tsx
+++ b/app/next-client-app/app/scanreports/[id]/mapping_rules/page.tsx
@@ -105,8 +105,8 @@ export default async function ScanReportsMappingRules({
                 <BarChartHorizontalBig className="ml-2 size-4" />
               </Button>
             </DialogTrigger>
-            <DialogContent className="max-w-[1200px]">
-              <ScrollArea className="w-[1000px] h-[400px]">
+            <DialogContent className="max-w-[1200px] h-5/6">
+              <ScrollArea className="w-auto">
                 <GetFile
                   name="Download Map Diagram"
                   scanreportId={id}

--- a/app/react-client-app/src/components/MappingTbl.jsx
+++ b/app/react-client-app/src/components/MappingTbl.jsx
@@ -468,9 +468,6 @@ const MappingTbl = (props) => {
         <Button variant="blue" onClick={onOpen}>
           Show Summary view
         </Button>
-        <Button variant="blue" onClick={onOpenAnalyse}>
-          Analyse Rules
-        </Button>
       </Wrap>
 
       <div>

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 Please append a line to the changelog for each change made.
 
+## v2.2.9
+### Bugfixes
+- Fix pagination ordering on API endpoints for Scan Report Concepts.
+- Fix Scan Report vulnerabilities.
+
 ## v2.2.5
 ## New features
 - Carrot Mapper is now deployed on carrot.ac.uk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carrot-mapper"
-version = "2.0.12"
+version = "2.2.9"
 description = ""
 authors = ["Sam Cox <sam.cox@nottingham.ac.uk>", "Philip Quinlan <philip.quinlan@nottingham.ac.uk>"]
 license = "MIT"


### PR DESCRIPTION
# Changes

A couple of fixes for issues:

- Fixed added ordering where endpoints have been paginated - as these do not use the `DjangoFilterBackend` they need ordering on the queryset.
- Fix download json mapping rules in the Next UI
- Fix mapping diagram dialog size
- Removes the `Analyse Rules` button in the React app, discussed in #751 
- Make default login go to `/scanreports`
- Version bump to 2.2.9

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
