### PR TITLE
Fix Adding dataset to projects where users don't have membership

### DIFF
--- a/app/api/datasets/serializers.py
+++ b/app/api/datasets/serializers.py
@@ -2,12 +2,19 @@ from drf_dynamic_fields import DynamicFieldsMixin  # type: ignore
 from rest_framework import serializers
 from shared.mapping.models import DataPartner, Dataset
 from shared.mapping.permissions import is_admin, is_az_function_user
+from projects.serializers import ProjectNameSerializer
 
 
 class DataPartnerSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     class Meta:
         model = DataPartner
         fields = "__all__"
+
+
+class DataPartnerNameSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    class Meta:
+        model = DataPartner
+        fields = ("id", "name")
 
 
 class DatasetSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
@@ -41,6 +48,9 @@ class DatasetAndDataPartnerViewSerializer(
 
 
 class DatasetViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer):
+    projects = ProjectNameSerializer(many=True, read_only=True)
+    data_partner = DataPartnerNameSerializer(read_only=True)
+
     class Meta:
         model = Dataset
         fields = (

--- a/app/api/projects/serializers.py
+++ b/app/api/projects/serializers.py
@@ -21,6 +21,16 @@ class ProjectNameSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
 
     class Meta:
         model = Project
+        fields = ["id", "name"]
+
+
+class ProjectWithMembersSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
+    """
+    Serialiser for showing the names and members of Projects. Use in non-admin ListViews.
+    """
+
+    class Meta:
+        model = Project
         fields = ["id", "name", "members"]
 
 

--- a/app/api/projects/views.py
+++ b/app/api/projects/views.py
@@ -4,7 +4,6 @@ from projects.serializers import (
     ProjectNameSerializer,
     ProjectSerializer,
 )
-from rest_framework import generics
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
 from shared.mapping.models import Project
@@ -37,7 +36,7 @@ class ProjectList(ListAPIView):
                 datasets__exact=dataset, members__id=self.request.user.id
             ).distinct()
 
-        return Project.objects.all()
+        return Project.objects.filter(members__id=self.request.user.id).distinct()
 
 
 class ProjectDetail(RetrieveAPIView):

--- a/app/api/projects/views.py
+++ b/app/api/projects/views.py
@@ -1,8 +1,8 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from projects.serializers import (
     ProjectDatasetSerializer,
-    ProjectNameSerializer,
     ProjectSerializer,
+    ProjectWithMembersSerializer,
 )
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.permissions import IsAuthenticated
@@ -28,7 +28,7 @@ class ProjectList(ListAPIView):
         if self.request.GET.get("datasets") is not None:
             return ProjectDatasetSerializer
 
-        return ProjectNameSerializer
+        return ProjectWithMembersSerializer
 
     def get_queryset(self):
         if dataset := self.request.GET.get("dataset"):

--- a/app/next-client-app/api/datasets.ts
+++ b/app/next-client-app/api/datasets.ts
@@ -23,7 +23,7 @@ const fetchKeys = {
 };
 
 export async function getDataSets(
-  filter: string | undefined,
+  filter: string | undefined
 ): Promise<PaginatedResponse<DataSet>> {
   try {
     return await request<DataSet>(fetchKeys.list(filter));
@@ -45,7 +45,12 @@ export async function getDataSet(id: string): Promise<DataSetSRList> {
       name: "",
       visibility: "",
       hidden: null,
-      data_partner: 0,
+      data_partner: {
+        id: 0,
+        name: "",
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
       viewers: [],
       admins: [],
       editors: [],
@@ -55,7 +60,7 @@ export async function getDataSet(id: string): Promise<DataSetSRList> {
 }
 
 export async function getDatasetList(
-  filter?: string,
+  filter?: string
 ): Promise<DataSetSRList[]> {
   try {
     return await request<DataSetSRList>(fetchKeys.datasetList(filter));
@@ -124,7 +129,7 @@ export async function updateDatasetDetails(id: number, data: {}) {
 }
 
 export async function getDatasetPermissions(
-  id: string,
+  id: string
 ): Promise<PermissionsResponse> {
   try {
     return await request<PermissionsResponse>(fetchKeys.permissions(id));

--- a/app/next-client-app/app/(protected)/datasets/[id]/layout.tsx
+++ b/app/next-client-app/app/(protected)/datasets/[id]/layout.tsx
@@ -5,12 +5,7 @@ import { Boundary } from "@/components/core/boundary";
 import { Suspense } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { format } from "date-fns/format";
-import {
-  getDataPartners,
-  getDataSet,
-  getDatasetPermissions,
-  getProjects,
-} from "@/api/datasets";
+import { getDataSet, getDatasetPermissions } from "@/api/datasets";
 import { Badge } from "@/components/ui/badge";
 import { InfoItem } from "@/components/core/InfoItem";
 import Link from "next/link";
@@ -34,22 +29,15 @@ export default async function DatasetLayout({
   ];
 
   const dataset = await getDataSet(params.id);
-  // Get the list of data partners then filter it
-  const dataPartnersList = await getDataPartners();
-  const dataPartner = dataPartnersList.filter(
-    (partner) => partner.id === dataset.data_partner,
-  );
-  // Get the list of projects then filter it
-  const projectsList = await getProjects();
-  const projects = projectsList.filter((project) =>
-    dataset.projects.includes(project.id),
-  );
+
+  const dataPartner = dataset.data_partner;
+  const projects = dataset.projects;
 
   const createdDate = new Date(dataset.created_at);
   // Checking permissions
   if (
     !requiredPermissions.some((permission) =>
-      permissions.permissions.includes(permission),
+      permissions.permissions.includes(permission)
     )
   ) {
     return <Forbidden />;
@@ -83,7 +71,7 @@ export default async function DatasetLayout({
         </h3>
         <InfoItem
           label="Data Partner"
-          value={dataPartner[0].name}
+          value={dataPartner.name}
           className="py-1 md:py-0 md:px-3"
         />
         <InfoItem

--- a/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
+++ b/app/next-client-app/components/datasets/CreateDatasetDialog.tsx
@@ -37,7 +37,9 @@ export function CreateDatasetDialog({
       </DialogTrigger>
       <DialogContent className="w-full">
         <DialogHeader>
-          <DialogTitle>Create a New Dataset</DialogTitle>
+          <DialogTitle className="text-center">
+            Create a New Dataset
+          </DialogTitle>
         </DialogHeader>
         {description && (
           <DialogDescription className="justify-center items-center text-center">

--- a/app/next-client-app/components/datasets/DatasetForm.tsx
+++ b/app/next-client-app/components/datasets/DatasetForm.tsx
@@ -49,7 +49,7 @@ export function DatasetForm({
   const projectOptions = FormDataFilter<Project>(projects);
   // Find the intial data partner which is required when adding Dataset
   const initialPartner = dataPartners.find(
-    (partner) => dataset.data_partner === partner.id
+    (partner) => dataset.data_partner.id === partner.id
   )!;
   // Find and make initial data suitable for React select
   const initialPartnerFilter = FormDataFilter<DataPartner>(initialPartner);
@@ -58,7 +58,7 @@ export function DatasetForm({
   const initialAdminsFilter = FindAndFormat<User>(users, dataset.admins);
   const initialProjectFilter = FindAndFormat<Project>(
     projects,
-    dataset.projects
+    dataset.projects.map((project) => project.id)
   );
 
   const handleSubmit = async (data: FormData) => {

--- a/app/next-client-app/components/form-components/FormikSelectDataset.tsx
+++ b/app/next-client-app/components/form-components/FormikSelectDataset.tsx
@@ -4,12 +4,10 @@ import {
   FieldProps,
   FormikProps,
   FormikValues,
-  useField,
   useFormikContext,
 } from "formik";
 import Select from "react-select";
 import makeAnimated from "react-select/animated";
-import config from "@/tailwind.config";
 import { getDatasetList, getProjects } from "@/api/datasets";
 import { useEffect, useState } from "react";
 
@@ -38,15 +36,17 @@ async function fetchDataset(dataPartner: string): Promise<GroupedOption[]> {
 
   // Process datasets, adding them to the appropriate project group in projectMap
   datasets.forEach((dataset) => {
-    dataset.projects.forEach((projectId) => {
-      const projectGroup = projectMap.get(projectId);
-      if (projectGroup) {
-        projectGroup.options.push({
-          value: dataset.id,
-          label: dataset.name,
-        });
-      }
-    });
+    dataset.projects
+      .map((project) => project.id)
+      .forEach((projectId) => {
+        const projectGroup = projectMap.get(projectId);
+        if (projectGroup) {
+          projectGroup.options.push({
+            value: dataset.id,
+            label: dataset.name,
+          });
+        }
+      });
   });
 
   // Ensure all projects without datasets have a "None" option

--- a/app/next-client-app/components/form-components/FormikSelectEditors.tsx
+++ b/app/next-client-app/components/form-components/FormikSelectEditors.tsx
@@ -4,7 +4,6 @@ import {
   FieldProps,
   FormikProps,
   FormikValues,
-  useField,
   useFormikContext,
 } from "formik";
 import Select from "react-select";

--- a/app/next-client-app/components/form-components/FormikSelectUsers.tsx
+++ b/app/next-client-app/components/form-components/FormikSelectUsers.tsx
@@ -8,7 +8,6 @@ import {
 } from "formik";
 import Select from "react-select";
 import makeAnimated from "react-select/animated";
-import config from "@/tailwind.config";
 import { getDataUsers, getProjects } from "@/api/datasets";
 import { useEffect, useState } from "react";
 import { FindAndFormat } from "./FormikUtils";

--- a/app/next-client-app/types/dataset.ts
+++ b/app/next-client-app/types/dataset.ts
@@ -25,11 +25,11 @@ interface DataSetSRList {
   name: string;
   visibility: string;
   hidden: boolean | null;
-  data_partner: number;
+  data_partner: DataPartner;
   viewers: number[];
   admins: number[];
   editors: number[];
-  projects: number[];
+  projects: Project[];
 }
 interface Project {
   id: number;


### PR DESCRIPTION
# Changes

This PR added a fix for issue #835 where users can add a new dataset to a project they are not a member. Now, users can't see the project they are not in in the list of projects in the Add Dataset form or anywhere else.

Also, this PR improved the code for the dataset details section

Closes #835 

# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
