### PR TITLE
Restructure API endpoints

### DIFF
--- a/app/api/api/deprecated_router.py
+++ b/app/api/api/deprecated_router.py
@@ -40,3 +40,18 @@ router.register(
 )
 router.register(r"omoptables", deprecated_views.OmopTableViewSet, basename="omoptables")
 router.register(r"omopfields", deprecated_views.OmopFieldViewSet, basename="omopfields")
+
+router.register(r"users", deprecated_views.UserViewSet, basename="users")
+router.register(
+    r"usersfilter", deprecated_views.UserFilterViewSet, basename="usersfilter"
+)
+router.register(
+    r"datapartners", deprecated_views.DataPartnerViewSet, basename="datapartners"
+)
+router.register(r"mappingruleslist", deprecated_views.RulesList, basename="getlist")
+router.register(
+    r"mappingruleslistsummary",
+    deprecated_views.SummaryRulesList,
+    basename="getsummarylist",
+)
+router.register(r"analyse", deprecated_views.AnalyseRules, basename="getanalysis")

--- a/app/api/api/deprecated_serializers.py
+++ b/app/api/api/deprecated_serializers.py
@@ -3,6 +3,8 @@ from rest_framework import serializers
 from rest_framework.exceptions import NotFound, PermissionDenied
 from shared.data.models import Concept
 from shared.mapping.models import (
+    DataPartner,
+    Dataset,
     OmopField,
     OmopTable,
     ScanReport,
@@ -165,3 +167,114 @@ class ContentTypeSerializer(serializers.Serializer):
     """
 
     type_name = serializers.CharField(max_length=100)
+
+
+class DataPartnerSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = DataPartner
+        fields = "__all__"
+
+
+class DatasetSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = ("id", "name")
+
+
+class DatasetViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = "__all__"
+
+
+class DatasetAndDataPartnerViewSerializer(
+    DynamicFieldsMixin, serializers.ModelSerializer
+):
+    data_partner = DataPartnerSerializer(read_only=True)
+
+    class Meta:
+        model = Dataset
+        fields = (
+            "id",
+            "name",
+            "data_partner",
+            "admins",
+            "visibility",
+            "created_at",
+            "hidden",
+        )
+
+
+class DatasetViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = (
+            "id",
+            "name",
+            "data_partner",
+            "admins",
+            "visibility",
+            "created_at",
+            "hidden",
+            "updated_at",
+            "projects",
+            "viewers",
+            "editors",
+        )
+
+
+class DatasetEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    def validate_viewers(self, viewers):
+        if request := self.context.get("request"):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
+                raise serializers.ValidationError(
+                    "You must be an admin to change this field."
+                )
+        return viewers
+
+    def validate_editors(self, editors):
+        if request := self.context.get("request"):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
+                raise serializers.ValidationError(
+                    "You must be an admin to change this field."
+                )
+        return editors
+
+    def validate_admins(self, admins):
+        if request := self.context.get("request"):
+            if not (
+                is_admin(self.instance, request) or is_az_function_user(request.user)
+            ):
+                raise serializers.ValidationError(
+                    "You must be an admin to change this field."
+                )
+        return admins
+
+    def save(self, **kwargs):
+        projects = self.context["projects"]
+
+        if self.instance is not None:
+            self.instance = self.update(self.instance, self.validated_data)
+            return self.instance
+        dataset = Dataset.objects.create(**self.validated_data, projects=projects)
+        return dataset
+
+    class Meta:
+        model = Dataset
+        fields = (
+            "id",
+            "name",
+            "data_partner",
+            "admins",
+            "visibility",
+            "created_at",
+            "hidden",
+            "updated_at",
+            "projects",
+            "viewers",
+            "editors",
+        )

--- a/app/api/api/deprecated_serializers.py
+++ b/app/api/api/deprecated_serializers.py
@@ -1,6 +1,7 @@
 from drf_dynamic_fields import DynamicFieldsMixin  # type: ignore
 from rest_framework import serializers
 from rest_framework.exceptions import NotFound, PermissionDenied
+from shared.data.models import Concept
 from shared.mapping.models import (
     OmopField,
     OmopTable,
@@ -10,6 +11,12 @@ from shared.mapping.models import (
     ScanReportValue,
 )
 from shared.mapping.permissions import has_editorship, is_admin, is_az_function_user
+
+
+class ConceptSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Concept
+        fields = "__all__"
 
 
 class ScanReportViewSerializer(DynamicFieldsMixin, serializers.ModelSerializer):

--- a/app/api/api/deprecated_urls.py
+++ b/app/api/api/deprecated_urls.py
@@ -3,6 +3,41 @@ from django.urls import path
 
 urlpatterns = [
     path(
+        r"datasets/",
+        deprecated_views.DatasetListView.as_view(),
+        name="dataset_list",
+    ),
+    path(
+        r"datasets/datasets_data_partners/",
+        deprecated_views.DatasetAndDataPartnerListView.as_view(),
+        name="dataset_data_partners_list",
+    ),
+    path(
+        r"datasets/<int:pk>/",
+        deprecated_views.DatasetRetrieveView.as_view(),
+        name="dataset_retrieve",
+    ),
+    path(
+        r"datasets/update/<int:pk>/",
+        deprecated_views.DatasetUpdateView.as_view(),
+        name="dataset_update",
+    ),
+    path(
+        r"datasets/delete/<int:pk>/",
+        deprecated_views.DatasetDeleteView.as_view(),
+        name="dataset_delete",
+    ),
+    path(
+        r"datasets/create/",
+        deprecated_views.DatasetCreateView.as_view(),
+        name="dataset_create",
+    ),
+    path(
+        "datasets/<int:pk>/permissions/",
+        deprecated_views.DatasetPermissionView.as_view(),
+        name="dataset-permissions",
+    ),
+    path(
         r"contenttypeid",
         deprecated_views.GetContentTypeID.as_view(),
         name="contenttypeid",

--- a/app/api/api/deprecated_urls.py
+++ b/app/api/api/deprecated_urls.py
@@ -8,7 +8,7 @@ urlpatterns = [
         name="dataset_list",
     ),
     path(
-        r"datasets/datasets_data_partners/",
+        r"datasets_data_partners/",
         deprecated_views.DatasetAndDataPartnerListView.as_view(),
         name="dataset_data_partners_list",
     ),

--- a/app/api/api/deprecated_views.py
+++ b/app/api/api/deprecated_views.py
@@ -21,7 +21,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models.query_utils import Q
 from django.http import HttpResponse, JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import status, viewsets
+from rest_framework import generics, status, viewsets
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import JSONRenderer
@@ -30,6 +30,7 @@ from rest_framework.views import APIView
 from shared.data.models import Concept
 from shared.mapping.models import (
     DataPartner,
+    Dataset,
     MappingRule,
     OmopField,
     OmopTable,
@@ -41,7 +42,12 @@ from shared.mapping.models import (
     ScanReportValue,
     VisibilityChoices,
 )
-from shared.mapping.permissions import CanAdmin, CanEdit, CanView
+from shared.mapping.permissions import (
+    CanAdmin,
+    CanEdit,
+    CanView,
+    get_user_permissions_on_dataset,
+)
 from shared.services.rules import delete_mapping_rules
 from shared.services.rules_export import (
     get_mapping_rules_json,
@@ -52,6 +58,9 @@ from shared.services.rules_export import (
 from .deprecated_serializers import (
     ConceptSerializer,
     ContentTypeSerializer,
+    DatasetAndDataPartnerViewSerializer,
+    DatasetEditSerializer,
+    DatasetViewSerializerV2,
     OmopFieldSerializer,
     OmopTableSerializer,
     ScanReportFieldListSerializer,
@@ -764,3 +773,155 @@ class CountStatsScanReportTableField(APIView):
             }
             jsonrecords.append(scanreportfield_content)
         return Response(jsonrecords)
+
+
+class DatasetListView(generics.ListAPIView):
+    """
+    API view to show all datasets.
+    """
+
+    serializer_class = DatasetViewSerializerV2
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {
+        "id": ["in"],
+        "data_partner": ["in", "exact"],
+        "hidden": ["in", "exact"],
+    }
+
+    def get_queryset(self):
+        """
+        If the User is the `AZ_FUNCTION_USER`, return all Datasets.
+
+        Else, return only the Datasets which are on projects a user is a member,
+        which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
+        """
+        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return Dataset.objects.all().distinct()
+
+        return Dataset.objects.filter(
+            Q(visibility=VisibilityChoices.PUBLIC)
+            | Q(
+                viewers=self.request.user.id,
+                visibility=VisibilityChoices.RESTRICTED,
+            )
+            | Q(
+                editors=self.request.user.id,
+                visibility=VisibilityChoices.RESTRICTED,
+            )
+            | Q(
+                admins=self.request.user.id,
+                visibility=VisibilityChoices.RESTRICTED,
+            ),
+            project__members=self.request.user.id,
+        ).distinct()
+
+
+class DatasetAndDataPartnerListView(generics.ListAPIView):
+    """
+    API view to show all datasets.
+    """
+
+    serializer_class = DatasetAndDataPartnerViewSerializer
+    pagination_class = CustomPagination
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    ordering_fields = ["id", "name", "created_at", "visibility", "data_partner"]
+    filterset_fields = {
+        "id": ["in"],
+        "hidden": ["in", "exact"],
+        "name": ["in", "icontains"],
+    }
+    ordering = "-created_at"
+
+    def get_queryset(self):
+        """
+        If the User is the `AZ_FUNCTION_USER`, return all Datasets.
+
+        Else, return only the Datasets which are on projects a user is a member,
+        which are "PUBLIC", or "RESTRICTED" Datasets that a user is a viewer of.
+        """
+
+        if self.request.user.username == os.getenv("AZ_FUNCTION_USER"):
+            return Dataset.objects.prefetch_related("data_partner").all().distinct()
+
+        return (
+            Dataset.objects.filter(
+                Q(visibility=VisibilityChoices.PUBLIC)
+                | Q(
+                    viewers=self.request.user.id,
+                    visibility=VisibilityChoices.RESTRICTED,
+                )
+                | Q(
+                    editors=self.request.user.id,
+                    visibility=VisibilityChoices.RESTRICTED,
+                )
+                | Q(
+                    admins=self.request.user.id,
+                    visibility=VisibilityChoices.RESTRICTED,
+                ),
+                project__members=self.request.user.id,
+            )
+            .prefetch_related("data_partner")
+            .distinct()
+            .order_by("-id")
+        )
+
+
+class DatasetCreateView(generics.CreateAPIView):
+    serializer_class = DatasetViewSerializerV2
+    queryset = Dataset.objects.all()
+
+    def perform_create(self, serializer):
+        admins = serializer.initial_data.get("admins")
+        # If no admins given, add the user uploading the dataset
+        if not admins:
+            serializer.save(admins=[self.request.user])
+        # If the user is not in the admins, add them
+        elif self.request.user.id not in admins:
+            serializer.save(admins=admins + [self.request.user.id])
+        # All is well, save
+        else:
+            serializer.save()
+
+
+class DatasetRetrieveView(generics.RetrieveAPIView):
+    """
+    This view should return a single dataset from an id
+    """
+
+    serializer_class = DatasetViewSerializerV2
+    permission_classes = [CanView | CanAdmin | CanEdit]
+
+    def get_queryset(self):
+        return Dataset.objects.filter(id=self.kwargs.get("pk"))
+
+
+class DatasetUpdateView(generics.UpdateAPIView):
+    serializer_class = DatasetEditSerializer
+    # User must be able to view and be an admin or an editor
+    permission_classes = [CanView & (CanAdmin | CanEdit)]
+
+    def get_queryset(self):
+        return Dataset.objects.filter(id=self.kwargs.get("pk"))
+
+    def get_serializer_context(self):
+        return {"projects": self.request.data.get("projects")}
+
+
+class DatasetDeleteView(generics.DestroyAPIView):
+    serializer_class = DatasetEditSerializer
+    # User must be able to view and be an admin
+    permission_classes = [CanView & CanAdmin]
+
+    def get_queryset(self):
+        return Dataset.objects.filter(id=self.kwargs.get("pk"))
+
+
+class DatasetPermissionView(APIView):
+    """
+    API for permissions a user has on a specific dataset.
+    """
+
+    def get(self, request, pk):
+        permissions = get_user_permissions_on_dataset(request, pk)
+
+        return Response({"permissions": permissions}, status=status.HTTP_200_OK)

--- a/app/api/api/deprecated_views.py
+++ b/app/api/api/deprecated_views.py
@@ -5,17 +5,22 @@ from urllib.parse import urljoin
 
 import requests
 from api.filters import ScanReportAccessFilter
+from api.paginations import CustomPagination
 from api.serializers import (
     ConceptSerializer,
+    GetRulesAnalysis,
     ScanReportConceptSerializer,
     ScanReportEditSerializer,
     ScanReportFieldEditSerializer,
     ScanReportTableEditSerializer,
+    UserSerializer,
 )
 from config import settings
+from datasets.serializers import DataPartnerSerializer
+from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.db.models.query_utils import Q
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status, viewsets
 from rest_framework.filters import OrderingFilter
@@ -25,6 +30,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from shared.data.models import Concept
 from shared.mapping.models import (
+    DataPartner,
     MappingRule,
     OmopField,
     OmopTable,
@@ -38,6 +44,11 @@ from shared.mapping.models import (
 )
 from shared.mapping.permissions import CanAdmin, CanEdit, CanView
 from shared.services.rules import delete_mapping_rules
+from shared.services.rules_export import (
+    get_mapping_rules_json,
+    get_mapping_rules_list,
+    make_dag,
+)
 
 from .deprecated_serializers import (
     ContentTypeSerializer,
@@ -49,6 +60,23 @@ from .deprecated_serializers import (
     ScanReportValueViewSerializer,
     ScanReportViewSerializer,
 )
+
+
+class UserViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+
+
+class UserFilterViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = {"id": ["in", "exact"], "is_active": ["exact"]}
+
+
+class DataPartnerViewSet(viewsets.ModelViewSet):
+    queryset = DataPartner.objects.all()
+    serializer_class = DataPartnerSerializer
 
 
 class ConceptViewSet(viewsets.ReadOnlyModelViewSet):
@@ -443,6 +471,165 @@ class ScanReportConceptFilterViewSet(viewsets.ModelViewSet):
         "id": ["in", "exact"],
         "content_type": ["in", "exact"],
     }
+
+
+class MappingRulesList(APIView):
+    def post(self, request, *args, **kwargs):
+        try:
+            body = request.data
+        except ValueError:
+            body = {}
+        if request.POST.get("get_svg") is not None or body.get("get_svg") is not None:
+            qs = self.get_queryset()
+            output = get_mapping_rules_json(qs)
+
+            # use make dag svg image
+            svg = make_dag(output["cdm"])
+            return HttpResponse(svg, content_type="image/svg+xml")
+        else:
+            return Response(
+                {"error": "Invalid request parameters"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+    def get_queryset(self):
+        qs = MappingRule.objects.all()
+        search_term = self.kwargs.get("pk")
+
+        if search_term is not None:
+            qs = qs.filter(scan_report__id=search_term).order_by(
+                "concept",
+                "omop_field__table",
+                "omop_field__field",
+                "source_table__name",
+                "source_field__name",
+            )
+
+        return qs
+
+
+class RulesList(viewsets.ModelViewSet):
+    queryset = MappingRule.objects.all().order_by("id")
+    pagination_class = CustomPagination
+    filter_backends = [DjangoFilterBackend]
+    http_method_names = ["get"]
+
+    def get_queryset(self):
+        _id = self.request.query_params.get("id", None)
+        queryset = self.queryset
+        if _id is not None:
+            queryset = queryset.filter(scan_report__id=_id)
+        return queryset
+
+    def list(self, request):
+        """
+        This is a somewhat strange way of doing things (because we don't use a serializer class,
+        but seems to be a limitation of how django handles the combination of pagination and
+        filtering on ID of a model (ScanReport) that's not that being returned (MappingRule).
+
+        Instead, this is in effect a ListSerializer for MappingRule but that only works for in
+        the scenario we have. This means that get_mapping_rules_list() must now handle pagination
+        directly.
+        """
+        queryset = self.queryset
+        _id = self.request.query_params.get("id", None)
+        # Filter on ScanReport ID
+        if _id is not None:
+            queryset = queryset.filter(scan_report__id=_id)
+        count = queryset.count()
+
+        # Get subset of mapping rules that fit onto the page to be displayed
+        p = self.request.query_params.get("p", 1)
+        page_size = self.request.query_params.get("page_size", 30)
+        rules = get_mapping_rules_list(
+            queryset, page_number=int(p), page_size=int(page_size)
+        )
+
+        # Process all rules
+        for rule in rules:
+            rule["destination_table"] = {
+                "id": int(str(rule["destination_table"])),
+                "name": rule["destination_table"].table,
+            }
+
+            rule["destination_field"] = {
+                "id": int(str(rule["destination_field"])),
+                "name": rule["destination_field"].field,
+            }
+
+            rule["domain"] = {
+                "name": rule["domain"],
+            }
+
+            rule["source_table"] = {
+                "id": int(str(rule["source_table"])),
+                "name": rule["source_table"].name,
+            }
+
+            rule["source_field"] = {
+                "id": int(str(rule["source_field"])),
+                "name": rule["source_field"].name,
+            }
+
+        return Response(data={"count": count, "results": rules})
+
+
+class SummaryRulesList(RulesList):
+    def list(self, request):
+        # Get p and page_size from query_params
+        p = self.request.query_params.get("p", 1)
+        page_size = self.request.query_params.get("page_size", 20)
+        # Get queryset
+        queryset = self.get_queryset()
+
+        # Directly filter OmopField objects that end with "_concept_id" but not "_source_concept_id"
+        omop_fields_queryset = OmopField.objects.filter(
+            pk__in=queryset.values_list("omop_field_id", flat=True),
+            field__endswith="_concept_id",
+        ).exclude(field__endswith="_source_concept_id")
+
+        ids_list = omop_fields_queryset.values_list("id", flat=True)
+        # Filter the queryset based on valid omop_field_ids
+        filtered_queryset = queryset.filter(omop_field_id__in=ids_list)
+        count = filtered_queryset.count()
+        # Get the rules list based on the filtered queryset
+        rules = get_mapping_rules_list(
+            filtered_queryset, page_number=int(p), page_size=int(page_size)
+        )
+        # Process rules
+        for rule in rules:
+            rule["destination_table"] = {
+                "id": int(str(rule["destination_table"])),
+                "name": rule["destination_table"].table,
+            }
+
+            rule["destination_field"] = {
+                "id": int(str(rule["destination_field"])),
+                "name": rule["destination_field"].field,
+            }
+
+            rule["domain"] = {
+                "name": rule["domain"],
+            }
+
+            rule["source_table"] = {
+                "id": int(str(rule["source_table"])),
+                "name": rule["source_table"].name,
+            }
+
+            rule["source_field"] = {
+                "id": int(str(rule["source_field"])),
+                "name": rule["source_field"].name,
+            }
+
+        return Response(data={"count": count, "results": rules})
+
+
+class AnalyseRules(viewsets.ModelViewSet):
+    queryset = ScanReport.objects.all()
+    serializer_class = GetRulesAnalysis
+    filter_backends = [DjangoFilterBackend]
+    filterset_fields = ["id"]
 
 
 class OmopTableViewSet(viewsets.ModelViewSet):

--- a/app/api/api/deprecated_views.py
+++ b/app/api/api/deprecated_views.py
@@ -7,7 +7,6 @@ import requests
 from api.filters import ScanReportAccessFilter
 from api.paginations import CustomPagination
 from api.serializers import (
-    ConceptSerializer,
     GetRulesAnalysis,
     ScanReportConceptSerializer,
     ScanReportEditSerializer,
@@ -51,6 +50,7 @@ from shared.services.rules_export import (
 )
 
 from .deprecated_serializers import (
+    ConceptSerializer,
     ContentTypeSerializer,
     OmopFieldSerializer,
     OmopTableSerializer,

--- a/app/api/api/mixins.py
+++ b/app/api/api/mixins.py
@@ -1,0 +1,49 @@
+from django.shortcuts import get_object_or_404
+from shared.mapping.models import ScanReport
+from shared.mapping.permissions import CanAdmin, CanEditOrAdmin, CanView
+
+
+class ScanReportPermissionMixin:
+    """
+    Mixin to handle permission checks for Scan Reports.
+
+    This mixin provides a method to fetch a Scan Report and apply
+    permission checks based on the request method.
+    """
+
+    permission_classes_by_method = {
+        "GET": [CanView],
+        "POST": [CanView],
+        "PUT": [CanEditOrAdmin],
+        "PATCH": [CanEditOrAdmin],
+        "DELETE": [CanAdmin],
+    }
+
+    def initial(self, request, *args, **kwargs):
+        """
+        Ensures that self.scan_report is set before get_queryset is called.
+        """
+        self.scan_report = get_object_or_404(ScanReport, pk=self.kwargs["pk"])
+        super().initial(request, *args, **kwargs)
+
+    def get_permissions(self):
+        """
+        Returns the list of permissions that the current action requires.
+        """
+
+        method = self.request.method
+        self.permission_classes = self.permission_classes_by_method.get(
+            method, [CanView]
+        )
+
+        permissions = [permission() for permission in self.permission_classes]
+
+        for permission in permissions:
+            if not permission.has_object_permission(
+                self.request, self, self.scan_report
+            ):
+                self.permission_denied(
+                    self.request, message=getattr(permission, "message", None)
+                )
+
+        return permissions

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -9,22 +9,6 @@ router.register(
 
 router.register(r"users", views.UserViewSet, basename="users")
 router.register(r"usersfilter", views.UserFilterViewSet, basename="usersfilter")
-router.register(r"v2/scanreports", views.ScanReportIndexV2, basename="v2scanreports")
-router.register(
-    r"v2/scanreporttables",
-    views.ScanReportTableViewSetV2,
-    basename="v2scanreporttables",
-)
-router.register(
-    r"v2/scanreportfields",
-    views.ScanReportFieldViewSetV2,
-    basename="v2scanreportfields",
-)
-router.register(
-    r"v2/scanreportvalues",
-    views.ScanReportValueViewSetV2,
-    basename="v2scanreportvalues",
-)
 router.register(
     r"v2/scanreportconcept",
     views.ScanReportConceptViewSetV2,

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -11,7 +11,6 @@ router.register(r"v2/users", views.UserViewSet, basename="users")
 router.register(r"v2/usersfilter", views.UserFilterViewSet, basename="usersfilter")
 router.register(r"v2/datapartners", views.DataPartnerViewSet, basename="datapartners")
 router.register(r"v2/mappingruleslist", views.RulesList, basename="getlist")
-router.register(
-    r"v2/mappingruleslistsummary", views.SummaryRulesList, basename="getsummarylist"
-)
-router.register(r"v2/analyse", views.AnalyseRules, basename="getanalysis")
+# router.register(
+#     r"v2/mappingruleslistsummary", views.SummaryRulesList, basename="getsummarylist"
+# )

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -10,7 +10,3 @@ router.register(
 router.register(r"v2/users", views.UserViewSet, basename="users")
 router.register(r"v2/usersfilter", views.UserFilterViewSet, basename="usersfilter")
 router.register(r"v2/datapartners", views.DataPartnerViewSet, basename="datapartners")
-router.register(r"v2/mappingruleslist", views.RulesList, basename="getlist")
-# router.register(
-#     r"v2/mappingruleslistsummary", views.SummaryRulesList, basename="getsummarylist"
-# )

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -1,8 +1,0 @@
-from api import views
-from rest_framework import routers
-
-router = routers.DefaultRouter()
-
-router.register(
-    r"v2/omop/conceptsfilter", views.ConceptFilterViewSetV2, basename="v2conceptsfilter"
-)

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -9,11 +9,6 @@ router.register(
 
 router.register(r"users", views.UserViewSet, basename="users")
 router.register(r"usersfilter", views.UserFilterViewSet, basename="usersfilter")
-# router.register(
-#     r"v2/scanreportconcepts",
-#     views.ScanReportConceptViewSetV2,
-#     basename="v2scanreportconcept",
-# )
 router.register(r"datapartners", views.DataPartnerViewSet, basename="datapartners")
 router.register(r"mappingruleslist", views.RulesList, basename="getlist")
 router.register(

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -7,11 +7,11 @@ router.register(
     r"v2/omop/conceptsfilter", views.ConceptFilterViewSetV2, basename="v2conceptsfilter"
 )
 
-router.register(r"users", views.UserViewSet, basename="users")
-router.register(r"usersfilter", views.UserFilterViewSet, basename="usersfilter")
-router.register(r"datapartners", views.DataPartnerViewSet, basename="datapartners")
-router.register(r"mappingruleslist", views.RulesList, basename="getlist")
+router.register(r"v2/users", views.UserViewSet, basename="users")
+router.register(r"v2/usersfilter", views.UserFilterViewSet, basename="usersfilter")
+router.register(r"v2/datapartners", views.DataPartnerViewSet, basename="datapartners")
+router.register(r"v2/mappingruleslist", views.RulesList, basename="getlist")
 router.register(
-    r"mappingruleslistsummary", views.SummaryRulesList, basename="getsummarylist"
+    r"v2/mappingruleslistsummary", views.SummaryRulesList, basename="getsummarylist"
 )
-router.register(r"analyse", views.AnalyseRules, basename="getanalysis")
+router.register(r"v2/analyse", views.AnalyseRules, basename="getanalysis")

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -6,7 +6,3 @@ router = routers.DefaultRouter()
 router.register(
     r"v2/omop/conceptsfilter", views.ConceptFilterViewSetV2, basename="v2conceptsfilter"
 )
-
-router.register(r"v2/users", views.UserViewSet, basename="users")
-router.register(r"v2/usersfilter", views.UserFilterViewSet, basename="usersfilter")
-router.register(r"v2/datapartners", views.DataPartnerViewSet, basename="datapartners")

--- a/app/api/api/router.py
+++ b/app/api/api/router.py
@@ -9,16 +9,11 @@ router.register(
 
 router.register(r"users", views.UserViewSet, basename="users")
 router.register(r"usersfilter", views.UserFilterViewSet, basename="usersfilter")
-router.register(
-    r"v2/scanreportconcept",
-    views.ScanReportConceptViewSetV2,
-    basename="v2scanreportconcept",
-)
-router.register(
-    r"v2/scanreportconceptsfilter",
-    views.ScanReportConceptFilterViewSetV2,
-    basename="v2scanreportconceptsfilter",
-)
+# router.register(
+#     r"v2/scanreportconcepts",
+#     views.ScanReportConceptViewSetV2,
+#     basename="v2scanreportconcept",
+# )
 router.register(r"datapartners", views.DataPartnerViewSet, basename="datapartners")
 router.register(r"mappingruleslist", views.RulesList, basename="getlist")
 router.register(

--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -23,7 +23,7 @@ from shared.mapping.permissions import has_editorship, is_admin, is_az_function_
 from shared.services.rules_export import analyse_concepts
 
 
-class ConceptSerializer(serializers.ModelSerializer):
+class ConceptSerializerV2(serializers.ModelSerializer):
     class Meta:
         model = Concept
         fields = "__all__"

--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -585,7 +585,7 @@ class ScanReportValueViewSerializerV2(serializers.ModelSerializer):
 class ScanReportConceptSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = ScanReportConcept
-        fields = "__all__"
+        fields = ["id", "object_id", "creation_type", "concept", "content_type"]
 
 
 class GetRulesAnalysis(DynamicFieldsMixin, serializers.ModelSerializer):

--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -26,7 +26,7 @@ from shared.services.rules_export import analyse_concepts
 class ConceptSerializerV2(serializers.ModelSerializer):
     class Meta:
         model = Concept
-        fields = ["concept_id", "concept_name", "concept_code", "creation_type"]
+        fields = ["concept_id", "concept_name", "concept_code"]
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -26,7 +26,7 @@ from shared.services.rules_export import analyse_concepts
 class ConceptSerializerV2(serializers.ModelSerializer):
     class Meta:
         model = Concept
-        fields = "__all__"
+        fields = ["concept_id", "concept_name", "concept_code", "creation_type"]
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -496,47 +496,6 @@ class ScanReportEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
         fields = "__all__"
 
 
-class ScanReportTableListSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
-
-    date_event = serializers.SerializerMethodField()
-    person_id = serializers.SerializerMethodField()
-
-    def validate(self, data):
-        if request := self.context.get("request"):
-            if sr := data.get("scan_report"):
-                if not (
-                    is_az_function_user(request.user)
-                    or is_admin(sr, request)
-                    or has_editorship(sr, request)
-                ):
-                    raise PermissionDenied(
-                        "You must have editor or admin privileges on the scan report to edit its tables.",
-                    )
-            else:
-                raise NotFound("Could not find the scan report for this table.")
-        else:
-            raise serializers.ValidationError(
-                "Missing request context. Unable to validate scan report table."
-            )
-        return super().validate(data)
-
-    def get_date_event(self, obj):
-        return obj.date_event.name if obj.date_event else None
-
-    def get_person_id(self, obj):
-        return obj.person_id.name if obj.person_id else None
-
-    class Meta:
-        model = ScanReportTable
-        fields = "__all__"
-
-
-class ScanReportTableEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
-    class Meta:
-        model = ScanReportTable
-        fields = "__all__"
-
-
 class ScanReportFieldListSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
     name = serializers.CharField(
         max_length=512, allow_blank=True, trim_whitespace=False
@@ -566,6 +525,41 @@ class ScanReportFieldListSerializerV2(DynamicFieldsMixin, serializers.ModelSeria
 
     class Meta:
         model = ScanReportField
+        fields = "__all__"
+
+
+class ScanReportTableListSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
+
+    date_event = ScanReportFieldListSerializerV2()
+    person_id = ScanReportFieldListSerializerV2()
+
+    class Meta:
+        model = ScanReportTable
+        fields = "__all__"
+
+    def validate(self, data):
+        if request := self.context.get("request"):
+            if sr := data.get("scan_report"):
+                if not (
+                    is_az_function_user(request.user)
+                    or is_admin(sr, request)
+                    or has_editorship(sr, request)
+                ):
+                    raise PermissionDenied(
+                        "You must have editor or admin privileges on the scan report to edit its tables.",
+                    )
+            else:
+                raise NotFound("Could not find the scan report for this table.")
+        else:
+            raise serializers.ValidationError(
+                "Missing request context. Unable to validate scan report table."
+            )
+        return super().validate(data)
+
+
+class ScanReportTableEditSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = ScanReportTable
         fields = "__all__"
 
 

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -1,13 +1,11 @@
 from api import views
 from api.deprecated_router import router as deprecated_router
-from api.router import router
 from django.urls import include, path
 from shared.files.views import FileDownloadView
 
 from .deprecated_urls import urlpatterns as deprecated_urlpatterns
 
 urlpatterns = [
-    path("", include(router.urls)),
     path("", include(deprecated_router.urls)),
     path("datasets/", include("datasets.urls")),
     path("projects/", include("projects.urls")),
@@ -51,17 +49,17 @@ urlpatterns = [
     path(
         "scanreports/<int:pk>/mapping_rules/",
         views.MappingRulesList.as_view(),
-        name="scan-report-rules",
+        name="scan-report-rules-download-svg",
     ),
     path(
         "v2/scanreports/<int:pk>/rules/",
         views.RulesListV2.as_view(),
-        name="scan-report-rules",
+        name="scan-report-rules-list",
     ),
     path(
         "v2/scanreports/<int:pk>/rules/summary",
         views.SummaryRulesListV2.as_view(),
-        name="scan-report-rules-summary",
+        name="scan-report-rules-list-summary",
     ),
     path(
         "v2/scanreports/<int:scanreport_pk>/rules/downloads/",
@@ -94,9 +92,14 @@ urlpatterns = [
         name="scan-report-values",
     ),
     path(r"user/me/", views.UserDetailView.as_view(), name="currentuser"),
-    path(r"v2/users", views.UserViewSet.as_view(), name="users"),
+    path(r"v2/users", views.UserViewSet.as_view(), name="users-list"),
     path(r"v2/usersfilter", views.UserFilterViewSet.as_view(), name="usersfilter"),
     path(r"v2/datapartners", views.DataPartnerViewSet.as_view(), name="datapartners"),
+    path(
+        r"v2/omop/conceptsfilter",
+        views.ConceptFilterViewSetV2.as_view(),
+        name="v2conceptsfilter",
+    ),
 ]
 
 urlpatterns += deprecated_urlpatterns

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -40,7 +40,7 @@ urlpatterns = [
     ),
     path(
         r"v2/scanreports/<int:pk>/analyse/",
-        views.AnalyseRules.as_view(),
+        views.AnalyseRulesV2.as_view(),
         name="scan-reports-analyse",
     ),
     path(
@@ -55,12 +55,12 @@ urlpatterns = [
     ),
     path(
         "v2/scanreports/<int:pk>/rules/",
-        views.RulesList.as_view(),
+        views.RulesListV2.as_view(),
         name="scan-report-rules",
     ),
     path(
         "v2/scanreports/<int:pk>/rules/summary",
-        views.SummaryRulesList.as_view(),
+        views.SummaryRulesListV2.as_view(),
         name="scan-report-rules-summary",
     ),
     path(

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -94,6 +94,9 @@ urlpatterns = [
         name="scan-report-values",
     ),
     path(r"user/me/", views.UserDetailView.as_view(), name="currentuser"),
+    path(r"v2/users", views.UserViewSet.as_view(), name="users"),
+    path(r"v2/usersfilter", views.UserFilterViewSet.as_view(), name="usersfilter"),
+    path(r"v2/datapartners", views.DataPartnerViewSet.as_view(), name="datapartners"),
 ]
 
 urlpatterns += deprecated_urlpatterns

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -25,26 +25,6 @@ urlpatterns = [
         name="scan-report-tables",
     ),
     path(
-        "v2/scanreports/<int:pk>/tables/<int:table_pk>/",
-        views.ScanReportTableDetailV2.as_view(),
-        name="scan-report-table-detail",
-    ),
-    path(
-        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/",
-        views.ScanReportFieldIndexV2.as_view(),
-        name="scan-report-fields",
-    ),
-    path(
-        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/<int:field_pk>/",
-        views.ScanReportFieldDetailV2.as_view(),
-        name="scan-report-fields-detail",
-    ),
-    path(
-        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/<int:field_pk>/values/",
-        views.ScanReportValueListV2.as_view(),
-        name="scan-report-values",
-    ),
-    path(
         r"v2/scanreports/<int:pk>/downloads/",
         views.DownloadScanReportViewSet.as_view({"get": "list"}),
     ),
@@ -67,6 +47,26 @@ urlpatterns = [
         "v2/scanreports/<int:scanreport_pk>/rules/downloads/<int:pk>",
         FileDownloadView.as_view(),
         name="scan-report-downloads-get",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/<int:table_pk>/",
+        views.ScanReportTableDetailV2.as_view(),
+        name="scan-report-table-detail",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/",
+        views.ScanReportFieldIndexV2.as_view(),
+        name="scan-report-fields",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/<int:field_pk>/",
+        views.ScanReportFieldDetailV2.as_view(),
+        name="scan-report-fields-detail",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/<int:field_pk>/values/",
+        views.ScanReportValueListV2.as_view(),
+        name="scan-report-values",
     ),
     path(r"user/me", views.UserDetailView.as_view(), name="currentuser"),
 ]

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -39,6 +39,11 @@ urlpatterns = [
         views.DownloadScanReportViewSet.as_view({"get": "list"}),
     ),
     path(
+        r"v2/scanreports/<int:pk>/analyse/",
+        views.AnalyseRules.as_view(),
+        name="scan-reports-analyse",
+    ),
+    path(
         "v2/scanreports/<int:pk>/permissions/",
         views.ScanReportPermissionView.as_view(),
         name="scan-report-permissions",

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -7,7 +7,7 @@ from .deprecated_urls import urlpatterns as deprecated_urlpatterns
 
 urlpatterns = [
     path("", include(deprecated_router.urls)),
-    path("datasets/", include("datasets.urls")),
+    path("v2/datasets/", include("datasets.urls")),
     path("projects/", include("projects.urls")),
     path(
         "v2/scanreports/", views.ScanReportIndexV2.as_view(), name="scan-report-index"

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -54,6 +54,16 @@ urlpatterns = [
         name="scan-report-rules",
     ),
     path(
+        "v2/scanreports/<int:pk>/rules/",
+        views.RulesList.as_view(),
+        name="scan-report-rules",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/rules/summary",
+        views.SummaryRulesList.as_view(),
+        name="scan-report-rules-summary",
+    ),
+    path(
         "v2/scanreports/<int:scanreport_pk>/rules/downloads/",
         FileDownloadView.as_view(),
         name="scan-reports-downloads",

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
         name="scan-report-tables",
     ),
     path(
-        r"v2/scanreports/<int:pk>/downloads/",
+        r"v2/scanreports/<int:pk>/download/",
         views.DownloadScanReportViewSet.as_view({"get": "list"}),
     ),
     path(

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -12,28 +12,61 @@ urlpatterns = [
     path("datasets/", include("datasets.urls")),
     path("projects/", include("projects.urls")),
     path(
-        r"scanreports/<int:pk>/download/",
+        "v2/scanreports/", views.ScanReportIndexV2.as_view(), name="scan-report-index"
+    ),
+    path(
+        "v2/scanreports/<int:pk>/",
+        views.ScanReportDetailV2.as_view(),
+        name="scan-report-detail",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/",
+        views.ScanReportTableIndexV2.as_view(),
+        name="scan-report-tables",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/<int:table_pk>/",
+        views.ScanReportTableDetailV2.as_view(),
+        name="scan-report-table-detail",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/",
+        views.ScanReportFieldIndexV2.as_view(),
+        name="scan-report-fields",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/<int:field_pk>/",
+        views.ScanReportFieldDetailV2.as_view(),
+        name="scan-report-fields-detail",
+    ),
+    path(
+        "v2/scanreports/<int:pk>/tables/<int:table_pk>/fields/<int:field_pk>/values/",
+        views.ScanReportValueListV2.as_view(),
+        name="scan-report-values",
+    ),
+    path(
+        r"v2/scanreports/<int:pk>/downloads/",
         views.DownloadScanReportViewSet.as_view({"get": "list"}),
     ),
     path(
-        "scanreports/<int:pk>/permissions/",
+        "v2/scanreports/<int:pk>/permissions/",
         views.ScanReportPermissionView.as_view(),
         name="scan-report-permissions",
     ),
     path(
         "scanreports/<int:pk>/mapping_rules/",
         views.MappingRulesList.as_view(),
-        name="tables-structural-mapping",
+        name="scan-report-rules",
     ),
     path(
-        "scanreports/<int:scanreport_pk>/mapping_rules/downloads/",
+        "v2/scanreports/<int:scanreport_pk>/rules/downloads/",
         FileDownloadView.as_view(),
-        name="filedownload-list",
+        name="scan-reports-downloads",
     ),
     path(
-        "scanreports/<int:scanreport_pk>/mapping_rules/downloads/<int:pk>",
+        "v2/scanreports/<int:scanreport_pk>/rules/downloads/<int:pk>",
         FileDownloadView.as_view(),
-        name="filedownload-get",
+        name="scan-report-downloads-get",
     ),
     path(r"user/me", views.UserDetailView.as_view(), name="currentuser"),
 ]

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -68,7 +68,7 @@ urlpatterns = [
         views.ScanReportValueListV2.as_view(),
         name="scan-report-values",
     ),
-    path(r"user/me", views.UserDetailView.as_view(), name="currentuser"),
+    path(r"user/me/", views.UserDetailView.as_view(), name="currentuser"),
 ]
 
 urlpatterns += deprecated_urlpatterns

--- a/app/api/api/urls.py
+++ b/app/api/api/urls.py
@@ -15,6 +15,16 @@ urlpatterns = [
         "v2/scanreports/", views.ScanReportIndexV2.as_view(), name="scan-report-index"
     ),
     path(
+        "v2/scanreports/concepts/",
+        views.ScanReportConceptListV2.as_view(),
+        name="scan-report-concepts",
+    ),
+    path(
+        "v2/scanreports/concepts/<int:pk>/",
+        views.ScanReportConceptDetailV2.as_view(),
+        name="scan-report-concepts",
+    ),
+    path(
         "v2/scanreports/<int:pk>/",
         views.ScanReportDetailV2.as_view(),
         name="scan-report-detail",

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -630,7 +630,7 @@ class MappingRulesList(APIView):
         return qs
 
 
-class RulesList(ScanReportPermissionMixin, GenericAPIView, ListModelMixin):
+class RulesListV2(ScanReportPermissionMixin, GenericAPIView, ListModelMixin):
     queryset = MappingRule.objects.all().order_by("id")
     pagination_class = CustomPagination
     filter_backends = [DjangoFilterBackend]
@@ -699,7 +699,7 @@ class RulesList(ScanReportPermissionMixin, GenericAPIView, ListModelMixin):
         return Response(data={"count": count, "results": rules})
 
 
-class SummaryRulesList(RulesList):
+class SummaryRulesListV2(RulesListV2):
     def list(self, request, *args, **kwargs):
         # Get p and page_size from query_params
         p = self.request.query_params.get("p", 1)
@@ -750,7 +750,7 @@ class SummaryRulesList(RulesList):
         return Response(data={"count": count, "results": rules})
 
 
-class AnalyseRules(ScanReportPermissionMixin, GenericAPIView, RetrieveModelMixin):
+class AnalyseRulesV2(ScanReportPermissionMixin, GenericAPIView, RetrieveModelMixin):
     queryset = ScanReport.objects.all()
     serializer_class = GetRulesAnalysis
     filter_backends = [DjangoFilterBackend]

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -41,6 +41,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.generics import GenericAPIView
 from rest_framework.mixins import (
     CreateModelMixin,
+    DestroyModelMixin,
     ListModelMixin,
     RetrieveModelMixin,
     UpdateModelMixin,
@@ -118,7 +119,7 @@ class UserDetailView(APIView):
         return Response(serializer.data)
 
 
-class ScanReportIndexV2(GenericAPIView, ListModelMixin):
+class ScanReportIndexV2(GenericAPIView, ListModelMixin, CreateModelMixin):
     """
     A custom viewset for retrieving and listing scan reports with additional functionality for version 2.
 
@@ -278,7 +279,9 @@ class ScanReportIndexV2(GenericAPIView, ListModelMixin):
         add_message(os.environ.get("UPLOAD_QUEUE_NAME"), azure_dict)
 
 
-class ScanReportDetailV2(GenericAPIView, RetrieveModelMixin):
+class ScanReportDetailV2(
+    GenericAPIView, RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin
+):
     queryset = ScanReport.objects.all()
     serializer_class = ScanReportViewSerializerV2
 
@@ -303,7 +306,7 @@ class ScanReportDetailV2(GenericAPIView, RetrieveModelMixin):
         instance.delete()
 
 
-class ScanReportTableIndexV2(GenericAPIView, ListModelMixin, CreateModelMixin):
+class ScanReportTableIndexV2(GenericAPIView, ListModelMixin):
     filterset_fields = {
         "name": ["icontains"],
     }

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -166,7 +166,7 @@ class ScanReportIndexV2(GenericAPIView, ListModelMixin, CreateModelMixin):
             return ScanReportEditSerializer
         return super().get_serializer_class()
 
-    def create(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
         non_file_serializer = ScanReportCreateSerializer(
             data=request.data, context={"request": request}
         )
@@ -374,6 +374,9 @@ class ScanReportTableDetailV2(
     queryset = ScanReportTable.objects.all()
     serializer_class = ScanReportTableListSerializerV2
 
+    def get_object(self):
+        return get_object_or_404(self.queryset, pk=self.kwargs["table_pk"])
+
     def get(self, request, *args, **kwargs):
         return self.retrieve(request, *args, **kwargs)
 
@@ -468,6 +471,9 @@ class ScanReportFieldDetailV2(
 ):
     queryset = ScanReportField.objects.all()
     serializer_class = ScanReportFieldListSerializerV2
+
+    def get_object(self):
+        return get_object_or_404(self.queryset, pk=self.kwargs["field_pk"])
 
     def get(self, request, *args, **kwargs):
         return self.retrieve(request, *args, **kwargs)

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -11,7 +11,7 @@ from api.filters import ScanReportAccessFilter
 from api.mixins import ScanReportPermissionMixin
 from api.paginations import CustomPagination
 from api.serializers import (
-    ConceptSerializer,
+    ConceptSerializerV2,
     GetRulesAnalysis,
     ScanReportConceptSerializer,
     ScanReportCreateSerializer,
@@ -88,7 +88,7 @@ class DataPartnerViewSet(GenericAPIView, ListModelMixin):
 
 class ConceptFilterViewSetV2(GenericAPIView, ListModelMixin):
     queryset = Concept.objects.all().order_by("concept_id")
-    serializer_class = ConceptSerializer
+    serializer_class = ConceptSerializerV2
     filter_backends = [DjangoFilterBackend]
     pagination_class = CustomPagination
     filterset_fields = {

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -64,12 +64,7 @@ from shared.mapping.models import (
     ScanReportTable,
     ScanReportValue,
 )
-from shared.mapping.permissions import (
-    CanAdmin,
-    CanEditOrAdmin,
-    CanView,
-    get_user_permissions_on_scan_report,
-)
+from shared.mapping.permissions import get_user_permissions_on_scan_report
 from shared.services.azurequeue import add_message
 from shared.services.rules import (
     _find_destination_table,

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -773,6 +773,7 @@ class AnalyseRules(viewsets.ModelViewSet):
 
 class DownloadScanReportViewSet(viewsets.ViewSet):
     def list(self, request, pk):
+        # TODO: This should not be a list view...
         scan_report = ScanReport.objects.get(id=pk)
         # scan_report = ScanReportSerializer(scan_reports, many=False).data
         # Set Storage Account connection string

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -451,7 +451,7 @@ class ScanReportFieldIndexV2(ScanReportBaseIndexView, ListModelMixin):
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["name", "description_column", "type_column"]
     pagination_class = CustomPagination
-    ordering = "name"
+    ordering = "pk"
 
     def get(self, request, *args, **kwargs):
         self.table = get_object_or_404(ScanReportTable, pk=kwargs["table_pk"])

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -440,6 +440,7 @@ class ScanReportTableDetailV2(
 
 class ScanReportFieldIndexV2(ScanReportBaseIndexView, ListModelMixin):
     queryset = ScanReportField.objects.all()
+    serializer_class = ScanReportFieldListSerializerV2
     filterset_fields = {
         "name": ["icontains"],
     }

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -747,7 +747,7 @@ class SummaryRulesList(RulesList):
         return Response(data={"count": count, "results": rules})
 
 
-class AnalyseRules(viewsets.ModelViewSet):
+class AnalyseRules(ScanReportPermissionMixin, GenericAPIView, RetrieveModelMixin):
     queryset = ScanReport.objects.all()
     serializer_class = GetRulesAnalysis
     filter_backends = [DjangoFilterBackend]

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -326,10 +326,11 @@ class ScanReportDetailV2(
     def get(self, request, *args, **kwargs):
         return self.retrieve(request, *args, **kwargs)
 
-    def destroy(self, request, *args, **kwargs):
-        instance = self.get_object()
-        self.perform_destroy(instance)
-        return Response(status=status.HTTP_204_NO_CONTENT)
+    def patch(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        return self.destroy(request, *args, **kwargs)
 
     def perform_destroy(self, instance):
         try:
@@ -389,7 +390,7 @@ class ScanReportTableDetailV2(
             return ScanReportTableEditSerializer
         return super().get_serializer_class()
 
-    def partial_update(self, request: Any, *args: Any, **kwargs: Any) -> Response:
+    def patch(self, request: Any, *args: Any, **kwargs: Any) -> Response:
         """
         Perform a partial update on the instance.
 
@@ -477,6 +478,9 @@ class ScanReportFieldDetailV2(
 
     def get(self, request, *args, **kwargs):
         return self.retrieve(request, *args, **kwargs)
+
+    def patch(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)
 
     def get_serializer_class(self):
         if self.request.method in ["GET", "POST"]:

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -83,7 +83,7 @@ from shared.services.rules_export import (
 )
 
 
-class DataPartnerViewSet(viewsets.ModelViewSet):
+class DataPartnerViewSet(GenericAPIView, ListModelMixin):
     queryset = DataPartner.objects.all()
     serializer_class = DataPartnerSerializer
 
@@ -100,16 +100,22 @@ class ConceptFilterViewSetV2(viewsets.ReadOnlyModelViewSet):
     }
 
 
-class UserViewSet(viewsets.ReadOnlyModelViewSet):
+class UserViewSet(GenericAPIView, ListModelMixin):
     queryset = User.objects.all()
     serializer_class = UserSerializer
 
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
 
-class UserFilterViewSet(viewsets.ReadOnlyModelViewSet):
+
+class UserFilterViewSet(GenericAPIView, ListModelMixin):
     queryset = User.objects.all()
     serializer_class = UserSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_fields = {"id": ["in", "exact"], "is_active": ["exact"]}
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
 
 
 class UserDetailView(APIView):

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -65,7 +65,7 @@ from shared.mapping.models import (
 )
 from shared.mapping.permissions import (
     CanAdmin,
-    CanEdit,
+    CanEditOrAdmin,
     CanView,
     get_user_permissions_on_scan_report,
 )
@@ -302,7 +302,7 @@ class ScanReportBaseDetailView(ScanReportBaseIndexView):
         if self.request.method == "DELETE":
             self.permission_classes = [CanAdmin]
         elif self.request.method in ["PUT", "PATCH"]:
-            self.permission_classes = [CanEdit]
+            self.permission_classes = [CanEditOrAdmin]
         else:
             self.permission_classes = [CanView]
         return super().get_permissions()

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -87,8 +87,11 @@ class DataPartnerViewSet(GenericAPIView, ListModelMixin):
     queryset = DataPartner.objects.all()
     serializer_class = DataPartnerSerializer
 
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
 
-class ConceptFilterViewSetV2(viewsets.ReadOnlyModelViewSet):
+
+class ConceptFilterViewSetV2(GenericAPIView, ListModelMixin):
     queryset = Concept.objects.all().order_by("concept_id")
     serializer_class = ConceptSerializer
     filter_backends = [DjangoFilterBackend]
@@ -98,6 +101,9 @@ class ConceptFilterViewSetV2(viewsets.ReadOnlyModelViewSet):
         "concept_code": ["in", "exact"],
         "vocabulary_id": ["in", "exact"],
     }
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
 
 
 class UserViewSet(GenericAPIView, ListModelMixin):

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -630,20 +630,23 @@ class MappingRulesList(APIView):
         return qs
 
 
-class RulesList(viewsets.ModelViewSet):
+class RulesList(ScanReportPermissionMixin, GenericAPIView, ListModelMixin):
     queryset = MappingRule.objects.all().order_by("id")
     pagination_class = CustomPagination
     filter_backends = [DjangoFilterBackend]
     http_method_names = ["get"]
 
     def get_queryset(self):
-        _id = self.request.query_params.get("id", None)
+        _id = self.kwargs["pk"]
         queryset = self.queryset
         if _id is not None:
             queryset = queryset.filter(scan_report__id=_id)
         return queryset
 
-    def list(self, request):
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
+    def list(self, request, *args, **kwargs):
         """
         This is a somewhat strange way of doing things (because we don't use a serializer class,
         but seems to be a limitation of how django handles the combination of pagination and
@@ -654,7 +657,7 @@ class RulesList(viewsets.ModelViewSet):
         directly.
         """
         queryset = self.queryset
-        _id = self.request.query_params.get("id", None)
+        _id = self.kwargs["pk"]
         # Filter on ScanReport ID
         if _id is not None:
             queryset = queryset.filter(scan_report__id=_id)
@@ -697,7 +700,7 @@ class RulesList(viewsets.ModelViewSet):
 
 
 class SummaryRulesList(RulesList):
-    def list(self, request):
+    def list(self, request, *args, **kwargs):
         # Get p and page_size from query_params
         p = self.request.query_params.get("p", 1)
         page_size = self.request.query_params.get("page_size", 20)

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -470,11 +470,11 @@ class ScanReportFieldIndexV2(ScanReportBaseIndexView, ListModelMixin):
 class ScanReportFieldDetailV2(
     ScanReportBaseDetailView, RetrieveModelMixin, UpdateModelMixin
 ):
-    queryset = ScanReportField.objects.all()
+    model = ScanReportField
     serializer_class = ScanReportFieldListSerializerV2
 
     def get_object(self):
-        return get_object_or_404(self.queryset, pk=self.kwargs["field_pk"])
+        return get_object_or_404(self.model, pk=self.kwargs["field_pk"])
 
     def get(self, request, *args, **kwargs):
         return self.retrieve(request, *args, **kwargs)

--- a/app/api/config/settings.py
+++ b/app/api/config/settings.py
@@ -187,9 +187,9 @@ STATIC_URL = "/static/"
 
 LOGIN_REDIRECT_URL = "/scanreports/"
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
-# NLP API KEY
-NLP_API_KEY = os.getenv("NLP_API_KEY")
+DATA_UPLOAD_MAX_MEMORY_SIZE = int(
+    os.environ.get("DATA_UPLOAD_MAX_MEMORY_SIZE", 2621440)
+)
 
 SESSION_COOKIE_AGE = 86400  # session length is 24 hours
 

--- a/app/api/datasets/urls.py
+++ b/app/api/datasets/urls.py
@@ -4,7 +4,7 @@ from django.urls import path
 urlpatterns = [
     path(
         r"",
-        views.DatasetListView.as_view(),
+        views.DatasetIndex.as_view(),
         name="dataset_list",
     ),
     path(
@@ -14,23 +14,8 @@ urlpatterns = [
     ),
     path(
         r"<int:pk>/",
-        views.DatasetRetrieveView.as_view(),
+        views.DatasetDetail.as_view(),
         name="dataset_retrieve",
-    ),
-    path(
-        r"update/<int:pk>/",
-        views.DatasetUpdateView.as_view(),
-        name="dataset_update",
-    ),
-    path(
-        r"delete/<int:pk>/",
-        views.DatasetDeleteView.as_view(),
-        name="dataset_delete",
-    ),
-    path(
-        r"create/",
-        views.DatasetCreateView.as_view(),
-        name="dataset_create",
     ),
     path(
         "<int:pk>/permissions/",

--- a/app/api/datasets/views.py
+++ b/app/api/datasets/views.py
@@ -42,6 +42,9 @@ class DatasetIndex(GenericAPIView, ListModelMixin, CreateModelMixin):
         "hidden": ["in", "exact"],
     }
 
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         admins = serializer.initial_data.get("admins")
         # If no admins given, add the user uploading the dataset
@@ -82,7 +85,7 @@ class DatasetIndex(GenericAPIView, ListModelMixin, CreateModelMixin):
         ).distinct()
 
 
-class DatasetAndDataPartnerListView(generics.ListAPIView):
+class DatasetAndDataPartnerListView(GenericAPIView, ListModelMixin):
     """
     API view to show all datasets.
     """
@@ -97,6 +100,9 @@ class DatasetAndDataPartnerListView(generics.ListAPIView):
         "name": ["in", "icontains"],
     }
     ordering = "-created_at"
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)
 
     def get_queryset(self):
         """
@@ -167,9 +173,6 @@ class DatasetDetail(
 
     def patch(self, request, *args, **kwargs):
         return self.partial_update(request, *args, **kwargs)
-
-    def delete(self, request, *args, **kwargs):
-        return self.destroy(request, *args, **kwargs)
 
 
 class DatasetPermissionView(APIView):

--- a/app/api/datasets/views.py
+++ b/app/api/datasets/views.py
@@ -45,6 +45,9 @@ class DatasetIndex(GenericAPIView, ListModelMixin, CreateModelMixin):
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
 
+    def post(self, request, *args, **kwargs):
+        return self.create(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         admins = serializer.initial_data.get("admins")
         # If no admins given, add the user uploading the dataset

--- a/app/api/test/test_views.py
+++ b/app/api/test/test_views.py
@@ -3,7 +3,7 @@ from datetime import date
 from unittest import mock
 
 import pytest
-from datasets.views import DatasetListView
+from datasets.views import DatasetIndex
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, TransactionTestCase
@@ -75,7 +75,7 @@ class TestDatasetListView(TestCase):
         self.factory = APIRequestFactory()
 
         # The view for the tests
-        self.view = DatasetListView.as_view()
+        self.view = DatasetIndex.as_view()
 
     def test_dataset_returns(self):
         # Make the request for Datasets

--- a/app/next-client-app/api/concepts.ts
+++ b/app/next-client-app/api/concepts.ts
@@ -5,10 +5,9 @@ import { fetchAllPages } from "@/lib/api/utils";
 const fetchKeys = {
   conceptFilter: (filter: string) =>
     `v2/omop/conceptsfilter/?concept_id__in=${filter}`,
-  addConcept: "v2/scanreportconcept/",
-  deleteConcept: (conceptId: number) => `v2/scanreportconcept/${conceptId}/`,
-  scanreportConcepts: (filter?: string) =>
-    `v2/scanreportconceptsfilter/?${filter}`,
+  addConcept: "v2/scanreports/concepts/",
+  deleteConcept: (conceptId: number) => `v2/scanreports/concepts/${conceptId}/`,
+  scanreportConcepts: (filter?: string) => `v2/scanreports/concepts/?${filter}`,
 };
 
 export async function getAllScanReportConcepts(

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -8,7 +8,7 @@ const fetchKeys = {
     filter
       ? `v2/datasets/datasets_data_partners/?${filter}`
       : "v2/datasets/datasets_data_partners/",
-  dataset: (id: string) => `datasets/${id}/`,
+  dataset: (id: string) => `v2/datasets/${id}/`,
   datasetList: (dataPartnerId?: string) =>
     dataPartnerId
       ? `v2/datasets/?data_partner=${dataPartnerId}&hidden=false`
@@ -17,9 +17,9 @@ const fetchKeys = {
   users: () => "v2/usersfilter/?is_active=true",
   projects: (dataset?: string) =>
     dataset ? `projects/?dataset=${dataset}` : "projects/",
-  updateDataset: (id: number) => `v2/datasets/update/${id}/`,
+  updateDataset: (id: number) => `v2/datasets/${id}/`,
   permissions: (id: string) => `v2/datasets/${id}/permissions/`,
-  create: "v2/datasets/create/",
+  create: "v2/datasets/",
 };
 
 export async function getDataSets(

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -6,20 +6,20 @@ import { redirect } from "next/navigation";
 const fetchKeys = {
   list: (filter?: string) =>
     filter
-      ? `datasets/datasets_data_partners/?${filter}`
-      : "datasets/datasets_data_partners/",
+      ? `v2/datasets/datasets_data_partners/?${filter}`
+      : "v2/datasets/datasets_data_partners/",
   dataset: (id: string) => `datasets/${id}/`,
   datasetList: (dataPartnerId?: string) =>
     dataPartnerId
-      ? `datasets/?data_partner=${dataPartnerId}&hidden=false`
-      : "datasets/",
+      ? `v2/datasets/?data_partner=${dataPartnerId}&hidden=false`
+      : "v2/datasets/",
   dataPartners: () => "v2/datapartners/",
   users: () => "v2/usersfilter/?is_active=true",
   projects: (dataset?: string) =>
     dataset ? `projects/?dataset=${dataset}` : "projects/",
-  updateDataset: (id: number) => `datasets/update/${id}/`,
-  permissions: (id: string) => `datasets/${id}/permissions/`,
-  create: "datasets/create/",
+  updateDataset: (id: number) => `v2/datasets/update/${id}/`,
+  permissions: (id: string) => `v2/datasets/${id}/permissions/`,
+  create: "v2/datasets/create/",
 };
 
 export async function getDataSets(

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -13,8 +13,8 @@ const fetchKeys = {
     dataPartnerId
       ? `datasets/?data_partner=${dataPartnerId}&hidden=false`
       : "datasets/",
-  dataPartners: () => "datapartners/",
-  users: () => "usersfilter/?is_active=true",
+  dataPartners: () => "v2/datapartners/",
+  users: () => "v2/usersfilter/?is_active=true",
   projects: (dataset?: string) =>
     dataset ? `projects/?dataset=${dataset}` : "projects/",
   updateDataset: (id: number) => `datasets/update/${id}/`,

--- a/app/next-client-app/api/files.ts
+++ b/app/next-client-app/api/files.ts
@@ -4,9 +4,9 @@ import request from "@/lib/api/request";
 
 const fetchKeys = {
   list: (scan_report_id: number, filter?: string) =>
-    `scanreports/${scan_report_id}/mapping_rules/downloads/?${filter}`,
+    `v2/scanreports/${scan_report_id}/rules/downloads/?${filter}`,
   requestFile: (scan_report_id: number) =>
-    `scanreports/${scan_report_id}/mapping_rules/downloads/`,
+    `v2/scanreports/${scan_report_id}/rules/downloads/`,
 };
 
 export async function list(

--- a/app/next-client-app/api/mapping-rules.ts
+++ b/app/next-client-app/api/mapping-rules.ts
@@ -2,18 +2,21 @@
 import request from "@/lib/api/request";
 
 const fetchKeys = {
-  mappingruleslist: (filter?: string) => `mappingruleslist/?${filter}`,
+  mappingruleslist: (id: string, filter?: string) =>
+    `v2/scanreports/${id}/rules/?${filter}`,
   getMapDiagram: (id: string, filter?: string) =>
     `scanreports/${id}/mapping_rules/?${filter}`,
-  summaryRules: (filter?: string) => `mappingruleslistsummary/?${filter}`,
+  summaryRules: (id: string, filter?: string) =>
+    `v2/scanreports/${id}/rules/summary/?${filter}`,
 };
 
 export async function getMappingRulesList(
+  id: string,
   filter: string | undefined,
 ): Promise<PaginatedResponse<MappingRule>> {
   try {
     return await request<PaginatedResponse<MappingRule>>(
-      fetchKeys.mappingruleslist(filter),
+      fetchKeys.mappingruleslist(id, filter),
     );
   } catch (error) {
     return { count: 0, next: null, previous: null, results: [] };
@@ -55,11 +58,12 @@ export async function getMappingRules(
 }
 
 export async function getSummaryRules(
+  id: string,
   filter: string,
 ): Promise<PaginatedResponse<MappingRule>> {
   try {
     return await request<PaginatedResponse<MappingRule>>(
-      fetchKeys.summaryRules(filter),
+      fetchKeys.summaryRules(id, filter),
     );
   } catch (error) {
     return { count: 0, next: null, previous: null, results: [] };

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -16,7 +16,7 @@ const fetchKeys = {
   field: (
     scanReportId: string | number,
     tableId: string | number,
-    fieldId: string,
+    fieldId: string | number | undefined,
   ) => `v2/scanreports/${scanReportId}/tables/${tableId}/fields/${fieldId}/`,
   fields: (scanReportId: string, tableId: string, filter?: string) =>
     `v2/scanreports/${scanReportId}/tables/${tableId}/fields/?${filter}`,
@@ -131,10 +131,10 @@ export async function getScanReportTable(
       id: 0,
       name: "",
       scan_report: 0,
-      person_id: "",
+      person_id: null,
       created_at: new Date(),
       updated_at: new Date(),
-      date_event: "",
+      date_event: null,
       permissions: [],
     };
   }
@@ -192,7 +192,7 @@ export async function getScanReportFields(
 export async function getScanReportField(
   scanReportId: string,
   tableId: string,
-  fieldId: string,
+  fieldId: string | number | undefined,
 ): Promise<ScanReportField> {
   try {
     return await request<ScanReportField>(

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -23,7 +23,7 @@ const fetchKeys = {
     fieldId: string,
     filter?: string,
   ) =>
-    `v2/scanreports/${scanReportId}/tables/£${tableId}/fields/${fieldId}/values/?${filter}`,
+    `v2/scanreports/${scanReportId}/tables/${tableId}/fields/${fieldId}/values/?${filter}`,
 };
 
 export async function getScanReports(

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -14,7 +14,7 @@ const fetchKeys = {
   tables: (scanReportId: string, filter?: string) =>
     `v2/scanreports/${scanReportId}/tables/?${filter}`,
   field: (scanReportId: string, tableId: string, fieldId: string) =>
-    `v2/scanreports/${scanReportId}/tables/${tableId}/fields/?${fieldId}`,
+    `v2/scanreports/${scanReportId}/tables/${tableId}/fields/${fieldId}/`,
   fields: (scanReportId: string, tableId: string, filter?: string) =>
     `v2/scanreports/${scanReportId}/tables/${tableId}/fields/?${filter}`,
   values: (
@@ -24,7 +24,6 @@ const fetchKeys = {
     filter?: string,
   ) =>
     `v2/scanreports/${scanReportId}/tables/£${tableId}/fields/${fieldId}/values/?${filter}`,
-  updateTable: (id: number) => `scanreporttables/${id}/`,
 };
 
 export async function getScanReports(

--- a/app/next-client-app/api/scanreports.ts
+++ b/app/next-client-app/api/scanreports.ts
@@ -9,12 +9,15 @@ const fetchKeys = {
     filter ? `v2/scanreports/?${filter}` : "v2/scanreports/",
   get: (id: string | number) => `v2/scanreports/${id}/`,
   permissions: (id: string) => `v2/scanreports/${id}/permissions/`,
-  table: (scanReportId: string, tableId: string) =>
+  table: (scanReportId: string | number, tableId: string | number) =>
     `v2/scanreports/${scanReportId}/tables/${tableId}/`,
   tables: (scanReportId: string, filter?: string) =>
     `v2/scanreports/${scanReportId}/tables/?${filter}`,
-  field: (scanReportId: string, tableId: string, fieldId: string) =>
-    `v2/scanreports/${scanReportId}/tables/${tableId}/fields/${fieldId}/`,
+  field: (
+    scanReportId: string | number,
+    tableId: string | number,
+    fieldId: string,
+  ) => `v2/scanreports/${scanReportId}/tables/${tableId}/fields/${fieldId}/`,
   fields: (scanReportId: string, tableId: string, filter?: string) =>
     `v2/scanreports/${scanReportId}/tables/${tableId}/fields/?${filter}`,
   values: (
@@ -138,8 +141,8 @@ export async function getScanReportTable(
 }
 
 export async function updateScanReportTable(
-  scanReportId: string,
-  tableId: string,
+  scanReportId: string | number,
+  tableId: string | number,
   data: {},
 ) {
   try {
@@ -224,8 +227,8 @@ export async function getScanReportField(
 }
 
 export async function updateScanReportField(
-  scanReportId: string,
-  tableId: string,
+  scanReportId: string | number,
+  tableId: string | number,
   fieldId: string,
   data: {},
 ) {

--- a/app/next-client-app/app/(protected)/scanreports/[id]/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/columns.tsx
@@ -24,8 +24,12 @@ export const columns: ColumnDef<ScanReportTable>[] = [
         sortName="person_id"
       />
     ),
+    cell: ({ row }) => {
+      const { person_id } = row.original;
+      return <>{person_id?.name}</>;
+    },
     enableHiding: true,
-    enableSorting: true,
+    enableSorting: false,
   },
   {
     id: "Event Date",
@@ -37,8 +41,12 @@ export const columns: ColumnDef<ScanReportTable>[] = [
         sortName="date_event"
       />
     ),
+    cell: ({ row }) => {
+      const { date_event } = row.original;
+      return <>{date_event?.name}</>;
+    },
     enableHiding: true,
-    enableSorting: true,
+    enableSorting: false,
   },
   {
     id: "edit",

--- a/app/next-client-app/app/(protected)/scanreports/[id]/downloads/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/downloads/columns.tsx
@@ -85,7 +85,7 @@ export const columns: ColumnDef<FileDownload>[] = [
       const { id, scan_report } = row.original;
       return (
         <Link
-          href={`/api/scanreports/${scan_report}/mapping_rules/downloads/${id}/`}
+          href={`/api/v2/scanreports/${scan_report}/rules/downloads/${id}/`}
         >
           <Button variant={"outline"}>
             Download <Download className="ml-2 size-4" />

--- a/app/next-client-app/app/(protected)/scanreports/[id]/downloads/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/downloads/page.tsx
@@ -13,6 +13,8 @@ interface DownloadsProps {
   searchParams?: FilterParameters;
 }
 
+export const revalidate = 30;
+
 export default async function Downloads({
   params: { id },
   searchParams,

--- a/app/next-client-app/app/(protected)/scanreports/[id]/layout.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/layout.tsx
@@ -131,7 +131,7 @@ export default async function ScanReportLayout({
               </DropdownMenuItem>
               <DropdownMenuItem>
                 <a
-                  href={`/api/scanreports/${params.id}/download/`}
+                  href={`/api/v2/scanreports/${params.id}/download/`}
                   download
                   className="flex"
                 >

--- a/app/next-client-app/app/(protected)/scanreports/[id]/layout.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/layout.tsx
@@ -79,7 +79,7 @@ export default async function ScanReportLayout({
         <h2>{scanreport.dataset}</h2>
       </div>
 
-      <div className="flex flex-col md:flex-row md:items-center text-sm space-y-2 md:space-y-0 divide-y md:divide-y-0 md:divide-x divide-gray-300">
+      <div className="flex flex-col md:flex-row md:items-center h-7 text-sm space-y-2 md:space-y-0 divide-y md:divide-y-0 md:divide-x divide-gray-300">
         <InfoItem
           label="Data Partner"
           value={scanreport.data_partner}
@@ -90,14 +90,15 @@ export default async function ScanReportLayout({
           value={format(createdDate, "MMM dd, yyyy h:mm a")}
           className="py-1 md:py-0 md:px-3"
         />
-
-        <ScanReportStatus
-          id={params.id}
-          status={scanreport.status}
-          dataset={scanreport.dataset}
-          className="w-[180px] h-7"
-          disabled={!canEdit} // Disable when users don't have permission
-        />
+        <div className="py-1 md:py-0 md:px-3 h-5">
+          <ScanReportStatus
+            id={params.id}
+            status={scanreport.status}
+            dataset={scanreport.dataset}
+            className="w-[180px] h-5"
+            disabled={!canEdit} // Disable when users don't have permission
+          />
+        </div>
       </div>
       {/* "Navs" group */}
       <div className="flex flex-col md:flex-row justify-between">

--- a/app/next-client-app/app/(protected)/scanreports/[id]/mapping_rules/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/mapping_rules/page.tsx
@@ -19,13 +19,12 @@ export default async function ScanReportsMappingRules({
 }: ScanReportsMappingRulesProps) {
   const defaultPageSize = 30;
   const defaultParams = {
-    id: id,
     p: 1,
     page_size: defaultPageSize,
   };
   const combinedParams = { ...defaultParams, ...searchParams };
   const query = objToQuery(combinedParams);
-  const mappingRulesList = await getMappingRulesList(query);
+  const mappingRulesList = await getMappingRulesList(id, query);
   const scanReport = await getScanReport(id);
   const fileName = `${scanReport?.dataset} Rules - ${new Date().toLocaleString()}`;
   const rulesButton = (

--- a/app/next-client-app/app/(protected)/scanreports/[id]/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { columns } from "./columns";
 import {
   getScanReportPermissions,
-  getScanReportsTables,
+  getScanReportTables,
 } from "@/api/scanreports";
 import { DataTable } from "@/components/data-table";
 import { objToQuery } from "@/lib/client-utils";
@@ -27,7 +27,7 @@ export default async function ScanReportsTable({
   const query = objToQuery(combinedParams);
   const filter = <DataTableFilter filter="name" />;
 
-  const scanReportsTables = await getScanReportsTables(query);
+  const scanReportsTables = await getScanReportTables(id, query);
   const permissions = await getScanReportPermissions(id);
   const scanReportsResult = scanReportsTables.results.map((table) => {
     table.permissions = permissions.permissions;

--- a/app/next-client-app/app/(protected)/scanreports/[id]/review_rules/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/review_rules/page.tsx
@@ -19,14 +19,13 @@ export default async function SummaryViewDialog({
 }: SummaryProps) {
   const defaultPageSize = 20;
   const defaultParams = {
-    id: id,
     p: 1,
     page_size: defaultPageSize,
   };
   const combinedParams = { ...defaultParams, ...searchParams };
   const query = objToQuery(combinedParams);
 
-  const summaryRules = await getSummaryRules(query);
+  const summaryRules = await getSummaryRules(id, query);
   const scanReport = await getScanReport(id);
   const fileName = `${scanReport?.dataset} Rules - ${new Date().toLocaleString()}`;
   const rulesButton = (

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/columns.tsx
@@ -77,7 +77,7 @@ export const columns = (
         <AddConcept
           rowId={id}
           tableId={scan_report_table.toString()}
-          location="SR-Fields"
+          contentType="scanreportfield"
           disabled={canEdit ? false : true}
           addSR={addSR}
         />

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/columns.tsx
@@ -11,7 +11,7 @@ import { usePathname } from "next/navigation";
 
 export const columns = (
   addSR: (concept: ScanReportConcept, c: Concept) => void,
-  deleteSR: (id: number) => void
+  deleteSR: (id: number) => void,
 ): ColumnDef<ScanReportField>[] => [
   {
     id: "Name",
@@ -76,7 +76,7 @@ export const columns = (
       return (
         <AddConcept
           rowId={id}
-          parentId={scan_report_table.toString()}
+          tableId={scan_report_table.toString()}
           location="SR-Fields"
           disabled={canEdit ? false : true}
           addSR={addSR}

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/columns.tsx
@@ -75,7 +75,7 @@ export const columns = (
         <AddConcept
           rowId={id}
           tableId={tableId}
-          location="SR-Values"
+          contentType="scanreportvalue"
           disabled={canEdit ? false : true}
           addSR={addSR}
         />

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/columns.tsx
@@ -8,7 +8,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 export const columns = (
   addSR: (concept: ScanReportConcept, c: Concept) => void,
-  deleteSR: (id: number) => void
+  deleteSR: (id: number) => void,
+  tableId: string,
 ): ColumnDef<ScanReportValue>[] => [
   {
     id: "Value",
@@ -67,13 +68,13 @@ export const columns = (
     id: "Add Concept",
     header: "",
     cell: ({ row }) => {
-      const { scan_report_field, id, permissions } = row.original;
+      const { id, permissions } = row.original;
       const canEdit =
         permissions.includes("CanEdit") || permissions.includes("CanAdmin");
       return (
         <AddConcept
           rowId={id}
-          parentId={scan_report_field.toString()}
+          tableId={tableId}
           location="SR-Values"
           disabled={canEdit ? false : true}
           addSR={addSR}

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
@@ -83,6 +83,7 @@ export default async function ScanReportsValue({
           clickable={false}
           filterCol="value"
           filterText="value "
+          tableId={tableId}
         />
       </div>
     </div>

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/page.tsx
@@ -30,28 +30,32 @@ export default async function ScanReportsValue({
 }: ScanReportsValueProps) {
   const defaultPageSize = 20;
   const defaultParams = {
-    scan_report_field: fieldId,
     page_size: defaultPageSize,
   };
   const combinedParams = { ...defaultParams, ...searchParams };
   const query = objToQuery(combinedParams);
   const permissions = await getScanReportPermissions(id);
-  const scanReportsValues = await getScanReportValues(query);
-  const tableName = await getScanReportTable(tableId);
-  const fieldName = await getScanReportField(fieldId);
+  const table = await getScanReportTable(id, tableId);
+  const field = await getScanReportField(id, tableId, fieldId);
+  const scanReportsValues = await getScanReportValues(
+    id,
+    tableId,
+    fieldId,
+    query,
+  );
 
   const scanReportsConcepts =
     scanReportsValues.results.length > 0
       ? await getAllScanReportConcepts(
           `object_id__in=${scanReportsValues.results
             .map((item) => item.id)
-            .join(",")}`
+            .join(",")}`,
         )
       : [];
   const conceptsFilter =
     scanReportsConcepts.length > 0
       ? await getAllConceptsFiltered(
-          scanReportsConcepts?.map((item) => item.concept).join(",")
+          scanReportsConcepts?.map((item) => item.concept).join(","),
         )
       : [];
   return (
@@ -60,11 +64,11 @@ export default async function ScanReportsValue({
         {" "}
         <Link href={`/scanreports/${id}/tables/${tableId}`}>
           <Button variant={"secondary"} className="mb-3">
-            Table: {tableName.name}
+            Table: {table.name}
           </Button>
         </Link>
         <Button variant={"secondary"} className="mb-3">
-          Field: {fieldName.name}
+          Field: {field.name}
         </Button>
       </div>
       <div>

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/update/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/fields/[fieldId]/update/page.tsx
@@ -21,8 +21,8 @@ export default async function ScanReportsEditField({
   params: { id, tableId, fieldId },
 }: ScanReportsEditFieldProps) {
   const scanReport = await getScanReport(id);
-  const table = await getScanReportTable(tableId);
-  const field = await getScanReportField(fieldId);
+  const table = await getScanReportTable(id, tableId);
+  const field = await getScanReportField(id, tableId, fieldId);
   const permissions = await getScanReportPermissions(id);
 
   if (!scanReport) {

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/page.tsx
@@ -68,6 +68,7 @@ export default async function ScanReportsField({
           filterCol="name"
           filterText="field "
           linkPrefix="fields/"
+          tableId={tableId}
         />
       </div>
     </div>

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/page.tsx
@@ -27,13 +27,12 @@ export default async function ScanReportsField({
 }: ScanReportsFieldProps) {
   const defaultPageSize = 20;
   const defaultParams = {
-    scan_report_table: tableId,
     page_size: defaultPageSize,
   };
   const combinedParams = { ...defaultParams, ...searchParams };
   const query = objToQuery(combinedParams);
-  const tableName = await getScanReportTable(tableId);
-  const scanReportsFields = await getScanReportFields(query);
+  const tableName = await getScanReportTable(id, tableId);
+  const scanReportsFields = await getScanReportFields(id, tableId, query);
   const permissions = await getScanReportPermissions(id);
 
   const scanReportsConcepts =
@@ -41,14 +40,14 @@ export default async function ScanReportsField({
       ? await getAllScanReportConcepts(
           `object_id__in=${scanReportsFields.results
             .map((item) => item.id)
-            .join(",")}`
+            .join(",")}`,
         )
       : [];
 
   const conceptsFilter =
     scanReportsConcepts.length > 0
       ? await getAllConceptsFiltered(
-          scanReportsConcepts?.map((item) => item.concept).join(",")
+          scanReportsConcepts?.map((item) => item.concept).join(","),
         )
       : [];
 

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
@@ -32,16 +32,8 @@ export default async function UpdateTable({
   const scanReportsFields = await getAllScanReportFields(id, tableId, query);
 
   const table = await getScanReportTable(id, tableId);
-  const personId = await getScanReportField(
-    id,
-    tableId,
-    table.person_id as string,
-  );
-  const dateEvent = await getScanReportField(
-    id,
-    tableId,
-    table.date_event as string,
-  );
+  const personId = await getScanReportField(id, tableId, table.person_id?.id);
+  const dateEvent = await getScanReportField(id, tableId, table.date_event?.id);
   const permissions = await getScanReportPermissions(id);
 
   return (

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
@@ -23,18 +23,25 @@ export default async function UpdateTable({
 }: UpdateTableProps) {
   const defaultPageSize = 50;
   const defaultParams = {
-    scan_report_table: tableId,
     fields: "name,id",
     page_size: defaultPageSize,
   };
   const combinedParams = { ...defaultParams };
   const query = objToQuery(combinedParams);
 
-  const scanReportsFields = await getAllScanReportFields(query);
+  const scanReportsFields = await getAllScanReportFields(id, tableId, query);
 
-  const table = await getScanReportTable(tableId);
-  const personId = await getScanReportField(table.person_id as string);
-  const dateEvent = await getScanReportField(table.date_event as string);
+  const table = await getScanReportTable(id, tableId);
+  const personId = await getScanReportField(
+    id,
+    tableId,
+    table.person_id as string,
+  );
+  const dateEvent = await getScanReportField(
+    id,
+    tableId,
+    table.date_event as string,
+  );
   const permissions = await getScanReportPermissions(id);
 
   return (

--- a/app/next-client-app/components/concepts/ConceptDataTable.tsx
+++ b/app/next-client-app/components/concepts/ConceptDataTable.tsx
@@ -14,16 +14,18 @@ interface CustomDataTableProps<T> {
   defaultPageSize: 10 | 20 | 30 | 40 | 50;
   columns: (
     addConcept: (newConcept: ScanReportConcept, newConFilter: Concept) => void,
-    deleteConcept: (id: number) => void
+    deleteConcept: (id: number) => void,
+    tableId: string,
   ) => any;
   clickable?: boolean;
   filterCol: string;
   filterText: string;
   linkPrefix?: string;
+  tableId: string;
 }
 
 export function ConceptDataTable<
-  T extends { id: number; concepts?: Concept[]; permissions: Permission[] }
+  T extends { id: number; concepts?: Concept[]; permissions: Permission[] },
 >({
   scanReportsData,
   scanReportsConcepts,
@@ -36,6 +38,7 @@ export function ConceptDataTable<
   filterCol,
   filterText,
   linkPrefix,
+  tableId,
 }: CustomDataTableProps<T>) {
   const filter = <DataTableFilter filter={filterCol} filterText={filterText} />;
 
@@ -56,7 +59,7 @@ export function ConceptDataTable<
   const deleteConcept = (id: number) => {
     // filter it out.
     const updatedConcepts = neededConcepts.filter(
-      (concept) => concept.id !== id
+      (concept) => concept.id !== id,
     );
     setNeededConcepts(updatedConcepts);
   };
@@ -75,13 +78,13 @@ export function ConceptDataTable<
     scanReportsData,
     neededConcepts,
     neededConceptFilter,
-    permissions
+    permissions,
   );
 
   return (
     <div>
       <DataTable
-        columns={columns(addConcept, deleteConcept)}
+        columns={columns(addConcept, deleteConcept, tableId)}
         data={scanReportsResult}
         count={count}
         Filter={filter}

--- a/app/next-client-app/components/concepts/add-concept.tsx
+++ b/app/next-client-app/components/concepts/add-concept.tsx
@@ -10,29 +10,25 @@ import { toast } from "sonner";
 
 interface AddConceptProps {
   rowId: number;
-  location: string;
+  tableId: string;
+  contentType: "scanreportvalue" | "scanreportfield";
   disabled: boolean;
   addSR: (concept: ScanReportConcept, c: Concept) => void;
-  tableId: string;
 }
 
 export default function AddConcept({
   rowId,
-  location,
+  tableId,
+  contentType,
   disabled,
   addSR,
-  tableId,
 }: AddConceptProps) {
   const handleSubmit = async (conceptCode: number) => {
     try {
-      const determineContentType = (location: string) => {
-        return location === "SR-Values" ? "scanreportvalue" : "scanreportfield";
-      };
-
       const response = await addConcept({
         concept: conceptCode,
         object_id: rowId,
-        content_type: determineContentType(location),
+        content_type: contentType,
         creation_type: "M",
         table_id: tableId,
       });

--- a/app/next-client-app/components/concepts/add-concept.tsx
+++ b/app/next-client-app/components/concepts/add-concept.tsx
@@ -3,7 +3,6 @@ import {
   getAllConceptsFiltered,
   getAllScanReportConcepts,
 } from "@/api/concepts";
-import { getScanReportField } from "@/api/scanreports";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Form, Formik } from "formik";
@@ -11,18 +10,18 @@ import { toast } from "sonner";
 
 interface AddConceptProps {
   rowId: number;
-  parentId: string;
   location: string;
   disabled: boolean;
   addSR: (concept: ScanReportConcept, c: Concept) => void;
+  tableId: string;
 }
 
 export default function AddConcept({
   rowId,
-  parentId,
   location,
   disabled,
   addSR,
+  tableId,
 }: AddConceptProps) {
   const handleSubmit = async (conceptCode: number) => {
     try {
@@ -30,19 +29,12 @@ export default function AddConcept({
         return location === "SR-Values" ? "scanreportvalue" : "scanreportfield";
       };
 
-      const determineTableId = async (location: string, parentId: string) => {
-        if (location === "SR-Values") {
-          const field = await getScanReportField(parentId);
-          return field?.scan_report_table;
-        }
-        return parentId;
-      };
       const response = await addConcept({
         concept: conceptCode,
         object_id: rowId,
         content_type: determineContentType(location),
         creation_type: "M",
-        table_id: await determineTableId(location, parentId),
+        table_id: tableId,
       });
 
       if (response) {

--- a/app/next-client-app/components/core/sidebar.tsx
+++ b/app/next-client-app/components/core/sidebar.tsx
@@ -34,7 +34,7 @@ export function Sidebar({
         {
           "lg:hidden": onPublic,
           "border-b-2 border-gray-300": !onPublic,
-        }
+        },
       )}
     >
       <div className="flex items-center">
@@ -128,7 +128,6 @@ export function Sidebar({
             </SheetContent>
           </Sheet>
         </div>
-        {/* TODO: Need to confirm again this link */}
         <Link href={"/"}>
           <div className="text-2xl flex items-center font-semibold">
             <Image

--- a/app/next-client-app/components/scanreports/ScanReportFieldEditForm.tsx
+++ b/app/next-client-app/components/scanreports/ScanReportFieldEditForm.tsx
@@ -38,8 +38,10 @@ export function ScanReportFieldEditForm({
       };
 
       const response = await updateScanReportField(
+        scanreportId,
+        scanReportField.scan_report_table,
         scanReportField?.id.toString(),
-        submittingData
+        submittingData,
       );
       if (response) {
         toast.error(`Update Dataset failed. Error: ${response.errorMessage}`);

--- a/app/next-client-app/components/scanreports/ScanReportTableUpdateForm.tsx
+++ b/app/next-client-app/components/scanreports/ScanReportTableUpdateForm.tsx
@@ -42,13 +42,13 @@ export function ScanReportTableUpdateForm({
     };
 
     const response = await updateScanReportTable(
+      scanreportTable.scan_report,
       scanreportTable.id,
       submittingData,
-      scanreportTable.scan_report
     );
     if (response) {
       toast.error(
-        `Update Scan Report Table failed. Error: ${response.errorMessage}`
+        `Update Scan Report Table failed. Error: ${response.errorMessage}`,
       );
     } else {
       toast.success("Update Scan Report Table successful!");

--- a/app/next-client-app/types/omop.ts
+++ b/app/next-client-app/types/omop.ts
@@ -1,14 +1,8 @@
 interface Concept {
   concept_id: number;
   concept_name: string;
-  domain_id: string;
-  vocabulary_id: string;
-  concept_class_id: string;
-  standard_concept: string | null;
   concept_code: string;
-  valid_start_date: Date;
-  valid_end_date: Date;
-  invalid_reason: string;
+  // TODO: these are added in code, not returned in API.
   scan_report_concept_id?: number;
   creation_type: string;
 }

--- a/app/next-client-app/types/scanreport.ts
+++ b/app/next-client-app/types/scanreport.ts
@@ -18,8 +18,8 @@ interface ScanReportTable {
   updated_at: Date;
   name: string;
   scan_report: number;
-  person_id: string | null;
-  date_event: string | null;
+  person_id: ScanReportField | null;
+  date_event: ScanReportField | null;
   permissions: Permission[];
 }
 

--- a/app/next-client-app/types/scanreport.ts
+++ b/app/next-client-app/types/scanreport.ts
@@ -50,14 +50,6 @@ interface ScanReportField {
 
 interface ScanReportConcept {
   id: number;
-  created_at: Date;
-  updated_at: Date;
-  nlp_entity: string | null;
-  nlp_entity_type: string | null;
-  nlp_confidence: string | null;
-  nlp_vocabulary: string | null;
-  nlp_concept_code: string | null;
-  nlp_processed_string: string | null;
   object_id: number;
   creation_type: string;
   concept: Concept | number;

--- a/app/shared/pyproject.toml
+++ b/app/shared/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "shared"
-version = "0.3.1"
+version = "0.3.2"
 description = "Carrot shared library"
 authors = ["Sam Cox <sam.cox@nottingham.ac.uk>", "Philip Quinlan <philip.quinlan@nottingham.ac.uk>"]
 license = "MIT"


### PR DESCRIPTION
# Changes

Restructure API endpoints, making `scanreports` nested. 

For example: `/api/v2/scanreports/42/tables` replaces `api/scanreporttables?scan_report=42`

This dramatically simplifies permissions, and routing.

Fix for #857 
Fix for #854 
