### PR TITLE
Add migrations

### DIFF
--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import logging
 import os
 import random
@@ -803,11 +804,6 @@ class ScanReportTableViewSetV2(ScanReportTableViewSet):
             # use the edit serialiser when the user tries to alter the scan report
             return ScanReportTableEditSerializer
         return super().get_serializer_class()
-
-    @method_decorator(cache_page(60 * 15))
-    @method_decorator(vary_on_cookie)
-    def list(self, request, *args, **kwargs):
-        return super().list(request, *args, **kwargs)
 
 
 class ScanReportFieldViewSet(viewsets.ModelViewSet):

--- a/app/api/pyproject.toml
+++ b/app/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "api"
-version = "2.2.9"
+version = "2.2.10"
 description = "Web app for Carrot-Mapper"
 authors = ["Sam Cox <sam.cox@nottingham.ac.uk>", "Philip Quinlan <philip.quinlan@nottingham.ac.uk>"]
 license = "MIT"

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -12,6 +12,7 @@ cd /api
 rm -rf staticfiles
 mkdir staticfiles
 python /api/manage.py collectstatic
+python /api/manage.py migrate
 
 # Set tmp dir to be in-memory for speed. Pass logs to stdout/err as Docker will expect them there
 gunicorn --config gunicorn.conf.py --worker-tmp-dir /dev/shm --timeout 600 --log-file=- --bind :8000 --workers 3 config.wsgi:application --reload

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,12 @@
 
 Please append a line to the changelog for each change made.
 
+## v2.2.10
+### Improvements
+- Add migrations to startup
+- Add Scan Reports and Datasets layouts
+- Optimise Scan Report Values API
+
 ## v2.2.9
 ### Bugfixes
 - Fix pagination ordering on API endpoints for Scan Report Concepts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carrot-mapper"
-version = "2.2.9"
+version = "2.2.10"
 description = ""
 authors = ["Sam Cox <sam.cox@nottingham.ac.uk>", "Philip Quinlan <philip.quinlan@nottingham.ac.uk>"]
 license = "MIT"


### PR DESCRIPTION
# Changes

Add migrations to startup.

The three deployed instances of Carrot have been checked, and they are now consistent with the existing migrations in the repo. We can now make database changes in code.

Also removed cache on Scan Report tables - had unintended consequences as we don't have the infra to invalidate cache right now. 

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
