### PR TITLE
Fix cache clearing

### DIFF
--- a/app/api/api/apps.py
+++ b/app/api/api/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class ApiConfig(AppConfig):
+    name = "api"
+
+    def ready(self):
+        import api.signals

--- a/app/api/api/signals.py
+++ b/app/api/api/signals.py
@@ -1,0 +1,26 @@
+from typing import Type
+
+from django.core.cache import cache
+from django.db.models import Model
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+from shared.data.models import Dataset, Project, ScanReport
+
+
+@receiver(post_save, sender=Project)
+@receiver(post_delete, sender=Project)
+@receiver(post_save, sender=Dataset)
+@receiver(post_delete, sender=Dataset)
+@receiver(post_save, sender=ScanReport)
+@receiver(post_delete, sender=ScanReport)
+def clear_cache(sender: Type[Model], **kwargs):
+    """
+    Clears the cache when a Project, Dataset, or Scan Report is saved or deleted.
+
+    Args:
+        sender: The sender of the signal.
+
+    Returns:
+        None
+    """
+    cache.clear()


### PR DESCRIPTION
# Changes

Fixes permissions filtering on Scan Report tables/fields/values
Adds clearing cache when permissions are updated.

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
