### PR TITLE
Feat/refactor structure

### DIFF
--- a/app/api/api/deprecated_router.py
+++ b/app/api/api/deprecated_router.py
@@ -40,6 +40,3 @@ router.register(
 )
 router.register(r"omoptables", deprecated_views.OmopTableViewSet, basename="omoptables")
 router.register(r"omopfields", deprecated_views.OmopFieldViewSet, basename="omopfields")
-router.register(
-    r"mappingrules", deprecated_views.MappingRuleViewSet, basename="mappingrule"
-)

--- a/app/api/api/deprecated_router.py
+++ b/app/api/api/deprecated_router.py
@@ -1,31 +1,45 @@
-from api import views
+from api import deprecated_views
 from rest_framework import routers
 
 router = routers.DefaultRouter()
 
 
-router.register(r"omop/concepts", views.ConceptViewSet, basename="concepts")
+router.register(r"omop/concepts", deprecated_views.ConceptViewSet, basename="concepts")
 router.register(
-    r"omop/conceptsfilter", views.ConceptFilterViewSet, basename="conceptsfilter"
-)
-router.register(r"scanreports", views.ScanReportListViewSet, basename="scanreports")
-router.register(
-    r"scanreporttables", views.ScanReportTableViewSet, basename="scanreporttables"
+    r"omop/conceptsfilter",
+    deprecated_views.ConceptFilterViewSet,
+    basename="conceptsfilter",
 )
 router.register(
-    r"scanreportfields", views.ScanReportFieldViewSet, basename="scanreportfields"
+    r"scanreports", deprecated_views.ScanReportListViewSet, basename="scanreports"
 )
 router.register(
-    r"scanreportvalues", views.ScanReportValueViewSet, basename="scanreportvalues"
+    r"scanreporttables",
+    deprecated_views.ScanReportTableViewSet,
+    basename="scanreporttables",
 )
 router.register(
-    r"scanreportconcepts", views.ScanReportConceptViewSet, basename="scanreportconcepts"
+    r"scanreportfields",
+    deprecated_views.ScanReportFieldViewSet,
+    basename="scanreportfields",
+)
+router.register(
+    r"scanreportvalues",
+    deprecated_views.ScanReportValueViewSet,
+    basename="scanreportvalues",
+)
+router.register(
+    r"scanreportconcepts",
+    deprecated_views.ScanReportConceptViewSet,
+    basename="scanreportconcepts",
 )
 router.register(
     r"scanreportconceptsfilter",
-    views.ScanReportConceptFilterViewSet,
+    deprecated_views.ScanReportConceptFilterViewSet,
     basename="scanreportconceptsfilter",
 )
-router.register(r"omoptables", views.OmopTableViewSet, basename="omoptables")
-router.register(r"omopfields", views.OmopFieldViewSet, basename="omopfields")
-router.register(r"mappingrules", views.MappingRuleViewSet, basename="mappingrule")
+router.register(r"omoptables", deprecated_views.OmopTableViewSet, basename="omoptables")
+router.register(r"omopfields", deprecated_views.OmopFieldViewSet, basename="omopfields")
+router.register(
+    r"mappingrules", deprecated_views.MappingRuleViewSet, basename="mappingrule"
+)

--- a/app/api/api/deprecated_router.py
+++ b/app/api/api/deprecated_router.py
@@ -1,0 +1,31 @@
+from api import views
+from rest_framework import routers
+
+router = routers.DefaultRouter()
+
+
+router.register(r"omop/concepts", views.ConceptViewSet, basename="concepts")
+router.register(
+    r"omop/conceptsfilter", views.ConceptFilterViewSet, basename="conceptsfilter"
+)
+router.register(r"scanreports", views.ScanReportListViewSet, basename="scanreports")
+router.register(
+    r"scanreporttables", views.ScanReportTableViewSet, basename="scanreporttables"
+)
+router.register(
+    r"scanreportfields", views.ScanReportFieldViewSet, basename="scanreportfields"
+)
+router.register(
+    r"scanreportvalues", views.ScanReportValueViewSet, basename="scanreportvalues"
+)
+router.register(
+    r"scanreportconcepts", views.ScanReportConceptViewSet, basename="scanreportconcepts"
+)
+router.register(
+    r"scanreportconceptsfilter",
+    views.ScanReportConceptFilterViewSet,
+    basename="scanreportconceptsfilter",
+)
+router.register(r"omoptables", views.OmopTableViewSet, basename="omoptables")
+router.register(r"omopfields", views.OmopFieldViewSet, basename="omopfields")
+router.register(r"mappingrules", views.MappingRuleViewSet, basename="mappingrule")

--- a/app/api/api/deprecated_serializers.py
+++ b/app/api/api/deprecated_serializers.py
@@ -1,0 +1,160 @@
+from drf_dynamic_fields import DynamicFieldsMixin  # type: ignore
+from rest_framework import serializers
+from rest_framework.exceptions import NotFound, PermissionDenied
+from shared.mapping.models import (
+    OmopField,
+    OmopTable,
+    ScanReport,
+    ScanReportField,
+    ScanReportTable,
+    ScanReportValue,
+)
+from shared.mapping.permissions import has_editorship, is_admin, is_az_function_user
+
+
+class ScanReportViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    def validate(self, data):
+        if request := self.context.get("request"):
+            if ds := data.get("parent_dataset"):
+                if not (
+                    is_az_function_user(request.user)
+                    or is_admin(ds, request)
+                    or has_editorship(ds, request)
+                ):
+                    raise PermissionDenied(
+                        "You must be an admin of the parent dataset to add a new scan report to it.",
+                    )
+            else:
+                raise NotFound("Could not find parent dataset.")
+        else:
+            raise serializers.ValidationError(
+                "Missing request context. Unable to validate scan report."
+            )
+        return super().validate(data)
+
+    class Meta:
+        model = ScanReport
+        fields = "__all__"
+
+
+class ScanReportTableListSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    def validate(self, data):
+        if request := self.context.get("request"):
+            if sr := data.get("scan_report"):
+                if not (
+                    is_az_function_user(request.user)
+                    or is_admin(sr, request)
+                    or has_editorship(sr, request)
+                ):
+                    raise PermissionDenied(
+                        "You must have editor or admin privileges on the scan report to edit its tables.",
+                    )
+            else:
+                raise NotFound("Could not find the scan report for this table.")
+        else:
+            raise serializers.ValidationError(
+                "Missing request context. Unable to validate scan report table."
+            )
+        return super().validate(data)
+
+    class Meta:
+        model = ScanReportTable
+        fields = "__all__"
+
+
+class ScanReportValueViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    value = serializers.CharField(
+        max_length=128, allow_blank=True, trim_whitespace=False
+    )
+
+    def validate(self, data):
+        if request := self.context.get("request"):
+            if srf := data.get("scan_report_field"):
+                if not (
+                    is_az_function_user(request.user)
+                    or is_admin(srf, request)
+                    or has_editorship(srf, request)
+                ):
+                    raise PermissionDenied(
+                        "You must have editor or admin privileges on the scan report to edit its values.",
+                    )
+            else:
+                raise NotFound("Could not find the scan report field for this value.")
+        else:
+            raise serializers.ValidationError(
+                "Missing request context. Unable to validate scan report value."
+            )
+        return super().validate(data)
+
+    class Meta:
+        model = ScanReportValue
+        fields = "__all__"
+
+
+class ScanReportValueEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    value = serializers.CharField(
+        max_length=128, allow_blank=True, trim_whitespace=False
+    )
+
+    class Meta:
+        model = ScanReportValue
+        fields = "__all__"
+
+
+class ScanReportFieldListSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    name = serializers.CharField(
+        max_length=512, allow_blank=True, trim_whitespace=False
+    )
+    description_column = serializers.CharField(
+        max_length=512, allow_blank=True, trim_whitespace=False
+    )
+
+    def validate(self, data):
+        if request := self.context.get("request"):
+            if srt := data.get("scan_report_table"):
+                if not (
+                    is_az_function_user(request.user)
+                    or is_admin(srt, request)
+                    or has_editorship(srt, request)
+                ):
+                    raise PermissionDenied(
+                        "You must have editor or admin privileges on the scan report to edit its fields.",
+                    )
+            else:
+                raise NotFound("Could not find the scan report table for this field.")
+        else:
+            raise serializers.ValidationError(
+                "Missing request context. Unable to validate scan report field."
+            )
+        return super().validate(data)
+
+    class Meta:
+        model = ScanReportField
+        fields = "__all__"
+
+
+class OmopFieldSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = OmopField
+        fields = "__all__"
+
+
+class OmopTableSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = OmopTable
+        fields = "__all__"
+
+
+class ContentTypeSerializer(serializers.Serializer):
+    """
+    Serializes the content type name.
+
+    Args:
+        self: The instance of the class.
+
+    Attributes:
+        type_name: The serialized content type name.
+
+    """
+
+    type_name = serializers.CharField(max_length=100)

--- a/app/api/api/deprecated_urls.py
+++ b/app/api/api/deprecated_urls.py
@@ -1,0 +1,31 @@
+from api import deprecated_views
+from django.urls import path
+
+urlpatterns = [
+    path(
+        r"contenttypeid",
+        deprecated_views.GetContentTypeID.as_view(),
+        name="contenttypeid",
+    ),
+    path(
+        r"countprojects/<int:dataset>",
+        deprecated_views.CountProjects.as_view(),
+        name="countprojects",
+    ),
+    path(r"countstats/", deprecated_views.CountStats.as_view(), name="countstats"),
+    path(
+        r"countstatsscanreport/",
+        deprecated_views.CountStatsScanReport.as_view(),
+        name="countstatsscanreport",
+    ),
+    path(
+        r"countstatsscanreporttable/",
+        deprecated_views.CountStatsScanReportTable.as_view(),
+        name="countstatsscanreporttable",
+    ),
+    path(
+        r"countstatsscanreporttablefield/",
+        deprecated_views.CountStatsScanReportTableField.as_view(),
+        name="countstatsscanreporttablefield",
+    ),
+]

--- a/app/api/api/deprecated_views.py
+++ b/app/api/api/deprecated_views.py
@@ -1,16 +1,461 @@
-from api.serializers import ContentTypeSerializer
+import logging
+import os
+from typing import Any
+from urllib.parse import urljoin
+
+import requests
+from api.filters import ScanReportAccessFilter
+from api.serializers import (
+    ConceptSerializer,
+    ContentTypeSerializer,
+    MappingRuleSerializer,
+    OmopFieldSerializer,
+    OmopTableSerializer,
+    ScanReportConceptSerializer,
+    ScanReportEditSerializer,
+    ScanReportFieldEditSerializer,
+    ScanReportFieldListSerializer,
+    ScanReportTableEditSerializer,
+    ScanReportTableListSerializer,
+    ScanReportValueEditSerializer,
+    ScanReportValueViewSerializer,
+    ScanReportViewSerializer,
+)
+from config import settings
 from django.contrib.contenttypes.models import ContentType
+from django.db.models.query_utils import Q
+from django.http import JsonResponse
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import status, viewsets
+from rest_framework.filters import OrderingFilter
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from shared.data.models import Concept
 from shared.mapping.models import (
     MappingRule,
+    OmopField,
+    OmopTable,
     Project,
     ScanReport,
+    ScanReportConcept,
     ScanReportField,
     ScanReportTable,
     ScanReportValue,
+    VisibilityChoices,
 )
+from shared.mapping.permissions import CanAdmin, CanEdit, CanView
+from shared.services.rules import delete_mapping_rules
+
+
+class ConceptViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Concept.objects.all()
+    serializer_class = ConceptSerializer
+
+
+class ConceptFilterViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = Concept.objects.all()
+    serializer_class = ConceptSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {
+        "concept_id": ["in", "exact"],
+        "concept_code": ["in", "exact"],
+        "vocabulary_id": ["in", "exact"],
+    }
+
+
+class ScanReportListViewSet(viewsets.ModelViewSet):
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {"parent_dataset": ["exact"]}
+
+    def get_permissions(self):
+        if self.request.method == "DELETE":
+            # user must be able to view and be an admin to delete a scan report
+            self.permission_classes = [IsAuthenticated & CanView & CanAdmin]
+        elif self.request.method in ["PUT", "PATCH"]:
+            # user must be able to view and be either an editor or and admin
+            # to edit a scan report
+            self.permission_classes = [IsAuthenticated & CanView & (CanEdit | CanAdmin)]
+        else:
+            self.permission_classes = [IsAuthenticated & (CanView | CanEdit | CanAdmin)]
+        return [permission() for permission in self.permission_classes]
+
+    def get_serializer_class(self):
+        if self.request.method in ["GET", "POST"]:
+            # use the view serialiser if on GET requests
+            return ScanReportViewSerializer
+        if self.request.method in ["PUT", "PATCH", "DELETE"]:
+            # use the edit serialiser when the user tries to alter the scan report
+            return ScanReportEditSerializer
+        return super().get_serializer_class()
+
+    def get_queryset(self):
+        """
+        If the User is the `AZ_FUNCTION_USER`, return all ScanReports.
+
+        Else, apply the correct rules regarding the visibility of the Dataset and SR,
+        and the membership of the User of viewer/editor/admin/author for either.
+        """
+        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return ScanReport.objects.all().distinct()
+
+        return ScanReport.objects.filter(
+            (
+                Q(parent_dataset__visibility=VisibilityChoices.PUBLIC)
+                & (
+                    Q(
+                        # Dataset and SR are 'PUBLIC'
+                        visibility=VisibilityChoices.PUBLIC,
+                    )
+                    | (
+                        Q(visibility=VisibilityChoices.RESTRICTED)
+                        & (
+                            Q(
+                                # Dataset is public
+                                # SR is restricted but user is in SR viewers
+                                viewers=self.request.user.id,
+                            )
+                            | Q(
+                                # Dataset is public
+                                # SR is restricted but user is in SR editors
+                                editors=self.request.user.id,
+                            )
+                            | Q(
+                                # Dataset is public
+                                # SR is restricted but user is SR author
+                                author=self.request.user.id,
+                            )
+                            | Q(
+                                # Dataset is public
+                                # SR is restricted but user is in Dataset editors
+                                parent_dataset__editors=self.request.user.id,
+                            )
+                            | Q(
+                                # Dataset is public
+                                # SR is restricted but user is in Dataset admins
+                                parent_dataset__admins=self.request.user.id,
+                            )
+                        )
+                    )
+                )
+            )
+            | (
+                Q(parent_dataset__visibility=VisibilityChoices.RESTRICTED)
+                & (
+                    Q(
+                        # Dataset and SR are restricted
+                        # User is in Dataset admins
+                        parent_dataset__admins=self.request.user.id,
+                    )
+                    | Q(
+                        # Dataset and SR are restricted
+                        # User is in Dataset editors
+                        parent_dataset__editors=self.request.user.id,
+                    )
+                    | (
+                        Q(parent_dataset__viewers=self.request.user.id)
+                        & (
+                            Q(
+                                # Dataset and SR are restricted
+                                # User is in Dataset viewers and SR viewers
+                                viewers=self.request.user.id,
+                            )
+                            | Q(
+                                # Dataset and SR are restricted
+                                # User is in Dataset viewers and SR editors
+                                editors=self.request.user.id,
+                            )
+                            | Q(
+                                # Dataset and SR are restricted
+                                # User is in Dataset viewers and SR author
+                                author=self.request.user.id,
+                            )
+                            | Q(
+                                # Dataset is restricted
+                                # But SR is 'PUBLIC'
+                                visibility=VisibilityChoices.PUBLIC,
+                            )
+                        )
+                    )
+                )
+            ),
+            parent_dataset__project__members=self.request.user.id,
+        ).distinct()
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(
+            data=request.data, many=isinstance(request.data, list)
+        )
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )
+
+
+class ScanReportTableViewSet(viewsets.ModelViewSet):
+    queryset = ScanReportTable.objects.all()
+    filter_backends = [DjangoFilterBackend, OrderingFilter, ScanReportAccessFilter]
+    ordering_fields = ["name", "person_id", "event_date"]
+    filterset_fields = {
+        "scan_report": ["in", "exact"],
+        "name": ["in", "icontains"],
+        "id": ["in", "exact"],
+    }
+
+    ordering = "-created_at"
+
+    def get_permissions(self):
+        if self.request.method == "DELETE":
+            # user must be able to view and be an admin to delete a scan report
+            self.permission_classes = [IsAuthenticated & CanView & CanAdmin]
+        elif self.request.method in ["PUT", "PATCH"]:
+            # user must be able to view and be either an editor or and admin
+            # to edit a scan report
+            self.permission_classes = [IsAuthenticated & CanView & (CanEdit | CanAdmin)]
+        else:
+            self.permission_classes = [IsAuthenticated & (CanView | CanEdit | CanAdmin)]
+        return [permission() for permission in self.permission_classes]
+
+    def get_serializer_class(self):
+        if self.request.method in ["GET", "POST"]:
+            # use the view serialiser if on GET requests
+            return ScanReportTableListSerializer
+        if self.request.method in ["PUT", "PATCH", "DELETE"]:
+            # use the edit serialiser when the user tries to alter the scan report
+            return ScanReportTableEditSerializer
+        return super().get_serializer_class()
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(
+            data=request.data, many=isinstance(request.data, list)
+        )
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )
+
+    def partial_update(self, request: Any, *args: Any, **kwargs: Any) -> Response:
+        """
+        Perform a partial update on the instance.
+
+        Args:
+            request (Any): The request object.
+            *args (Any): Additional positional arguments.
+            **kwargs (Any): Additional keyword arguments.
+
+        Returns:
+            Response: The response object.
+        """
+        instance = self.get_object()
+        partial = kwargs.pop("partial", True)
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+
+        # Delete the current mapping rules
+        delete_mapping_rules(instance.id)
+
+        # Map the table
+        scan_report_instance = instance.scan_report
+        data_dictionary_name = (
+            scan_report_instance.data_dictionary.name
+            if scan_report_instance.data_dictionary
+            else None
+        )
+
+        # Send to functions
+        msg = {
+            "scan_report_id": scan_report_instance.id,
+            "table_id": instance.id,
+            "data_dictionary_blob": data_dictionary_name,
+        }
+        base_url = f"{settings.AZ_URL}"
+        trigger = (
+            f"/api/orchestrators/{settings.AZ_RULES_NAME}?code={settings.AZ_RULES_KEY}"
+        )
+        try:
+            response = requests.post(urljoin(base_url, trigger), json=msg)
+            response.raise_for_status()
+        except request.exceptions.HTTPError as e:
+            logging.error(f"HTTP Trigger failed: {e}")
+
+        # TODO: The worker_id can be used for status, but we need to save it somewhere.
+        # resp_json = response.json()
+        # worker_id = resp_json.get("instanceId")
+
+        return Response(serializer.data)
+
+
+class ScanReportFieldViewSet(viewsets.ModelViewSet):
+    queryset = ScanReportField.objects.all()
+    filter_backends = [DjangoFilterBackend, ScanReportAccessFilter]
+    filterset_fields = {
+        "scan_report_table": ["in", "exact"],
+        "name": ["in", "exact"],
+    }
+
+    def get_permissions(self):
+        if self.request.method == "DELETE":
+            # user must be able to view and be an admin to delete a scan report
+            self.permission_classes = [IsAuthenticated & CanView & CanAdmin]
+        elif self.request.method in ["PUT", "PATCH"]:
+            # user must be able to view and be either an editor or and admin
+            # to edit a scan report
+            self.permission_classes = [IsAuthenticated & CanView & (CanEdit | CanAdmin)]
+        else:
+            self.permission_classes = [IsAuthenticated & CanView | CanEdit | CanAdmin]
+        return [permission() for permission in self.permission_classes]
+
+    def get_serializer_class(self):
+        if self.request.method in ["GET", "POST"]:
+            # use the view serialiser if on GET requests
+            return ScanReportFieldListSerializer
+        if self.request.method in ["PUT", "PATCH", "DELETE"]:
+            # use the edit serialiser when the user tries to alter the scan report
+            return ScanReportFieldEditSerializer
+        return super().get_serializer_class()
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(
+            data=request.data, many=isinstance(request.data, list)
+        )
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )
+
+
+class ScanReportValueViewSet(viewsets.ModelViewSet):
+    queryset = ScanReportValue.objects.all()
+    filter_backends = [DjangoFilterBackend, ScanReportAccessFilter]
+    filterset_fields = {
+        "scan_report_field": ["in", "exact"],
+        "value": ["in", "exact"],
+        "id": ["in", "exact"],
+    }
+    ordering = "id"
+
+    def get_permissions(self):
+        if self.request.method == "DELETE":
+            # user must be able to view and be an admin to delete a scan report
+            self.permission_classes = [IsAuthenticated & CanView & CanAdmin]
+        elif self.request.method in ["PUT", "PATCH"]:
+            # user must be able to view and be either an editor or and admin
+            # to edit a scan report
+            self.permission_classes = [IsAuthenticated & CanView & (CanEdit | CanAdmin)]
+        else:
+            self.permission_classes = [IsAuthenticated & (CanView | CanEdit | CanAdmin)]
+        return [permission() for permission in self.permission_classes]
+
+    def get_serializer_class(self):
+        if self.request.method in ["GET", "POST"]:
+            # use the view serialiser if on GET requests
+            return ScanReportValueViewSerializer
+        if self.request.method in ["PUT", "PATCH", "DELETE"]:
+            # use the edit serialiser when the user tries to alter the scan report
+            return ScanReportValueEditSerializer
+        return super().get_serializer_class()
+
+    def create(self, request, *args, **kwargs):
+        serializer = self.get_serializer(
+            data=request.data, many=isinstance(request.data, list)
+        )
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )
+
+
+class ScanReportConceptViewSet(viewsets.ModelViewSet):
+    queryset = ScanReportConcept.objects.all()
+    serializer_class = ScanReportConceptSerializer
+
+    def create(self, request, *args, **kwargs):
+        body = request.data
+        if not isinstance(body, list):
+            # Extract the content_type
+            content_type_str = body.pop("content_type", None)
+            content_type = ContentType.objects.get(model=content_type_str)
+            body["content_type"] = content_type.id
+
+            concept = ScanReportConcept.objects.filter(
+                concept=body["concept"],
+                object_id=body["object_id"],
+                content_type=content_type,
+            )
+            if concept.count() > 0:
+                print("Can't add multiple concepts of the same id to the same object")
+                response = JsonResponse(
+                    {
+                        "status_code": 403,
+                        "ok": False,
+                        "statusText": "Can't add multiple concepts of the same id to the same object",
+                    }
+                )
+                response.status_code = 403
+                return response
+        else:
+            # for each item in the list, identify any existing SRConcepts that clash, and block their creation
+            # this method may be quite slow as it has to wait for each query
+            filtered = []
+            for item in body:
+                # Extract the content_type
+                content_type_str = item.pop("content_type", None)
+                content_type = ContentType.objects.get(model=content_type_str)
+                item["content_type"] = content_type.id
+
+                concept = ScanReportConcept.objects.filter(
+                    concept=item["concept"],
+                    object_id=item["object_id"],
+                    content_type=content_type,
+                )
+                if concept.count() == 0:
+                    filtered.append(item)
+            body = filtered
+
+        serializer = self.get_serializer(data=body, many=isinstance(body, list))
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(
+            serializer.data, status=status.HTTP_201_CREATED, headers=headers
+        )
+
+
+class ScanReportConceptFilterViewSet(viewsets.ModelViewSet):
+    queryset = ScanReportConcept.objects.all()
+    serializer_class = ScanReportConceptSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {
+        "concept__concept_id": ["in", "exact"],
+        "object_id": ["in", "exact"],
+        "id": ["in", "exact"],
+        "content_type": ["in", "exact"],
+    }
+
+
+class OmopTableViewSet(viewsets.ModelViewSet):
+    queryset = OmopTable.objects.all()
+    serializer_class = OmopTableSerializer
+
+
+class OmopFieldViewSet(viewsets.ModelViewSet):
+    queryset = OmopField.objects.all()
+    serializer_class = OmopFieldSerializer
+
+
+class MappingRuleViewSet(viewsets.ModelViewSet):
+    queryset = MappingRule.objects.all()
+    serializer_class = MappingRuleSerializer
 
 
 class GetContentTypeID(APIView):

--- a/app/api/api/deprecated_views.py
+++ b/app/api/api/deprecated_views.py
@@ -7,19 +7,10 @@ import requests
 from api.filters import ScanReportAccessFilter
 from api.serializers import (
     ConceptSerializer,
-    ContentTypeSerializer,
-    MappingRuleSerializer,
-    OmopFieldSerializer,
-    OmopTableSerializer,
     ScanReportConceptSerializer,
     ScanReportEditSerializer,
     ScanReportFieldEditSerializer,
-    ScanReportFieldListSerializer,
     ScanReportTableEditSerializer,
-    ScanReportTableListSerializer,
-    ScanReportValueEditSerializer,
-    ScanReportValueViewSerializer,
-    ScanReportViewSerializer,
 )
 from config import settings
 from django.contrib.contenttypes.models import ContentType
@@ -47,6 +38,17 @@ from shared.mapping.models import (
 )
 from shared.mapping.permissions import CanAdmin, CanEdit, CanView
 from shared.services.rules import delete_mapping_rules
+
+from .deprecated_serializers import (
+    ContentTypeSerializer,
+    OmopFieldSerializer,
+    OmopTableSerializer,
+    ScanReportFieldListSerializer,
+    ScanReportTableListSerializer,
+    ScanReportValueEditSerializer,
+    ScanReportValueViewSerializer,
+    ScanReportViewSerializer,
+)
 
 
 class ConceptViewSet(viewsets.ReadOnlyModelViewSet):
@@ -451,11 +453,6 @@ class OmopTableViewSet(viewsets.ModelViewSet):
 class OmopFieldViewSet(viewsets.ModelViewSet):
     queryset = OmopField.objects.all()
     serializer_class = OmopFieldSerializer
-
-
-class MappingRuleViewSet(viewsets.ModelViewSet):
-    queryset = MappingRule.objects.all()
-    serializer_class = MappingRuleSerializer
 
 
 class GetContentTypeID(APIView):

--- a/app/api/api/deprecated_views.py
+++ b/app/api/api/deprecated_views.py
@@ -1,0 +1,137 @@
+from api.serializers import ContentTypeSerializer
+from django.contrib.contenttypes.models import ContentType
+from rest_framework.renderers import JSONRenderer
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from shared.mapping.models import (
+    MappingRule,
+    Project,
+    ScanReport,
+    ScanReportField,
+    ScanReportTable,
+    ScanReportValue,
+)
+
+
+class GetContentTypeID(APIView):
+
+    def get(self, request, *args, **kwargs):
+        """
+        Retrieves the content type ID based on the provided type name.
+
+        Args:
+            self: The instance of the class.
+            request: The HTTP request object.
+            *args: Additional positional arguments.
+            **kwargs: Additional keyword arguments.
+        """
+        serializer = ContentTypeSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        type_name = serializer.validated_data.get("type_name")
+        try:
+            content_type = ContentType.objects.get(model=type_name)
+            return Response({"content_type_id": content_type.id})
+        except ContentType.DoesNotExist:
+            return Response({"error": "Content type not found"}, status=404)
+
+
+class CountProjects(APIView):
+    renderer_classes = (JSONRenderer,)
+
+    def get(self, request, dataset):
+        project_count = (
+            Project.objects.filter(datasets__exact=dataset).distinct().count()
+        )
+        content = {
+            "project_count": project_count,
+        }
+        return Response(content)
+
+
+class CountStats(APIView):
+    renderer_classes = (JSONRenderer,)
+
+    def get(self, request, format=None):
+        scanreport_count = ScanReport.objects.count()
+        scanreporttable_count = ScanReportTable.objects.count()
+        scanreportfield_count = ScanReportField.objects.count()
+        scanreportvalue_count = ScanReportValue.objects.count()
+        scanreportmappingrule_count = MappingRule.objects.count()
+        content = {
+            "scanreport_count": scanreport_count,
+            "scanreporttable_count": scanreporttable_count,
+            "scanreportfield_count": scanreportfield_count,
+            "scanreportvalue_count": scanreportvalue_count,
+            "scanreportmappingrule_count": scanreportmappingrule_count,
+        }
+        return Response(content)
+
+
+class CountStatsScanReport(APIView):
+    renderer_classes = (JSONRenderer,)
+
+    def get(self, request, format=None):
+        parameterlist = list(
+            map(int, self.request.query_params["scan_report"].split(","))
+        )
+        jsonrecords = []
+        scanreporttable_count = "Disabled"
+        scanreportfield_count = "Disabled"
+        scanreportvalue_count = "Disabled"
+        scanreportmappingrule_count = "Disabled"
+
+        for scanreport in parameterlist:
+            scanreport_content = {
+                "scanreport": scanreport,
+                "scanreporttable_count": scanreporttable_count,
+                "scanreportfield_count": scanreportfield_count,
+                "scanreportvalue_count": scanreportvalue_count,
+                "scanreportmappingrule_count": scanreportmappingrule_count,
+            }
+            jsonrecords.append(scanreport_content)
+        return Response(jsonrecords)
+
+
+class CountStatsScanReportTable(APIView):
+    renderer_classes = (JSONRenderer,)
+
+    def get(self, request, format=None):
+        parameterlist = list(
+            map(int, self.request.query_params["scan_report_table"].split(","))
+        )
+        jsonrecords = []
+        for scanreporttable in parameterlist:
+            scanreportfield_count = ScanReportField.objects.filter(
+                scan_report_table=scanreporttable
+            ).count()
+            scanreportvalue_count = ScanReportValue.objects.filter(
+                scan_report_field__scan_report_table=scanreporttable
+            ).count()
+
+            scanreporttable_content = {
+                "scanreporttable": scanreporttable,
+                "scanreportfield_count": scanreportfield_count,
+                "scanreportvalue_count": scanreportvalue_count,
+            }
+            jsonrecords.append(scanreporttable_content)
+        return Response(jsonrecords)
+
+
+class CountStatsScanReportTableField(APIView):
+    renderer_classes = (JSONRenderer,)
+
+    def get(self, request, format=None):
+        parameterlist = list(
+            map(int, self.request.query_params["scan_report_field"].split(","))
+        )
+        jsonrecords = []
+        for scanreportfield in parameterlist:
+            scanreportvalue_count = ScanReportValue.objects.filter(
+                scan_report_field=scanreportfield
+            ).count()
+            scanreportfield_content = {
+                "scanreportfield": scanreportfield,
+                "scanreportvalue_count": scanreportvalue_count,
+            }
+            jsonrecords.append(scanreportfield_content)
+        return Response(jsonrecords)

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -3,33 +3,19 @@ from rest_framework import routers
 
 router = routers.DefaultRouter()
 
-
-router.register(r"omop/concepts", views.ConceptViewSet, basename="concepts")
-router.register(
-    r"omop/conceptsfilter", views.ConceptFilterViewSet, basename="conceptsfilter"
-)
 router.register(
     r"v2/omop/conceptsfilter", views.ConceptFilterViewSetV2, basename="v2conceptsfilter"
 )
 
 router.register(r"users", views.UserViewSet, basename="users")
 router.register(r"usersfilter", views.UserFilterViewSet, basename="usersfilter")
-
-router.register(r"scanreports", views.ScanReportListViewSet, basename="scanreports")
 router.register(
     r"v2/scanreports", views.ScanReportListViewSetV2, basename="v2scanreports"
-)
-router.register(
-    r"scanreporttables", views.ScanReportTableViewSet, basename="scanreporttables"
 )
 router.register(
     r"v2/scanreporttables",
     views.ScanReportTableViewSetV2,
     basename="v2scanreporttables",
-)
-
-router.register(
-    r"scanreportfields", views.ScanReportFieldViewSet, basename="scanreportfields"
 )
 router.register(
     r"v2/scanreportfields",
@@ -37,15 +23,9 @@ router.register(
     basename="v2scanreportfields",
 )
 router.register(
-    r"scanreportvalues", views.ScanReportValueViewSet, basename="scanreportvalues"
-)
-router.register(
     r"v2/scanreportvalues",
     views.ScanReportValueViewSetV2,
     basename="v2scanreportvalues",
-)
-router.register(
-    r"scanreportconcepts", views.ScanReportConceptViewSet, basename="scanreportconcepts"
 )
 router.register(
     r"v2/scanreportconcept",
@@ -53,22 +33,11 @@ router.register(
     basename="v2scanreportconcept",
 )
 router.register(
-    r"scanreportconceptsfilter",
-    views.ScanReportConceptFilterViewSet,
-    basename="scanreportconceptsfilter",
-)
-router.register(
     r"v2/scanreportconceptsfilter",
     views.ScanReportConceptFilterViewSetV2,
     basename="v2scanreportconceptsfilter",
 )
-
 router.register(r"datapartners", views.DataPartnerViewSet, basename="datapartners")
-
-router.register(r"omoptables", views.OmopTableViewSet, basename="omoptables")
-router.register(r"omopfields", views.OmopFieldViewSet, basename="omopfields")
-
-router.register(r"mappingrules", views.MappingRuleViewSet, basename="mappingrule")
 router.register(r"mappingruleslist", views.RulesList, basename="getlist")
 router.register(
     r"mappingruleslistsummary", views.SummaryRulesList, basename="getsummarylist"

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -9,9 +9,7 @@ router.register(
 
 router.register(r"users", views.UserViewSet, basename="users")
 router.register(r"usersfilter", views.UserFilterViewSet, basename="usersfilter")
-router.register(
-    r"v2/scanreports", views.ScanReportListViewSetV2, basename="v2scanreports"
-)
+router.register(r"v2/scanreports", views.ScanReportIndexV2, basename="v2scanreports")
 router.register(
     r"v2/scanreporttables",
     views.ScanReportTableViewSetV2,

--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -15,7 +15,6 @@ from shared.mapping.models import (
     MappingRule,
     OmopField,
     OmopTable,
-    Project,
     ScanReport,
     ScanReportConcept,
     ScanReportField,
@@ -734,37 +733,6 @@ class MappingRuleSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = MappingRule
         fields = "__all__"
-
-
-class ProjectSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
-    """
-    Serialiser for showing all details of a Project. Use in RetrieveViews
-    where User is permitted to view a particular Project.
-    """
-
-    class Meta:
-        model = Project
-        fields = "__all__"
-
-
-class ProjectNameSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
-    """
-    Serialiser for only showing the names of Projects. Use in non-admin ListViews.
-    """
-
-    class Meta:
-        model = Project
-        fields = ["id", "name", "members"]
-
-
-class ProjectDatasetSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
-    """
-    Serialiser for only showing the names of Projects. Use in non-admin ListViews.
-    """
-
-    class Meta:
-        model = Project
-        fields = ["name", "datasets", "members"]
 
 
 class GetRulesAnalysis(DynamicFieldsMixin, serializers.ModelSerializer):

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -6,6 +6,7 @@ from shared.files.views import FileDownloadView
 urlpatterns = [
     path("", include(router.urls)),
     path("datasets/", include("datasets.urls")),
+    path("projects/", include("projects.urls")),
     path(r"contenttypeid", views.GetContentTypeID.as_view(), name="contenttypeid"),
     path(
         r"countprojects/<int:dataset>",
@@ -51,17 +52,6 @@ urlpatterns = [
         "scanreports/<int:scanreport_pk>/mapping_rules/downloads/<int:pk>",
         FileDownloadView.as_view(),
         name="filedownload-get",
-    ),
-    path("projects/", views.ProjectListView.as_view(), name="project_list"),
-    path(
-        "projects/<int:pk>/",
-        views.ProjectRetrieveView.as_view(),
-        name="project_retrieve",
-    ),
-    path(
-        r"projects/update/<int:pk>/",
-        views.ProjectUpdateView.as_view(),
-        name="projects_update",
     ),
     path(r"user/me", views.UserDetailView.as_view(), name="currentuser"),
 ]

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -3,32 +3,12 @@ from api.router import router
 from django.urls import include, path
 from shared.files.views import FileDownloadView
 
+from .deprecated_urls import urlpatterns as deprecated_urlpatterns
+
 urlpatterns = [
     path("", include(router.urls)),
     path("datasets/", include("datasets.urls")),
     path("projects/", include("projects.urls")),
-    path(r"contenttypeid", views.GetContentTypeID.as_view(), name="contenttypeid"),
-    path(
-        r"countprojects/<int:dataset>",
-        views.CountProjects.as_view(),
-        name="countprojects",
-    ),
-    path(r"countstats/", views.CountStats.as_view(), name="countstats"),
-    path(
-        r"countstatsscanreport/",
-        views.CountStatsScanReport.as_view(),
-        name="countstatsscanreport",
-    ),
-    path(
-        r"countstatsscanreporttable/",
-        views.CountStatsScanReportTable.as_view(),
-        name="countstatsscanreporttable",
-    ),
-    path(
-        r"countstatsscanreporttablefield/",
-        views.CountStatsScanReportTableField.as_view(),
-        name="countstatsscanreporttablefield",
-    ),
     path(
         r"scanreports/<int:pk>/download/",
         views.DownloadScanReportViewSet.as_view({"get": "list"}),
@@ -55,3 +35,5 @@ urlpatterns = [
     ),
     path(r"user/me", views.UserDetailView.as_view(), name="currentuser"),
 ]
+
+urlpatterns += deprecated_urlpatterns

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -1,4 +1,5 @@
 from api import views
+from api.deprecated_router import router as deprecated_router
 from api.router import router
 from django.urls import include, path
 from shared.files.views import FileDownloadView
@@ -7,6 +8,7 @@ from .deprecated_urls import urlpatterns as deprecated_urlpatterns
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("", include(deprecated_router.urls)),
     path("datasets/", include("datasets.urls")),
     path("projects/", include("projects.urls")),
     path(

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
     ),
     path(
         "scanreports/<int:pk>/mapping_rules/",
-        views.StructuralMappingTableAPIView.as_view(),
+        views.MappingRulesList.as_view(),
         name="tables-structural-mapping",
     ),
     path(

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -5,6 +5,7 @@ from shared.files.views import FileDownloadView
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("datasets/", include("datasets.urls")),
     path(r"contenttypeid", views.GetContentTypeID.as_view(), name="contenttypeid"),
     path(
         r"countprojects/<int:dataset>",
@@ -28,36 +29,6 @@ urlpatterns = [
         name="countstatsscanreporttablefield",
     ),
     path(
-        r"datasets/",
-        views.DatasetListView.as_view(),
-        name="dataset_list",
-    ),
-    path(
-        r"datasets_data_partners/",
-        views.DatasetAndDataPartnerListView.as_view(),
-        name="dataset_data_partners_list",
-    ),
-    path(
-        r"datasets/<int:pk>/",
-        views.DatasetRetrieveView.as_view(),
-        name="dataset_retrieve",
-    ),
-    path(
-        r"datasets/update/<int:pk>/",
-        views.DatasetUpdateView.as_view(),
-        name="dataset_update",
-    ),
-    path(
-        r"datasets/delete/<int:pk>/",
-        views.DatasetDeleteView.as_view(),
-        name="dataset_delete",
-    ),
-    path(
-        r"datasets/create/",
-        views.DatasetCreateView.as_view(),
-        name="dataset_create",
-    ),
-    path(
         r"scanreports/<int:pk>/download/",
         views.DownloadScanReportViewSet.as_view({"get": "list"}),
     ),
@@ -65,11 +36,6 @@ urlpatterns = [
         "scanreports/<int:pk>/permissions/",
         views.ScanReportPermissionView.as_view(),
         name="scan-report-permissions",
-    ),
-    path(
-        "dataset/<int:pk>/permissions/",
-        views.DatasetPermissionView.as_view(),
-        name="dataset-permissions",
     ),
     path(
         "scanreports/<int:pk>/mapping_rules/",

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -12,7 +12,6 @@ from api.filters import ScanReportAccessFilter
 from api.paginations import CustomPagination
 from api.serializers import (
     ConceptSerializer,
-    ContentTypeSerializer,
     GetRulesAnalysis,
     MappingRuleSerializer,
     OmopFieldSerializer,
@@ -50,7 +49,6 @@ from rest_framework import status, viewsets
 from rest_framework.filters import OrderingFilter
 from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.data.models import Concept
@@ -61,7 +59,6 @@ from shared.mapping.models import (
     MappingRule,
     OmopField,
     OmopTable,
-    Project,
     ScanReport,
     ScanReportConcept,
     ScanReportField,
@@ -115,19 +112,6 @@ class ConceptFilterViewSetV2(viewsets.ReadOnlyModelViewSet):
         "concept_code": ["in", "exact"],
         "vocabulary_id": ["in", "exact"],
     }
-
-
-class CountProjects(APIView):
-    renderer_classes = (JSONRenderer,)
-
-    def get(self, request, dataset):
-        project_count = (
-            Project.objects.filter(datasets__exact=dataset).distinct().count()
-        )
-        content = {
-            "project_count": project_count,
-        }
-        return Response(content)
 
 
 class UserViewSet(viewsets.ReadOnlyModelViewSet):
@@ -1199,117 +1183,6 @@ class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):
                 "scan_report"
             ]
         )
-
-
-class CountStats(APIView):
-    renderer_classes = (JSONRenderer,)
-
-    def get(self, request, format=None):
-        scanreport_count = ScanReport.objects.count()
-        scanreporttable_count = ScanReportTable.objects.count()
-        scanreportfield_count = ScanReportField.objects.count()
-        scanreportvalue_count = ScanReportValue.objects.count()
-        scanreportmappingrule_count = MappingRule.objects.count()
-        content = {
-            "scanreport_count": scanreport_count,
-            "scanreporttable_count": scanreporttable_count,
-            "scanreportfield_count": scanreportfield_count,
-            "scanreportvalue_count": scanreportvalue_count,
-            "scanreportmappingrule_count": scanreportmappingrule_count,
-        }
-        return Response(content)
-
-
-class CountStatsScanReport(APIView):
-    renderer_classes = (JSONRenderer,)
-
-    def get(self, request, format=None):
-        parameterlist = list(
-            map(int, self.request.query_params["scan_report"].split(","))
-        )
-        jsonrecords = []
-        scanreporttable_count = "Disabled"
-        scanreportfield_count = "Disabled"
-        scanreportvalue_count = "Disabled"
-        scanreportmappingrule_count = "Disabled"
-
-        for scanreport in parameterlist:
-            scanreport_content = {
-                "scanreport": scanreport,
-                "scanreporttable_count": scanreporttable_count,
-                "scanreportfield_count": scanreportfield_count,
-                "scanreportvalue_count": scanreportvalue_count,
-                "scanreportmappingrule_count": scanreportmappingrule_count,
-            }
-            jsonrecords.append(scanreport_content)
-        return Response(jsonrecords)
-
-
-class CountStatsScanReportTable(APIView):
-    renderer_classes = (JSONRenderer,)
-
-    def get(self, request, format=None):
-        parameterlist = list(
-            map(int, self.request.query_params["scan_report_table"].split(","))
-        )
-        jsonrecords = []
-        for scanreporttable in parameterlist:
-            scanreportfield_count = ScanReportField.objects.filter(
-                scan_report_table=scanreporttable
-            ).count()
-            scanreportvalue_count = ScanReportValue.objects.filter(
-                scan_report_field__scan_report_table=scanreporttable
-            ).count()
-
-            scanreporttable_content = {
-                "scanreporttable": scanreporttable,
-                "scanreportfield_count": scanreportfield_count,
-                "scanreportvalue_count": scanreportvalue_count,
-            }
-            jsonrecords.append(scanreporttable_content)
-        return Response(jsonrecords)
-
-
-class CountStatsScanReportTableField(APIView):
-    renderer_classes = (JSONRenderer,)
-
-    def get(self, request, format=None):
-        parameterlist = list(
-            map(int, self.request.query_params["scan_report_field"].split(","))
-        )
-        jsonrecords = []
-        for scanreportfield in parameterlist:
-            scanreportvalue_count = ScanReportValue.objects.filter(
-                scan_report_field=scanreportfield
-            ).count()
-            scanreportfield_content = {
-                "scanreportfield": scanreportfield,
-                "scanreportvalue_count": scanreportvalue_count,
-            }
-            jsonrecords.append(scanreportfield_content)
-        return Response(jsonrecords)
-
-
-class GetContentTypeID(APIView):
-
-    def get(self, request, *args, **kwargs):
-        """
-        Retrieves the content type ID based on the provided type name.
-
-        Args:
-            self: The instance of the class.
-            request: The HTTP request object.
-            *args: Additional positional arguments.
-            **kwargs: Additional keyword arguments.
-        """
-        serializer = ContentTypeSerializer(data=request.query_params)
-        serializer.is_valid(raise_exception=True)
-        type_name = serializer.validated_data.get("type_name")
-        try:
-            content_type = ContentType.objects.get(model=type_name)
-            return Response({"content_type_id": content_type.id})
-        except ContentType.DoesNotExist:
-            return Response({"error": "Content type not found"}, status=404)
 
 
 class DownloadScanReportViewSet(viewsets.ViewSet):

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -13,23 +13,16 @@ from api.paginations import CustomPagination
 from api.serializers import (
     ConceptSerializer,
     GetRulesAnalysis,
-    MappingRuleSerializer,
-    OmopFieldSerializer,
-    OmopTableSerializer,
     ScanReportConceptSerializer,
     ScanReportCreateSerializer,
     ScanReportEditSerializer,
     ScanReportFieldEditSerializer,
-    ScanReportFieldListSerializer,
     ScanReportFieldListSerializerV2,
     ScanReportFilesSerializer,
     ScanReportTableEditSerializer,
-    ScanReportTableListSerializer,
     ScanReportTableListSerializerV2,
-    ScanReportValueEditSerializer,
     ScanReportValueViewSerializer,
     ScanReportValueViewSerializerV2,
-    ScanReportViewSerializer,
     ScanReportViewSerializerV2,
     UserSerializer,
 )
@@ -39,8 +32,7 @@ from datasets.serializers import DataPartnerSerializer
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models.query_utils import Q
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie
@@ -58,13 +50,11 @@ from shared.mapping.models import (
     DataPartner,
     MappingRule,
     OmopField,
-    OmopTable,
     ScanReport,
     ScanReportConcept,
     ScanReportField,
     ScanReportTable,
     ScanReportValue,
-    VisibilityChoices,
 )
 from shared.mapping.permissions import (
     CanAdmin,
@@ -84,22 +74,6 @@ from shared.services.rules_export import (
     get_mapping_rules_list,
     make_dag,
 )
-
-
-class ConceptViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Concept.objects.all()
-    serializer_class = ConceptSerializer
-
-
-class ConceptFilterViewSet(viewsets.ReadOnlyModelViewSet):
-    queryset = Concept.objects.all()
-    serializer_class = ConceptSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = {
-        "concept_id": ["in", "exact"],
-        "concept_code": ["in", "exact"],
-        "vocabulary_id": ["in", "exact"],
-    }
 
 
 class ConceptFilterViewSetV2(viewsets.ReadOnlyModelViewSet):
@@ -132,136 +106,6 @@ class UserDetailView(APIView):
     def get(self, request, *args, **kwargs):
         serializer = UserSerializer(request.user)
         return Response(serializer.data)
-
-
-class ScanReportListViewSet(viewsets.ModelViewSet):
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = {"parent_dataset": ["exact"]}
-
-    def get_permissions(self):
-        if self.request.method == "DELETE":
-            # user must be able to view and be an admin to delete a scan report
-            self.permission_classes = [IsAuthenticated & CanView & CanAdmin]
-        elif self.request.method in ["PUT", "PATCH"]:
-            # user must be able to view and be either an editor or and admin
-            # to edit a scan report
-            self.permission_classes = [IsAuthenticated & CanView & (CanEdit | CanAdmin)]
-        else:
-            self.permission_classes = [IsAuthenticated & (CanView | CanEdit | CanAdmin)]
-        return [permission() for permission in self.permission_classes]
-
-    def get_serializer_class(self):
-        if self.request.method in ["GET", "POST"]:
-            # use the view serialiser if on GET requests
-            return ScanReportViewSerializer
-        if self.request.method in ["PUT", "PATCH", "DELETE"]:
-            # use the edit serialiser when the user tries to alter the scan report
-            return ScanReportEditSerializer
-        return super().get_serializer_class()
-
-    def get_queryset(self):
-        """
-        If the User is the `AZ_FUNCTION_USER`, return all ScanReports.
-
-        Else, apply the correct rules regarding the visibility of the Dataset and SR,
-        and the membership of the User of viewer/editor/admin/author for either.
-        """
-        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
-            return ScanReport.objects.all().distinct()
-
-        return ScanReport.objects.filter(
-            (
-                Q(parent_dataset__visibility=VisibilityChoices.PUBLIC)
-                & (
-                    Q(
-                        # Dataset and SR are 'PUBLIC'
-                        visibility=VisibilityChoices.PUBLIC,
-                    )
-                    | (
-                        Q(visibility=VisibilityChoices.RESTRICTED)
-                        & (
-                            Q(
-                                # Dataset is public
-                                # SR is restricted but user is in SR viewers
-                                viewers=self.request.user.id,
-                            )
-                            | Q(
-                                # Dataset is public
-                                # SR is restricted but user is in SR editors
-                                editors=self.request.user.id,
-                            )
-                            | Q(
-                                # Dataset is public
-                                # SR is restricted but user is SR author
-                                author=self.request.user.id,
-                            )
-                            | Q(
-                                # Dataset is public
-                                # SR is restricted but user is in Dataset editors
-                                parent_dataset__editors=self.request.user.id,
-                            )
-                            | Q(
-                                # Dataset is public
-                                # SR is restricted but user is in Dataset admins
-                                parent_dataset__admins=self.request.user.id,
-                            )
-                        )
-                    )
-                )
-            )
-            | (
-                Q(parent_dataset__visibility=VisibilityChoices.RESTRICTED)
-                & (
-                    Q(
-                        # Dataset and SR are restricted
-                        # User is in Dataset admins
-                        parent_dataset__admins=self.request.user.id,
-                    )
-                    | Q(
-                        # Dataset and SR are restricted
-                        # User is in Dataset editors
-                        parent_dataset__editors=self.request.user.id,
-                    )
-                    | (
-                        Q(parent_dataset__viewers=self.request.user.id)
-                        & (
-                            Q(
-                                # Dataset and SR are restricted
-                                # User is in Dataset viewers and SR viewers
-                                viewers=self.request.user.id,
-                            )
-                            | Q(
-                                # Dataset and SR are restricted
-                                # User is in Dataset viewers and SR editors
-                                editors=self.request.user.id,
-                            )
-                            | Q(
-                                # Dataset and SR are restricted
-                                # User is in Dataset viewers and SR author
-                                author=self.request.user.id,
-                            )
-                            | Q(
-                                # Dataset is restricted
-                                # But SR is 'PUBLIC'
-                                visibility=VisibilityChoices.PUBLIC,
-                            )
-                        )
-                    )
-                )
-            ),
-            parent_dataset__project__members=self.request.user.id,
-        ).distinct()
-
-    def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(
-            data=request.data, many=isinstance(request.data, list)
-        )
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(
-            serializer.data, status=status.HTTP_201_CREATED, headers=headers
-        )
 
 
 class ScanReportListViewSetV2(viewsets.ModelViewSet):
@@ -509,102 +353,6 @@ class StructuralMappingTableAPIView(APIView):
         return qs
 
 
-class ScanReportTableViewSet(viewsets.ModelViewSet):
-    queryset = ScanReportTable.objects.all()
-    filter_backends = [DjangoFilterBackend, OrderingFilter, ScanReportAccessFilter]
-    ordering_fields = ["name", "person_id", "event_date"]
-    filterset_fields = {
-        "scan_report": ["in", "exact"],
-        "name": ["in", "icontains"],
-        "id": ["in", "exact"],
-    }
-
-    ordering = "-created_at"
-
-    def get_permissions(self):
-        if self.request.method == "DELETE":
-            # user must be able to view and be an admin to delete a scan report
-            self.permission_classes = [IsAuthenticated & CanView & CanAdmin]
-        elif self.request.method in ["PUT", "PATCH"]:
-            # user must be able to view and be either an editor or and admin
-            # to edit a scan report
-            self.permission_classes = [IsAuthenticated & CanView & (CanEdit | CanAdmin)]
-        else:
-            self.permission_classes = [IsAuthenticated & (CanView | CanEdit | CanAdmin)]
-        return [permission() for permission in self.permission_classes]
-
-    def get_serializer_class(self):
-        if self.request.method in ["GET", "POST"]:
-            # use the view serialiser if on GET requests
-            return ScanReportTableListSerializer
-        if self.request.method in ["PUT", "PATCH", "DELETE"]:
-            # use the edit serialiser when the user tries to alter the scan report
-            return ScanReportTableEditSerializer
-        return super().get_serializer_class()
-
-    def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(
-            data=request.data, many=isinstance(request.data, list)
-        )
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(
-            serializer.data, status=status.HTTP_201_CREATED, headers=headers
-        )
-
-    def partial_update(self, request: Any, *args: Any, **kwargs: Any) -> Response:
-        """
-        Perform a partial update on the instance.
-
-        Args:
-            request (Any): The request object.
-            *args (Any): Additional positional arguments.
-            **kwargs (Any): Additional keyword arguments.
-
-        Returns:
-            Response: The response object.
-        """
-        instance = self.get_object()
-        partial = kwargs.pop("partial", True)
-        serializer = self.get_serializer(instance, data=request.data, partial=partial)
-        serializer.is_valid(raise_exception=True)
-        self.perform_update(serializer)
-
-        # Delete the current mapping rules
-        delete_mapping_rules(instance.id)
-
-        # Map the table
-        scan_report_instance = instance.scan_report
-        data_dictionary_name = (
-            scan_report_instance.data_dictionary.name
-            if scan_report_instance.data_dictionary
-            else None
-        )
-
-        # Send to functions
-        msg = {
-            "scan_report_id": scan_report_instance.id,
-            "table_id": instance.id,
-            "data_dictionary_blob": data_dictionary_name,
-        }
-        base_url = f"{settings.AZ_URL}"
-        trigger = (
-            f"/api/orchestrators/{settings.AZ_RULES_NAME}?code={settings.AZ_RULES_KEY}"
-        )
-        try:
-            response = requests.post(urljoin(base_url, trigger), json=msg)
-            response.raise_for_status()
-        except request.exceptions.HTTPError as e:
-            logging.error(f"HTTP Trigger failed: {e}")
-
-        # TODO: The worker_id can be used for status, but we need to save it somewhere.
-        # resp_json = response.json()
-        # worker_id = resp_json.get("instanceId")
-
-        return Response(serializer.data)
-
-
 class ScanReportTableViewSetV2(viewsets.ModelViewSet):
     queryset = ScanReportTable.objects.all()
     filterset_fields = {
@@ -701,47 +449,6 @@ class ScanReportTableViewSetV2(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-class ScanReportFieldViewSet(viewsets.ModelViewSet):
-    queryset = ScanReportField.objects.all()
-    filter_backends = [DjangoFilterBackend, ScanReportAccessFilter]
-    filterset_fields = {
-        "scan_report_table": ["in", "exact"],
-        "name": ["in", "exact"],
-    }
-
-    def get_permissions(self):
-        if self.request.method == "DELETE":
-            # user must be able to view and be an admin to delete a scan report
-            self.permission_classes = [IsAuthenticated & CanView & CanAdmin]
-        elif self.request.method in ["PUT", "PATCH"]:
-            # user must be able to view and be either an editor or and admin
-            # to edit a scan report
-            self.permission_classes = [IsAuthenticated & CanView & (CanEdit | CanAdmin)]
-        else:
-            self.permission_classes = [IsAuthenticated & CanView | CanEdit | CanAdmin]
-        return [permission() for permission in self.permission_classes]
-
-    def get_serializer_class(self):
-        if self.request.method in ["GET", "POST"]:
-            # use the view serialiser if on GET requests
-            return ScanReportFieldListSerializer
-        if self.request.method in ["PUT", "PATCH", "DELETE"]:
-            # use the edit serialiser when the user tries to alter the scan report
-            return ScanReportFieldEditSerializer
-        return super().get_serializer_class()
-
-    def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(
-            data=request.data, many=isinstance(request.data, list)
-        )
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(
-            serializer.data, status=status.HTTP_201_CREATED, headers=headers
-        )
-
-
 class ScanReportFieldViewSetV2(viewsets.ModelViewSet):
     # Need to reset to see the change in data returned?!
     queryset = ScanReportField.objects.all()
@@ -779,62 +486,6 @@ class ScanReportFieldViewSetV2(viewsets.ModelViewSet):
     @method_decorator(vary_on_cookie)
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
-
-
-class ScanReportConceptViewSet(viewsets.ModelViewSet):
-    queryset = ScanReportConcept.objects.all()
-    serializer_class = ScanReportConceptSerializer
-
-    def create(self, request, *args, **kwargs):
-        body = request.data
-        if not isinstance(body, list):
-            # Extract the content_type
-            content_type_str = body.pop("content_type", None)
-            content_type = ContentType.objects.get(model=content_type_str)
-            body["content_type"] = content_type.id
-
-            concept = ScanReportConcept.objects.filter(
-                concept=body["concept"],
-                object_id=body["object_id"],
-                content_type=content_type,
-            )
-            if concept.count() > 0:
-                print("Can't add multiple concepts of the same id to the same object")
-                response = JsonResponse(
-                    {
-                        "status_code": 403,
-                        "ok": False,
-                        "statusText": "Can't add multiple concepts of the same id to the same object",
-                    }
-                )
-                response.status_code = 403
-                return response
-        else:
-            # for each item in the list, identify any existing SRConcepts that clash, and block their creation
-            # this method may be quite slow as it has to wait for each query
-            filtered = []
-            for item in body:
-                # Extract the content_type
-                content_type_str = item.pop("content_type", None)
-                content_type = ContentType.objects.get(model=content_type_str)
-                item["content_type"] = content_type.id
-
-                concept = ScanReportConcept.objects.filter(
-                    concept=item["concept"],
-                    object_id=item["object_id"],
-                    content_type=content_type,
-                )
-                if concept.count() == 0:
-                    filtered.append(item)
-            body = filtered
-
-        serializer = self.get_serializer(data=body, many=isinstance(body, list))
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(
-            serializer.data, status=status.HTTP_201_CREATED, headers=headers
-        )
 
 
 class ScanReportConceptViewSetV2(viewsets.ModelViewSet):
@@ -931,18 +582,6 @@ class ScanReportConceptViewSetV2(viewsets.ModelViewSet):
         )
 
 
-class ScanReportConceptFilterViewSet(viewsets.ModelViewSet):
-    queryset = ScanReportConcept.objects.all()
-    serializer_class = ScanReportConceptSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = {
-        "concept__concept_id": ["in", "exact"],
-        "object_id": ["in", "exact"],
-        "id": ["in", "exact"],
-        "content_type": ["in", "exact"],
-    }
-
-
 class ScanReportConceptFilterViewSetV2(viewsets.ModelViewSet):
     queryset = ScanReportConcept.objects.all().order_by("id")
     serializer_class = ScanReportConceptSerializer
@@ -970,21 +609,6 @@ class DataPartnerViewSet(viewsets.ModelViewSet):
         return Response(
             serializer.data, status=status.HTTP_201_CREATED, headers=headers
         )
-
-
-class OmopTableViewSet(viewsets.ModelViewSet):
-    queryset = OmopTable.objects.all()
-    serializer_class = OmopTableSerializer
-
-
-class OmopFieldViewSet(viewsets.ModelViewSet):
-    queryset = OmopField.objects.all()
-    serializer_class = OmopFieldSerializer
-
-
-class MappingRuleViewSet(viewsets.ModelViewSet):
-    queryset = MappingRule.objects.all()
-    serializer_class = MappingRuleSerializer
 
 
 class RulesList(viewsets.ModelViewSet):
@@ -1111,49 +735,6 @@ class AnalyseRules(viewsets.ModelViewSet):
     filterset_fields = ["id"]
 
 
-class ScanReportValueViewSet(viewsets.ModelViewSet):
-    queryset = ScanReportValue.objects.all()
-    filter_backends = [DjangoFilterBackend, ScanReportAccessFilter]
-    filterset_fields = {
-        "scan_report_field": ["in", "exact"],
-        "value": ["in", "exact"],
-        "id": ["in", "exact"],
-    }
-    ordering = "id"
-
-    def get_permissions(self):
-        if self.request.method == "DELETE":
-            # user must be able to view and be an admin to delete a scan report
-            self.permission_classes = [IsAuthenticated & CanView & CanAdmin]
-        elif self.request.method in ["PUT", "PATCH"]:
-            # user must be able to view and be either an editor or and admin
-            # to edit a scan report
-            self.permission_classes = [IsAuthenticated & CanView & (CanEdit | CanAdmin)]
-        else:
-            self.permission_classes = [IsAuthenticated & (CanView | CanEdit | CanAdmin)]
-        return [permission() for permission in self.permission_classes]
-
-    def get_serializer_class(self):
-        if self.request.method in ["GET", "POST"]:
-            # use the view serialiser if on GET requests
-            return ScanReportValueViewSerializer
-        if self.request.method in ["PUT", "PATCH", "DELETE"]:
-            # use the edit serialiser when the user tries to alter the scan report
-            return ScanReportValueEditSerializer
-        return super().get_serializer_class()
-
-    def create(self, request, *args, **kwargs):
-        serializer = self.get_serializer(
-            data=request.data, many=isinstance(request.data, list)
-        )
-        serializer.is_valid(raise_exception=True)
-        self.perform_create(serializer)
-        headers = self.get_success_headers(serializer.data)
-        return Response(
-            serializer.data, status=status.HTTP_201_CREATED, headers=headers
-        )
-
-
 class ScanReportValueViewSetV2(viewsets.ModelViewSet):
     queryset = ScanReportValue.objects.order_by("id").only(
         "id", "value", "frequency", "value_description", "scan_report_field"
@@ -1170,19 +751,6 @@ class ScanReportValueViewSetV2(viewsets.ModelViewSet):
     @method_decorator(vary_on_cookie)
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
-
-
-class ScanReportValuesFilterViewSetScanReport(viewsets.ModelViewSet):
-    serializer_class = ScanReportValueViewSerializer
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = ["scan_report_field__scan_report_table__scan_report"]
-
-    def get_queryset(self):
-        return ScanReportValue.objects.filter(
-            scan_report_field__scan_report_table__scan_report=self.request.GET[
-                "scan_report"
-            ]
-        )
 
 
 class DownloadScanReportViewSet(viewsets.ViewSet):

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -21,7 +21,6 @@ from api.serializers import (
     ScanReportFilesSerializer,
     ScanReportTableEditSerializer,
     ScanReportTableListSerializerV2,
-    ScanReportValueViewSerializer,
     ScanReportValueViewSerializerV2,
     ScanReportViewSerializerV2,
     UserSerializer,

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -13,10 +13,6 @@ from api.paginations import CustomPagination
 from api.serializers import (
     ConceptSerializer,
     ContentTypeSerializer,
-    DataPartnerSerializer,
-    DatasetAndDataPartnerViewSerializer,
-    DatasetEditSerializer,
-    DatasetViewSerializerV2,
     GetRulesAnalysis,
     MappingRuleSerializer,
     OmopFieldSerializer,
@@ -43,6 +39,7 @@ from api.serializers import (
 )
 from azure.storage.blob import BlobServiceClient
 from config import settings
+from datasets.serializers import DataPartnerSerializer
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
@@ -65,7 +62,6 @@ from shared.files.service import delete_blob, modify_filename, upload_blob
 from shared.mapping.models import (
     DataDictionary,
     DataPartner,
-    Dataset,
     MappingRule,
     OmopField,
     OmopTable,
@@ -82,7 +78,6 @@ from shared.mapping.permissions import (
     CanEdit,
     CanView,
     CanViewProject,
-    get_user_permissions_on_dataset,
     get_user_permissions_on_scan_report,
 )
 from shared.services.azurequeue import add_message
@@ -578,147 +573,6 @@ class StructuralMappingTableAPIView(APIView):
             )
 
         return qs
-
-
-class DatasetListView(generics.ListAPIView):
-    """
-    API view to show all datasets.
-    """
-
-    serializer_class = DatasetViewSerializerV2
-    filter_backends = [DjangoFilterBackend]
-    filterset_fields = {
-        "id": ["in"],
-        "data_partner": ["in", "exact"],
-        "hidden": ["in", "exact"],
-    }
-
-    def get_queryset(self):
-        """
-        If the User is the `AZ_FUNCTION_USER`, return all Datasets.
-
-        Else, return only the Datasets which are on projects a user is a member,
-        which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
-        """
-        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
-            return Dataset.objects.all().distinct()
-
-        return Dataset.objects.filter(
-            Q(visibility=VisibilityChoices.PUBLIC)
-            | Q(
-                viewers=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                editors=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            )
-            | Q(
-                admins=self.request.user.id,
-                visibility=VisibilityChoices.RESTRICTED,
-            ),
-            project__members=self.request.user.id,
-        ).distinct()
-
-
-class DatasetAndDataPartnerListView(generics.ListAPIView):
-    """
-    API view to show all datasets.
-    """
-
-    serializer_class = DatasetAndDataPartnerViewSerializer
-    pagination_class = CustomPagination
-    filter_backends = [DjangoFilterBackend, OrderingFilter]
-    ordering_fields = ["id", "name", "created_at", "visibility", "data_partner"]
-    filterset_fields = {
-        "id": ["in"],
-        "hidden": ["in", "exact"],
-        "name": ["in", "icontains"],
-    }
-    ordering = "-created_at"
-
-    def get_queryset(self):
-        """
-        If the User is the `AZ_FUNCTION_USER`, return all Datasets.
-
-        Else, return only the Datasets which are on projects a user is a member,
-        which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
-        """
-
-        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
-            return Dataset.objects.prefetch_related("data_partner").all().distinct()
-
-        return (
-            Dataset.objects.filter(
-                Q(visibility=VisibilityChoices.PUBLIC)
-                | Q(
-                    viewers=self.request.user.id,
-                    visibility=VisibilityChoices.RESTRICTED,
-                )
-                | Q(
-                    editors=self.request.user.id,
-                    visibility=VisibilityChoices.RESTRICTED,
-                )
-                | Q(
-                    admins=self.request.user.id,
-                    visibility=VisibilityChoices.RESTRICTED,
-                ),
-                project__members=self.request.user.id,
-            )
-            .prefetch_related("data_partner")
-            .distinct()
-            .order_by("-id")
-        )
-
-
-class DatasetCreateView(generics.CreateAPIView):
-    serializer_class = DatasetViewSerializerV2
-    queryset = Dataset.objects.all()
-
-    def perform_create(self, serializer):
-        admins = serializer.initial_data.get("admins")
-        # If no admins given, add the user uploading the dataset
-        if not admins:
-            serializer.save(admins=[self.request.user])
-        # If the user is not in the admins, add them
-        elif self.request.user.id not in admins:
-            serializer.save(admins=admins + [self.request.user.id])
-        # All is well, save
-        else:
-            serializer.save()
-
-
-class DatasetRetrieveView(generics.RetrieveAPIView):
-    """
-    This view should return a single dataset from an id
-    """
-
-    serializer_class = DatasetViewSerializerV2
-    permission_classes = [CanView | CanAdmin | CanEdit]
-
-    def get_queryset(self):
-        return Dataset.objects.filter(id=self.kwargs.get("pk"))
-
-
-class DatasetUpdateView(generics.UpdateAPIView):
-    serializer_class = DatasetEditSerializer
-    # User must be able to view and be an admin or an editor
-    permission_classes = [CanView & (CanAdmin | CanEdit)]
-
-    def get_queryset(self):
-        return Dataset.objects.filter(id=self.kwargs.get("pk"))
-
-    def get_serializer_context(self):
-        return {"projects": self.request.data.get("projects")}
-
-
-class DatasetDeleteView(generics.DestroyAPIView):
-    serializer_class = DatasetEditSerializer
-    # User must be able to view and be an admin
-    permission_classes = [CanView & CanAdmin]
-
-    def get_queryset(self):
-        return Dataset.objects.filter(id=self.kwargs.get("pk"))
 
 
 class ScanReportTableViewSet(viewsets.ModelViewSet):
@@ -1546,16 +1400,5 @@ class ScanReportPermissionView(APIView):
 
     def get(self, request, pk):
         permissions = get_user_permissions_on_scan_report(request, pk)
-
-        return Response({"permissions": permissions}, status=status.HTTP_200_OK)
-
-
-class DatasetPermissionView(APIView):
-    """
-    API for permissions a user has on a specific dataset.
-    """
-
-    def get(self, request, pk):
-        permissions = get_user_permissions_on_dataset(request, pk)
 
         return Response({"permissions": permissions}, status=status.HTTP_200_OK)

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -105,7 +105,7 @@ class UserDetailView(APIView):
         return Response(serializer.data)
 
 
-class ScanReportListViewSetV2(viewsets.ModelViewSet):
+class ScanReportIndexV2(viewsets.ModelViewSet):
     """
     A custom viewset for retrieving and listing scan reports with additional functionality for version 2.
 

--- a/app/api/config/settings.py
+++ b/app/api/config/settings.py
@@ -58,6 +58,7 @@ INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",
     "django.contrib.staticfiles",
     "extra_views",
+    "datasets",
     "api",
     "shared.data",
     "shared.mapping",

--- a/app/api/config/settings.py
+++ b/app/api/config/settings.py
@@ -59,6 +59,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "extra_views",
     "datasets",
+    "projects",
     "api",
     "shared.data",
     "shared.mapping",

--- a/app/api/datasets/apps.py
+++ b/app/api/datasets/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class DatasetsConfig(AppConfig):
+    name = "datasets"

--- a/app/api/datasets/serializers.py
+++ b/app/api/datasets/serializers.py
@@ -1,0 +1,115 @@
+from drf_dynamic_fields import DynamicFieldsMixin  # type: ignore
+from rest_framework import serializers
+from shared.mapping.models import DataPartner, Dataset
+from shared.mapping.permissions import is_admin, is_az_function_user
+
+
+class DataPartnerSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = DataPartner
+        fields = "__all__"
+
+
+class DatasetSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = ("id", "name")
+
+
+class DatasetViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = "__all__"
+
+
+class DatasetAndDataPartnerViewSerializer(
+    DynamicFieldsMixin, serializers.ModelSerializer
+):
+    data_partner = DataPartnerSerializer(read_only=True)
+
+    class Meta:
+        model = Dataset
+        fields = (
+            "id",
+            "name",
+            "data_partner",
+            "admins",
+            "visibility",
+            "created_at",
+            "hidden",
+        )
+
+
+class DatasetViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = (
+            "id",
+            "name",
+            "data_partner",
+            "admins",
+            "visibility",
+            "created_at",
+            "hidden",
+            "updated_at",
+            "projects",
+            "viewers",
+            "editors",
+        )
+
+
+class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    def validate_viewers(self, viewers):
+        if request := self.context.get("request"):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
+                raise serializers.ValidationError(
+                    "You must be an admin to change this field."
+                )
+        return viewers
+
+    def validate_editors(self, editors):
+        if request := self.context.get("request"):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
+                raise serializers.ValidationError(
+                    "You must be an admin to change this field."
+                )
+        return editors
+
+    def validate_admins(self, admins):
+        if request := self.context.get("request"):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
+                raise serializers.ValidationError(
+                    "You must be an admin to change this field."
+                )
+        return admins
+
+    def save(self, **kwargs):
+        projects = self.context["projects"]
+
+        if self.instance is not None:
+            self.instance = self.update(self.instance, self.validated_data)
+            return self.instance
+        dataset = Dataset.objects.create(**self.validated_data, projects=projects)
+        return dataset
+
+    class Meta:
+        model = Dataset
+        fields = (
+            "id",
+            "name",
+            "data_partner",
+            "admins",
+            "visibility",
+            "created_at",
+            "hidden",
+            "updated_at",
+            "projects",
+            "viewers",
+            "editors",
+        )

--- a/app/api/datasets/urls.py
+++ b/app/api/datasets/urls.py
@@ -1,0 +1,40 @@
+from datasets import views
+from django.urls import path
+
+urlpatterns = [
+    path(
+        r"datasets/",
+        views.DatasetListView.as_view(),
+        name="dataset_list",
+    ),
+    path(
+        r"datasets_data_partners/",
+        views.DatasetAndDataPartnerListView.as_view(),
+        name="dataset_data_partners_list",
+    ),
+    path(
+        r"datasets/<int:pk>/",
+        views.DatasetRetrieveView.as_view(),
+        name="dataset_retrieve",
+    ),
+    path(
+        r"datasets/update/<int:pk>/",
+        views.DatasetUpdateView.as_view(),
+        name="dataset_update",
+    ),
+    path(
+        r"datasets/delete/<int:pk>/",
+        views.DatasetDeleteView.as_view(),
+        name="dataset_delete",
+    ),
+    path(
+        r"datasets/create/",
+        views.DatasetCreateView.as_view(),
+        name="dataset_create",
+    ),
+    path(
+        "dataset/<int:pk>/permissions/",
+        views.DatasetPermissionView.as_view(),
+        name="dataset-permissions",
+    ),
+]

--- a/app/api/datasets/urls.py
+++ b/app/api/datasets/urls.py
@@ -3,7 +3,7 @@ from django.urls import path
 
 urlpatterns = [
     path(
-        r"datasets/",
+        r"",
         views.DatasetListView.as_view(),
         name="dataset_list",
     ),
@@ -13,27 +13,27 @@ urlpatterns = [
         name="dataset_data_partners_list",
     ),
     path(
-        r"datasets/<int:pk>/",
+        r"<int:pk>/",
         views.DatasetRetrieveView.as_view(),
         name="dataset_retrieve",
     ),
     path(
-        r"datasets/update/<int:pk>/",
+        r"update/<int:pk>/",
         views.DatasetUpdateView.as_view(),
         name="dataset_update",
     ),
     path(
-        r"datasets/delete/<int:pk>/",
+        r"delete/<int:pk>/",
         views.DatasetDeleteView.as_view(),
         name="dataset_delete",
     ),
     path(
-        r"datasets/create/",
+        r"create/",
         views.DatasetCreateView.as_view(),
         name="dataset_create",
     ),
     path(
-        "dataset/<int:pk>/permissions/",
+        "<int:pk>/permissions/",
         views.DatasetPermissionView.as_view(),
         name="dataset-permissions",
     ),

--- a/app/api/datasets/views.py
+++ b/app/api/datasets/views.py
@@ -1,0 +1,173 @@
+import os
+
+from api.paginations import CustomPagination
+from datasets.serializers import (
+    DatasetAndDataPartnerViewSerializer,
+    DatasetEditSerializer,
+    DatasetViewSerializerV2,
+)
+from django.db.models.query_utils import Q
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import generics, status
+from rest_framework.filters import OrderingFilter
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from shared.mapping.models import Dataset, VisibilityChoices
+from shared.mapping.permissions import (
+    CanAdmin,
+    CanEdit,
+    CanView,
+    get_user_permissions_on_dataset,
+)
+
+
+class DatasetListView(generics.ListAPIView):
+    """
+    API view to show all datasets.
+    """
+
+    serializer_class = DatasetViewSerializerV2
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {
+        "id": ["in"],
+        "data_partner": ["in", "exact"],
+        "hidden": ["in", "exact"],
+    }
+
+    def get_queryset(self):
+        """
+        If the User is the `AZ_FUNCTION_USER`, return all Datasets.
+
+        Else, return only the Datasets which are on projects a user is a member,
+        which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
+        """
+        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return Dataset.objects.all().distinct()
+
+        return Dataset.objects.filter(
+            Q(visibility=VisibilityChoices.PUBLIC)
+            | Q(
+                viewers=self.request.user.id,
+                visibility=VisibilityChoices.RESTRICTED,
+            )
+            | Q(
+                editors=self.request.user.id,
+                visibility=VisibilityChoices.RESTRICTED,
+            )
+            | Q(
+                admins=self.request.user.id,
+                visibility=VisibilityChoices.RESTRICTED,
+            ),
+            project__members=self.request.user.id,
+        ).distinct()
+
+
+class DatasetAndDataPartnerListView(generics.ListAPIView):
+    """
+    API view to show all datasets.
+    """
+
+    serializer_class = DatasetAndDataPartnerViewSerializer
+    pagination_class = CustomPagination
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["id", "name", "created_at", "visibility", "data_partner"]
+    filterset_fields = {
+        "id": ["in"],
+        "hidden": ["in", "exact"],
+        "name": ["in", "icontains"],
+    }
+    ordering = "-created_at"
+
+    def get_queryset(self):
+        """
+        If the User is the `AZ_FUNCTION_USER`, return all Datasets.
+
+        Else, return only the Datasets which are on projects a user is a member,
+        which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
+        """
+
+        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return Dataset.objects.prefetch_related("data_partner").all().distinct()
+
+        return (
+            Dataset.objects.filter(
+                Q(visibility=VisibilityChoices.PUBLIC)
+                | Q(
+                    viewers=self.request.user.id,
+                    visibility=VisibilityChoices.RESTRICTED,
+                )
+                | Q(
+                    editors=self.request.user.id,
+                    visibility=VisibilityChoices.RESTRICTED,
+                )
+                | Q(
+                    admins=self.request.user.id,
+                    visibility=VisibilityChoices.RESTRICTED,
+                ),
+                project__members=self.request.user.id,
+            )
+            .prefetch_related("data_partner")
+            .distinct()
+            .order_by("-id")
+        )
+
+
+class DatasetCreateView(generics.CreateAPIView):
+    serializer_class = DatasetViewSerializerV2
+    queryset = Dataset.objects.all()
+
+    def perform_create(self, serializer):
+        admins = serializer.initial_data.get("admins")
+        # If no admins given, add the user uploading the dataset
+        if not admins:
+            serializer.save(admins=[self.request.user])
+        # If the user is not in the admins, add them
+        elif self.request.user.id not in admins:
+            serializer.save(admins=admins + [self.request.user.id])
+        # All is well, save
+        else:
+            serializer.save()
+
+
+class DatasetRetrieveView(generics.RetrieveAPIView):
+    """
+    This view should return a single dataset from an id
+    """
+
+    serializer_class = DatasetViewSerializerV2
+    permission_classes = [CanView | CanAdmin | CanEdit]
+
+    def get_queryset(self):
+        return Dataset.objects.filter(id=self.kwargs.get("pk"))
+
+
+class DatasetUpdateView(generics.UpdateAPIView):
+    serializer_class = DatasetEditSerializer
+    # User must be able to view and be an admin or an editor
+    permission_classes = [CanView & (CanAdmin | CanEdit)]
+
+    def get_queryset(self):
+        return Dataset.objects.filter(id=self.kwargs.get("pk"))
+
+    def get_serializer_context(self):
+        return {"projects": self.request.data.get("projects")}
+
+
+class DatasetDeleteView(generics.DestroyAPIView):
+    serializer_class = DatasetEditSerializer
+    # User must be able to view and be an admin
+    permission_classes = [CanView & CanAdmin]
+
+    def get_queryset(self):
+        return Dataset.objects.filter(id=self.kwargs.get("pk"))
+
+
+class DatasetPermissionView(APIView):
+    """
+    API for permissions a user has on a specific dataset.
+    """
+
+    def get(self, request, pk):
+        permissions = get_user_permissions_on_dataset(request, pk)
+
+        return Response({"permissions": permissions}, status=status.HTTP_200_OK)

--- a/app/api/projects/apps.py
+++ b/app/api/projects/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+
+class ProjectsConfig(AppConfig):
+    name = "projects"

--- a/app/api/projects/serializers.py
+++ b/app/api/projects/serializers.py
@@ -1,0 +1,34 @@
+from drf_dynamic_fields import DynamicFieldsMixin  # type: ignore
+from rest_framework import serializers
+from shared.mapping.models import Project
+
+
+class ProjectSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    """
+    Serialiser for showing all details of a Project. Use in RetrieveViews
+    where User is permitted to view a particular Project.
+    """
+
+    class Meta:
+        model = Project
+        fields = "__all__"
+
+
+class ProjectNameSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    """
+    Serialiser for only showing the names of Projects. Use in non-admin ListViews.
+    """
+
+    class Meta:
+        model = Project
+        fields = ["id", "name", "members"]
+
+
+class ProjectDatasetSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    """
+    Serialiser for only showing the names of Projects. Use in non-admin ListViews.
+    """
+
+    class Meta:
+        model = Project
+        fields = ["name", "datasets", "members"]

--- a/app/api/projects/urls.py
+++ b/app/api/projects/urls.py
@@ -2,10 +2,10 @@ from django.urls import path
 from projects import views
 
 urlpatterns = [
-    path("", views.ProjectListView.as_view(), name="project_list"),
+    path("", views.ProjectList.as_view(), name="project_list"),
     path(
         "<int:pk>/",
-        views.ProjectRetrieveView.as_view(),
-        name="project_retrieve",
+        views.ProjectDetail.as_view(),
+        name="project_detail",
     ),
 ]

--- a/app/api/projects/urls.py
+++ b/app/api/projects/urls.py
@@ -1,0 +1,16 @@
+from django.urls import path
+from projects import views
+
+urlpatterns = [
+    path("", views.ProjectListView.as_view(), name="project_list"),
+    path(
+        "<int:pk>/",
+        views.ProjectRetrieveView.as_view(),
+        name="project_retrieve",
+    ),
+    path(
+        r"update/<int:pk>/",
+        views.ProjectUpdateView.as_view(),
+        name="projects_update",
+    ),
+]

--- a/app/api/projects/urls.py
+++ b/app/api/projects/urls.py
@@ -8,9 +8,4 @@ urlpatterns = [
         views.ProjectRetrieveView.as_view(),
         name="project_retrieve",
     ),
-    path(
-        r"update/<int:pk>/",
-        views.ProjectUpdateView.as_view(),
-        name="projects_update",
-    ),
 ]

--- a/app/api/projects/views.py
+++ b/app/api/projects/views.py
@@ -1,0 +1,56 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from projects.serializers import (
+    ProjectDatasetSerializer,
+    ProjectNameSerializer,
+    ProjectSerializer,
+)
+from rest_framework import generics
+from rest_framework.generics import ListAPIView, RetrieveAPIView
+from rest_framework.permissions import IsAuthenticated
+from shared.mapping.models import Project
+from shared.mapping.permissions import CanViewProject
+
+
+class ProjectListView(ListAPIView):
+    """
+    API view to show all projects' names.
+    """
+
+    permission_classes = [IsAuthenticated]
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {"name": ["in", "exact"]}
+
+    def get_serializer_class(self):
+        if (
+            self.request.GET.get("name") is not None
+            or self.request.GET.get("name__in") is not None
+        ):
+            return ProjectSerializer
+        if self.request.GET.get("datasets") is not None:
+            return ProjectDatasetSerializer
+
+        return ProjectNameSerializer
+
+    def get_queryset(self):
+        if dataset := self.request.GET.get("dataset"):
+            return Project.objects.filter(
+                datasets__exact=dataset, members__id=self.request.user.id
+            ).distinct()
+
+        return Project.objects.all()
+
+
+class ProjectRetrieveView(RetrieveAPIView):
+    """
+    API view to retrieve a single project.
+    Will return 403 Forbidden if User isn't a member.
+    """
+
+    permission_classes = [CanViewProject]
+    serializer_class = ProjectSerializer
+    queryset = Project.objects.all()
+
+
+class ProjectUpdateView(generics.UpdateAPIView):
+    serializer_class = ProjectSerializer
+    queryset = Project.objects.all()

--- a/app/api/projects/views.py
+++ b/app/api/projects/views.py
@@ -49,8 +49,3 @@ class ProjectRetrieveView(RetrieveAPIView):
     permission_classes = [CanViewProject]
     serializer_class = ProjectSerializer
     queryset = Project.objects.all()
-
-
-class ProjectUpdateView(generics.UpdateAPIView):
-    serializer_class = ProjectSerializer
-    queryset = Project.objects.all()

--- a/app/api/projects/views.py
+++ b/app/api/projects/views.py
@@ -11,7 +11,7 @@ from shared.mapping.models import Project
 from shared.mapping.permissions import CanViewProject
 
 
-class ProjectListView(ListAPIView):
+class ProjectList(ListAPIView):
     """
     API view to show all projects' names.
     """
@@ -40,7 +40,7 @@ class ProjectListView(ListAPIView):
         return Project.objects.all()
 
 
-class ProjectRetrieveView(RetrieveAPIView):
+class ProjectDetail(RetrieveAPIView):
     """
     API view to retrieve a single project.
     Will return 403 Forbidden if User isn't a member.

--- a/app/api/pyproject.toml
+++ b/app/api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "api"
-version = "2.2.11"
+version = "2.2.13"
 description = "Web app for Carrot-Mapper"
 authors = ["Sam Cox <sam.cox@nottingham.ac.uk>", "Philip Quinlan <philip.quinlan@nottingham.ac.uk>"]
 license = "MIT"

--- a/app/api/test/test_permissions.py
+++ b/app/api/test/test_permissions.py
@@ -1,9 +1,9 @@
 import os
 from unittest import mock
 
-from api.views import ProjectRetrieveView
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from projects.views import ProjectDetail
 from rest_framework.authtoken.models import Token
 from rest_framework.generics import GenericAPIView
 from rest_framework.test import APIRequestFactory, force_authenticate
@@ -392,7 +392,7 @@ class TestCanViewProject(TestCase):
         # Request factory for setting up requests
         self.factory = APIRequestFactory()
         # The instance of the view required for the permission class
-        self.view = ProjectRetrieveView.as_view()
+        self.view = ProjectDetail.as_view()
 
         # The permission class
         self.permission = CanViewProject()

--- a/app/api/test/test_serializers.py
+++ b/app/api/test/test_serializers.py
@@ -1,9 +1,7 @@
-import os
-
-from api.serializers import DatasetEditSerializer, ScanReportEditSerializer
+from api.serializers import ScanReportEditSerializer
+from datasets.serializers import DatasetEditSerializer
 from django.contrib.auth import get_user_model
 from django.test import TestCase
-from rest_framework.authtoken.models import Token
 from rest_framework.serializers import ValidationError
 from rest_framework.test import APIRequestFactory
 from shared.mapping.models import (

--- a/app/api/test/test_views.py
+++ b/app/api/test/test_views.py
@@ -3,7 +3,7 @@ from datetime import date
 from unittest import mock
 
 import pytest
-from api.views import DatasetListView
+from datasets.views import DatasetListView
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, TransactionTestCase

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -5,7 +5,9 @@ import { redirect } from "next/navigation";
 
 const fetchKeys = {
   list: (filter?: string) =>
-    filter ? `datasets_data_partners/?${filter}` : "datasets_data_partners/",
+    filter
+      ? `datasets/datasets_data_partners/?${filter}`
+      : "datasets/datasets_data_partners/",
   dataset: (id: string) => `datasets/${id}/`,
   datasetList: (dataPartnerId?: string) =>
     dataPartnerId
@@ -16,12 +18,12 @@ const fetchKeys = {
   projects: (dataset?: string) =>
     dataset ? `projects/?dataset=${dataset}` : "projects/",
   updateDataset: (id: number) => `datasets/update/${id}/`,
-  permissions: (id: string) => `dataset/${id}/permissions/`,
+  permissions: (id: string) => `datasets/${id}/permissions/`,
   create: "datasets/create/",
 };
 
 export async function getDataSets(
-  filter: string | undefined
+  filter: string | undefined,
 ): Promise<PaginatedResponse<DataSet>> {
   try {
     return await request<DataSet>(fetchKeys.list(filter));
@@ -53,7 +55,7 @@ export async function getDataSet(id: string): Promise<DataSetSRList> {
 }
 
 export async function getDatasetList(
-  filter?: string
+  filter?: string,
 ): Promise<DataSetSRList[]> {
   try {
     return await request<DataSetSRList>(fetchKeys.datasetList(filter));
@@ -122,7 +124,7 @@ export async function updateDatasetDetails(id: number, data: {}) {
 }
 
 export async function getDatasetPermissions(
-  id: string
+  id: string,
 ): Promise<PermissionsResponse> {
   try {
     return await request<PermissionsResponse>(fetchKeys.permissions(id));

--- a/app/react-client-app/src/views/DatasetTbl.jsx
+++ b/app/react-client-app/src/views/DatasetTbl.jsx
@@ -1,268 +1,420 @@
-import React, { useState, useEffect, useRef } from 'react'
-import { Center, Flex, Spinner, Table, Thead, Tbody, Tr, Th, Td, Spacer, TableCaption, Link, Button, HStack, Select, Text, useDisclosure, ScaleFade } from "@chakra-ui/react"
-import { useGet, usePatch } from '../api/values'
-import { set_pagination_variables } from '../api/pagination_helpers'
-import PageHeading from '../components/PageHeading'
-import ConceptTag from '../components/ConceptTag'
-import CCBreadcrumbBar from '../components/CCBreadcrumbBar'
-import moment from 'moment';
-import { ViewIcon, ViewOffIcon } from '@chakra-ui/icons'
-import Pagination from 'react-js-pagination'
-import ToastAlert from '../components/ToastAlert'
+import React, { useState, useEffect, useRef } from "react";
+import {
+  Center,
+  Flex,
+  Spinner,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Spacer,
+  TableCaption,
+  Link,
+  Button,
+  HStack,
+  Select,
+  Text,
+  useDisclosure,
+  ScaleFade,
+} from "@chakra-ui/react";
+import { useGet, usePatch } from "../api/values";
+import { set_pagination_variables } from "../api/pagination_helpers";
+import PageHeading from "../components/PageHeading";
+import ConceptTag from "../components/ConceptTag";
+import CCBreadcrumbBar from "../components/CCBreadcrumbBar";
+import moment from "moment";
+import { ViewIcon, ViewOffIcon } from "@chakra-ui/icons";
+import Pagination from "react-js-pagination";
+import ToastAlert from "../components/ToastAlert";
 
 const DatasetTbl = (props) => {
-    const data = useRef(null);
-    const [displayedData, setDisplayedData] = useState(null);
-    const activeDatasets = useRef(null);
-    const active = useRef(true)
-    const [page_size, set_page_size] = useState(10)
-    const archivedDatasets = useRef(null);
-    const [loadingMessage, setLoadingMessage] = useState("Loading Datasets")
-    const [datapartnerFilter, setDataPartnerFilter] = useState("All");
-    const [title, setTitle] = useState("Datasets");
-    const [alert, setAlert] = useState({ hidden: true, title: '', description: '', status: 'error' });
-    const { isOpen, onOpen, onClose } = useDisclosure()
-    const [currentPage, setCurrentPage] = useState(1);
-    const [totalItemsCount, setTotalItemsCount] = useState(null);
-    const [firstLoad, setFirstLoad] = useState(true);
+  const data = useRef(null);
+  const [displayedData, setDisplayedData] = useState(null);
+  const activeDatasets = useRef(null);
+  const active = useRef(true);
+  const [page_size, set_page_size] = useState(10);
+  const archivedDatasets = useRef(null);
+  const [loadingMessage, setLoadingMessage] = useState("Loading Datasets");
+  const [datapartnerFilter, setDataPartnerFilter] = useState("All");
+  const [title, setTitle] = useState("Datasets");
+  const [alert, setAlert] = useState({
+    hidden: true,
+    title: "",
+    description: "",
+    status: "error",
+  });
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalItemsCount, setTotalItemsCount] = useState(null);
+  const [firstLoad, setFirstLoad] = useState(true);
 
-    useEffect(async () => {
-        // run on initial page load
-        props.setTitle(null);
-        let { local_page, local_page_size } = await set_pagination_variables(window.location.search, page_size, set_page_size, currentPage, setCurrentPage);
-
-        // set active.current based on the presence of the filter=archived flag.
-        if (window.location.search.search('filter=archived') > 0) {
-            active.current = false
-            window.history.pushState({}, '', `/datasets/?filter=archived&p=${local_page}&page_size=${local_page_size}`)
-        }
-        else
-        {
-            active.current = true
-            window.history.pushState({}, '', `/datasets/?p=${local_page}&page_size=${local_page_size}`)
-        }
-
-        setFirstLoad(false)
-    }, []);
-
-    useEffect(async () => {
-        // if not the first load, then load data etc. This clause avoids an initial call using the default values of
-        // currentPage and page_size, which is not desired.
-        if (!firstLoad) {
-            // run on initial page load
-            props.setTitle(null);
-            window.location.search.search('filter=archived') > 0 ? active.current = false : active.current = true
-            // get datasets and data partners, and sort by id
-            let datasets = await useGet(`/datasets_data_partners/?p=${currentPage}&page_size=${page_size}`);
-            setTotalItemsCount(datasets.count)
-            datasets = datasets.results.sort((b, a) => (a.id > b.id) ? 1 : ((b.id > a.id) ? -1 : 0));
-            // for each dataset use the data partner and admin ids to get name to display
-            // get list of unique data partner and admin ids
-            const adminObject = {};
-            datasets.map((dataset) => {
-                adminObject[dataset.admin] = true;
-                const created_at = {};
-                created_at.created_at = dataset.created_at;
-                created_at.displayString = moment(dataset.created_at.toString()).format("MMM. DD, YYYY, h:mm a");
-                dataset.created_at = created_at;
-            });
-
-            data.current = datasets
-            activeDatasets.current = datasets.filter(dataset => dataset.hidden == false)
-            archivedDatasets.current = datasets.filter(dataset => dataset.hidden == true)
-            active.current ? setDisplayedData(activeDatasets.current) : setDisplayedData(archivedDatasets.current);
-            active.current ? setTitle("Active Datasets") : setTitle("Archived Datasets");
-            setLoadingMessage(null)
-        }
-    }, [currentPage, page_size, firstLoad]);
-
-    const onPageChange = (page) => {
-        if (active.current == false) {
-            window.history.pushState({}, '', `/datasets/?filter=archived&p=${page}&page_size=${page_size}`)
-        }
-        else
-        {
-            window.history.pushState({}, '', `/datasets/?p=${page}&page_size=${page_size}`)
-        }
-        setCurrentPage(page)
-    }
-
-    const activateOrArchiveDataset = async (id, theIndicator) => {
-        try {
-            setDisplayedData(currentData => currentData.map(dataset => dataset.id == id ? { ...dataset, loading: true } : dataset))
-            const patchData = { hidden: theIndicator }
-            const res = await usePatch(`/datasets/update/${id}/`, patchData)
-            data.current = data.current.map(dataset => dataset.id == id ? { ...dataset, hidden: theIndicator } : dataset)
-            activeDatasets.current = data.current.filter(dataset => dataset.hidden == false)
-            archivedDatasets.current = data.current.filter(dataset => dataset.hidden == true)
-            active.current ? setDisplayedData(activeDatasets.current) : setDisplayedData(archivedDatasets.current)
-        }
-        catch (err) {
-            setAlert({
-                status: 'error',
-                title: 'Unable to archive dataset ' + id,
-                description: ""
-            })
-            onOpen()
-            setDisplayedData(currentData => currentData.map(scanreport => scanreport.id == id ? { ...scanreport, loading: false } : scanreport))
-        }
-    }
-
-    // show active datasets and change url when 'Active Datasets' button is pressed
-    const goToActive = () => {
-        if (active.current == false) {
-            active.current = true
-            setDisplayedData(activeDatasets.current)
-            window.history.pushState({}, '', `/datasets/?p=${currentPage}&page_size=${page_size}`)
-            setTitle("Active Datasets")
-        }
-    }
-
-    // show archived datasets and change url when 'Archived Datasets' button is pressed
-    const goToArchived = () => {
-        if (active.current == true) {
-            active.current = false
-            setDisplayedData(archivedDatasets.current)
-            window.history.pushState({}, '', `/datasets/?filter=archived&p=${currentPage}&page_size=${page_size}`)
-            setTitle("Archived Datasets");
-        }
-    }
-
-    const applyFilters = (variable) => {
-        let newData = variable.map(dataset => dataset)
-
-        if (datapartnerFilter !== "All") {
-            newData = newData.filter(dataset => dataset.data_partner.name === datapartnerFilter)
-        }
-        return newData
-    }
-
-    const removeFilter = (a, b) => {
-        if (a.includes("Data Partner")) {
-            setDataPartnerFilter("All")
-        }
-    }
-
-    if (loadingMessage) {
-        //Render Loading State
-        return (
-            <div>
-                <Flex padding="30px">
-                    <Spinner />
-                    <Flex marginLeft="10px">{loadingMessage}</Flex>
-                </Flex>
-            </div>
-        )
-    }
-
-    return (
-        <div>
-            <CCBreadcrumbBar>
-                <Link href={"/"}>Home</Link>
-                <Link href={"/datasets/"}>Datasets</Link>
-            </CCBreadcrumbBar>
-            {isOpen &&
-                <ScaleFade initialScale={0.9} in={isOpen}>
-                    <ToastAlert hide={onClose} title={alert.title} status={alert.status} description={alert.description} />
-                </ScaleFade>
-            }
-            <Flex>
-                <PageHeading text={title} />
-                <Spacer />
-                <Button disabled={title === "Active Datasets"} variant="blue" mr="10px" onClick={goToActive}>
-                    Active Datasets
-                </Button>
-                <Button disabled={title === "Archived Datasets"} variant="blue" onClick={goToArchived}>
-                    Archived Datasets
-                 </Button>
-            </Flex>
-            <Center>
-                <Pagination
-                    activePage={currentPage}
-                    itemsCountPerPage={page_size}
-                    totalItemsCount={totalItemsCount}
-                    pageRangeDisplayed={5}
-                    onChange={onPageChange}
-                    itemClass='btn paginate-inactive'
-                    activeClass='btn paginate-active'
-                />
-            </Center>
-            <HStack>
-                <Text style={{ fontWeight: "bold" }}>Applied Filters: </Text>
-                {[{ title: "Data Partner -", filter: datapartnerFilter }].map(filter => {
-                    if (filter.filter === "All") {
-                        return null
-                    }
-                    else {
-                        return (
-                            <ConceptTag key={filter.title} conceptName={filter.filter} conceptId={filter.title} conceptIdentifier={filter.title} itemId={filter.title} handleDelete={removeFilter} />
-                        )
-                    }
-                })}
-            </HStack>
-            <Table w="100%" variant="striped" colorScheme="greyBasic">
-                <TableCaption></TableCaption>
-                <Thead>
-                    <Tr className={"mediumTbl"}>
-                        <Th style={{ fontSize: "16px" }}>ID</Th>
-                        <Th>Name</Th>
-                        <Select minW="130px" style={{ fontWeight: "bold" }} variant="unstyled" value="Data Partner" readOnly onChange={(option) => setDataPartnerFilter(option.target.value)}>
-                            <option style={{ fontWeight: "bold" }} disabled>Data Partner</option>
-                            <>
-                                {[...[...new Set(displayedData.map(data => data.data_partner.name))]].sort((a, b) => a.localeCompare(b))
-                                    .map((item, index) =>
-                                        <option key={index} value={item}>{item}</option>
-                                    )}
-                            </>
-                        </Select>
-                        <Th>Visibility</Th>
-                        <Th>Creation Date</Th>
-                        <Th></Th>
-                        <Th>Archive</Th>
-
-                    </Tr>
-                </Thead>
-                <Tbody>
-                    {applyFilters(displayedData).length > 0 &&
-                        applyFilters(displayedData).map((item, index) =>
-
-                            <Tr className={"mediumTbl"} key={index}>
-                                <Td maxW={"100px"}><Link style={{ color: "#0000FF", }} href={`/datasets/${item.id}/`}>{item.id}</Link></Td>
-                                <Td maxW={"100px"}><Link style={{ color: "#0000FF", }} href={`/datasets/${item.id}/`}> {item.name}</Link></Td>
-                                <Td maxW={"100px"}> {item.data_partner.name} </Td>
-                                <Td maxW={"100px"}> {item.visibility} </Td>
-                                <Td maxW={"200px"} minW={"180px"}>{item.created_at.displayString}</Td>
-                                <Td maxW={"100px"}><Link href={`/datasets/${item.id}/details/`}><Button variant="blue" my="10px">Details</Button></Link></Td>
-                                <Td textAlign="center">
-                                    {item.hidden ?
-                                        <>
-                                            {item.loading ?
-                                                <Spinner />
-                                                :
-                                                <ViewOffIcon _hover={{ color: "blue" }} onClick={() => activateOrArchiveDataset(item.id, false)} />
-                                            }
-                                        </>
-                                        :
-                                        <>
-                                            {item.loading ?
-                                                <Spinner />
-                                                :
-                                                <ViewIcon _hover={{ color: "blue" }} onClick={() => activateOrArchiveDataset(item.id, true)} />
-                                            }
-                                        </>
-                                    }
-                                </Td>
-                            </Tr>
-
-                        )
-                    }
-                </Tbody>
-            </Table>
-            {applyFilters(displayedData).length == 0 &&
-                <Flex marginLeft="10px">No Datasets available</Flex>
-            }
-        </div>
+  useEffect(async () => {
+    // run on initial page load
+    props.setTitle(null);
+    let { local_page, local_page_size } = await set_pagination_variables(
+      window.location.search,
+      page_size,
+      set_page_size,
+      currentPage,
+      setCurrentPage,
     );
-}
+
+    // set active.current based on the presence of the filter=archived flag.
+    if (window.location.search.search("filter=archived") > 0) {
+      active.current = false;
+      window.history.pushState(
+        {},
+        "",
+        `/datasets/?filter=archived&p=${local_page}&page_size=${local_page_size}`,
+      );
+    } else {
+      active.current = true;
+      window.history.pushState(
+        {},
+        "",
+        `/datasets/?p=${local_page}&page_size=${local_page_size}`,
+      );
+    }
+
+    setFirstLoad(false);
+  }, []);
+
+  useEffect(async () => {
+    // if not the first load, then load data etc. This clause avoids an initial call using the default values of
+    // currentPage and page_size, which is not desired.
+    if (!firstLoad) {
+      // run on initial page load
+      props.setTitle(null);
+      window.location.search.search("filter=archived") > 0
+        ? (active.current = false)
+        : (active.current = true);
+      // get datasets and data partners, and sort by id
+      let datasets = await useGet(
+        `/datasets/datasets_data_partners/?p=${currentPage}&page_size=${page_size}`,
+      );
+      setTotalItemsCount(datasets.count);
+      datasets = datasets.results.sort((b, a) =>
+        a.id > b.id ? 1 : b.id > a.id ? -1 : 0,
+      );
+      // for each dataset use the data partner and admin ids to get name to display
+      // get list of unique data partner and admin ids
+      const adminObject = {};
+      datasets.map((dataset) => {
+        adminObject[dataset.admin] = true;
+        const created_at = {};
+        created_at.created_at = dataset.created_at;
+        created_at.displayString = moment(dataset.created_at.toString()).format(
+          "MMM. DD, YYYY, h:mm a",
+        );
+        dataset.created_at = created_at;
+      });
+
+      data.current = datasets;
+      activeDatasets.current = datasets.filter(
+        (dataset) => dataset.hidden == false,
+      );
+      archivedDatasets.current = datasets.filter(
+        (dataset) => dataset.hidden == true,
+      );
+      active.current
+        ? setDisplayedData(activeDatasets.current)
+        : setDisplayedData(archivedDatasets.current);
+      active.current
+        ? setTitle("Active Datasets")
+        : setTitle("Archived Datasets");
+      setLoadingMessage(null);
+    }
+  }, [currentPage, page_size, firstLoad]);
+
+  const onPageChange = (page) => {
+    if (active.current == false) {
+      window.history.pushState(
+        {},
+        "",
+        `/datasets/?filter=archived&p=${page}&page_size=${page_size}`,
+      );
+    } else {
+      window.history.pushState(
+        {},
+        "",
+        `/datasets/?p=${page}&page_size=${page_size}`,
+      );
+    }
+    setCurrentPage(page);
+  };
+
+  const activateOrArchiveDataset = async (id, theIndicator) => {
+    try {
+      setDisplayedData((currentData) =>
+        currentData.map((dataset) =>
+          dataset.id == id ? { ...dataset, loading: true } : dataset,
+        ),
+      );
+      const patchData = { hidden: theIndicator };
+      const res = await usePatch(`/datasets/update/${id}/`, patchData);
+      data.current = data.current.map((dataset) =>
+        dataset.id == id ? { ...dataset, hidden: theIndicator } : dataset,
+      );
+      activeDatasets.current = data.current.filter(
+        (dataset) => dataset.hidden == false,
+      );
+      archivedDatasets.current = data.current.filter(
+        (dataset) => dataset.hidden == true,
+      );
+      active.current
+        ? setDisplayedData(activeDatasets.current)
+        : setDisplayedData(archivedDatasets.current);
+    } catch (err) {
+      setAlert({
+        status: "error",
+        title: "Unable to archive dataset " + id,
+        description: "",
+      });
+      onOpen();
+      setDisplayedData((currentData) =>
+        currentData.map((scanreport) =>
+          scanreport.id == id ? { ...scanreport, loading: false } : scanreport,
+        ),
+      );
+    }
+  };
+
+  // show active datasets and change url when 'Active Datasets' button is pressed
+  const goToActive = () => {
+    if (active.current == false) {
+      active.current = true;
+      setDisplayedData(activeDatasets.current);
+      window.history.pushState(
+        {},
+        "",
+        `/datasets/?p=${currentPage}&page_size=${page_size}`,
+      );
+      setTitle("Active Datasets");
+    }
+  };
+
+  // show archived datasets and change url when 'Archived Datasets' button is pressed
+  const goToArchived = () => {
+    if (active.current == true) {
+      active.current = false;
+      setDisplayedData(archivedDatasets.current);
+      window.history.pushState(
+        {},
+        "",
+        `/datasets/?filter=archived&p=${currentPage}&page_size=${page_size}`,
+      );
+      setTitle("Archived Datasets");
+    }
+  };
+
+  const applyFilters = (variable) => {
+    let newData = variable.map((dataset) => dataset);
+
+    if (datapartnerFilter !== "All") {
+      newData = newData.filter(
+        (dataset) => dataset.data_partner.name === datapartnerFilter,
+      );
+    }
+    return newData;
+  };
+
+  const removeFilter = (a, b) => {
+    if (a.includes("Data Partner")) {
+      setDataPartnerFilter("All");
+    }
+  };
+
+  if (loadingMessage) {
+    //Render Loading State
+    return (
+      <div>
+        <Flex padding="30px">
+          <Spinner />
+          <Flex marginLeft="10px">{loadingMessage}</Flex>
+        </Flex>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <CCBreadcrumbBar>
+        <Link href={"/"}>Home</Link>
+        <Link href={"/datasets/"}>Datasets</Link>
+      </CCBreadcrumbBar>
+      {isOpen && (
+        <ScaleFade initialScale={0.9} in={isOpen}>
+          <ToastAlert
+            hide={onClose}
+            title={alert.title}
+            status={alert.status}
+            description={alert.description}
+          />
+        </ScaleFade>
+      )}
+      <Flex>
+        <PageHeading text={title} />
+        <Spacer />
+        <Button
+          disabled={title === "Active Datasets"}
+          variant="blue"
+          mr="10px"
+          onClick={goToActive}
+        >
+          Active Datasets
+        </Button>
+        <Button
+          disabled={title === "Archived Datasets"}
+          variant="blue"
+          onClick={goToArchived}
+        >
+          Archived Datasets
+        </Button>
+      </Flex>
+      <Center>
+        <Pagination
+          activePage={currentPage}
+          itemsCountPerPage={page_size}
+          totalItemsCount={totalItemsCount}
+          pageRangeDisplayed={5}
+          onChange={onPageChange}
+          itemClass="btn paginate-inactive"
+          activeClass="btn paginate-active"
+        />
+      </Center>
+      <HStack>
+        <Text style={{ fontWeight: "bold" }}>Applied Filters: </Text>
+        {[{ title: "Data Partner -", filter: datapartnerFilter }].map(
+          (filter) => {
+            if (filter.filter === "All") {
+              return null;
+            } else {
+              return (
+                <ConceptTag
+                  key={filter.title}
+                  conceptName={filter.filter}
+                  conceptId={filter.title}
+                  conceptIdentifier={filter.title}
+                  itemId={filter.title}
+                  handleDelete={removeFilter}
+                />
+              );
+            }
+          },
+        )}
+      </HStack>
+      <Table w="100%" variant="striped" colorScheme="greyBasic">
+        <TableCaption></TableCaption>
+        <Thead>
+          <Tr className={"mediumTbl"}>
+            <Th style={{ fontSize: "16px" }}>ID</Th>
+            <Th>Name</Th>
+            <Select
+              minW="130px"
+              style={{ fontWeight: "bold" }}
+              variant="unstyled"
+              value="Data Partner"
+              readOnly
+              onChange={(option) => setDataPartnerFilter(option.target.value)}
+            >
+              <option style={{ fontWeight: "bold" }} disabled>
+                Data Partner
+              </option>
+              <>
+                {[
+                  ...[
+                    ...new Set(
+                      displayedData.map((data) => data.data_partner.name),
+                    ),
+                  ],
+                ]
+                  .sort((a, b) => a.localeCompare(b))
+                  .map((item, index) => (
+                    <option key={index} value={item}>
+                      {item}
+                    </option>
+                  ))}
+              </>
+            </Select>
+            <Th>Visibility</Th>
+            <Th>Creation Date</Th>
+            <Th></Th>
+            <Th>Archive</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          {applyFilters(displayedData).length > 0 &&
+            applyFilters(displayedData).map((item, index) => (
+              <Tr className={"mediumTbl"} key={index}>
+                <Td maxW={"100px"}>
+                  <Link
+                    style={{ color: "#0000FF" }}
+                    href={`/datasets/${item.id}/`}
+                  >
+                    {item.id}
+                  </Link>
+                </Td>
+                <Td maxW={"100px"}>
+                  <Link
+                    style={{ color: "#0000FF" }}
+                    href={`/datasets/${item.id}/`}
+                  >
+                    {" "}
+                    {item.name}
+                  </Link>
+                </Td>
+                <Td maxW={"100px"}> {item.data_partner.name} </Td>
+                <Td maxW={"100px"}> {item.visibility} </Td>
+                <Td maxW={"200px"} minW={"180px"}>
+                  {item.created_at.displayString}
+                </Td>
+                <Td maxW={"100px"}>
+                  <Link href={`/datasets/${item.id}/details/`}>
+                    <Button variant="blue" my="10px">
+                      Details
+                    </Button>
+                  </Link>
+                </Td>
+                <Td textAlign="center">
+                  {item.hidden ? (
+                    <>
+                      {item.loading ? (
+                        <Spinner />
+                      ) : (
+                        <ViewOffIcon
+                          _hover={{ color: "blue" }}
+                          onClick={() =>
+                            activateOrArchiveDataset(item.id, false)
+                          }
+                        />
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      {item.loading ? (
+                        <Spinner />
+                      ) : (
+                        <ViewIcon
+                          _hover={{ color: "blue" }}
+                          onClick={() =>
+                            activateOrArchiveDataset(item.id, true)
+                          }
+                        />
+                      )}
+                    </>
+                  )}
+                </Td>
+              </Tr>
+            ))}
+        </Tbody>
+      </Table>
+      {applyFilters(displayedData).length == 0 && (
+        <Flex marginLeft="10px">No Datasets available</Flex>
+      )}
+    </div>
+  );
+};
 
 export default DatasetTbl;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "carrot-mapper"
-version = "2.2.11"
+version = "2.2.13"
 description = ""
 authors = ["Sam Cox <sam.cox@nottingham.ac.uk>", "Philip Quinlan <philip.quinlan@nottingham.ac.uk>"]
 license = "MIT"


### PR DESCRIPTION
# Changes

Restructuring backend api slightly:
- Reorganises `projects`/`datasets` into domain specific apps
- Prepares deprecated: `router`, `urls`, `views`, `serializers` for deletion.