### PR TITLE
Add Author column to ScanReport list page

### DIFF
--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -49,6 +49,7 @@ class ScanReportViewSerializerV2(DynamicFieldsMixin, serializers.ModelSerializer
         NotFound: If the parent dataset is not found.
     """
 
+    author = UserSerializer(read_only=True)
     parent_dataset = DatasetSerializer(read_only=True)
     data_partner = serializers.SerializerMethodField()
 

--- a/app/next-client-app/app/(protected)/scanreports/[id]/downloads/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/downloads/page.tsx
@@ -30,21 +30,22 @@ export default async function Downloads({
 
   return (
     <div>
-      <Alert className="max-w-sm">
-        <AlertDescription className="flex">
-          <InfoIcon className="h-4 w-4 mr-2" />
-          <AlertTitle>
-            Downloads might take a few minutes to be ready.
-          </AlertTitle>
-        </AlertDescription>
-      </Alert>
-
       {filesList && (
         <DataTable
           columns={columns}
           data={filesList.results}
           count={filesList.count}
           clickableRow={false}
+          Filter={
+            <Alert className="max-w-sm h-10 flex items-center">
+              <AlertDescription className="flex">
+                <InfoIcon className="h-4 w-4 mr-2" />
+                <AlertTitle>
+                  Downloads might take a few minutes to be ready.
+                </AlertTitle>
+              </AlertDescription>
+            </Alert>
+          }
           defaultPageSize={defaultPageSize}
         />
       )}

--- a/app/next-client-app/app/(protected)/scanreports/[id]/layout.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/layout.tsx
@@ -57,7 +57,7 @@ export default async function ScanReportLayout({
 
   if (
     !requiredPermissions.some((permission) =>
-      permissions.permissions.includes(permission),
+      permissions.permissions.includes(permission)
     )
   ) {
     return <Forbidden />;
@@ -84,6 +84,11 @@ export default async function ScanReportLayout({
           label="Data Partner"
           value={scanreport.data_partner}
           className="py-1 md:py-0 md:pr-3"
+        />
+        <InfoItem
+          label="Author"
+          value={scanreport.author.username}
+          className="py-1 md:py-0 md:px-3"
         />
         <InfoItem
           label="Created"

--- a/app/next-client-app/app/(protected)/scanreports/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/columns.tsx
@@ -73,6 +73,19 @@ export const columns: ColumnDef<ScanReport>[] = [
     enableSorting: false,
   },
   {
+    id: "Author",
+    accessorKey: "author",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Author" />
+    ),
+    enableHiding: true,
+    enableSorting: true,
+    cell: ({ row }) => {
+      const { author } = row.original;
+      return author.username;
+    },
+  },
+  {
     id: "Uploaded",
     accessorKey: "created_at",
     header: ({ column }) => (

--- a/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
+++ b/app/next-client-app/components/scanreports/ScanReportDetailsForm.tsx
@@ -39,7 +39,7 @@ export function ScanReportDetailsForm({
   const canUpdate = permissions.includes("CanAdmin") || isAuthor;
   // State control for viewers fields
   const [publicVisibility, setPublicVisibility] = useState<boolean>(
-    scanreport.visibility === "PUBLIC" ? true : false,
+    scanreport.visibility === "PUBLIC" ? true : false
   );
 
   // Making options suitable for React Select
@@ -47,10 +47,10 @@ export function ScanReportDetailsForm({
   const parentDatasetOptions = FormDataFilter<DataSetSRList>(datasetList);
   // Find the intial parent dataset and author which is required when adding Dataset
   const initialParentDataset = datasetList.find(
-    (dataset) => scanreport.parent_dataset.name === dataset.name, // parent's dataset is unique (set by the models.py) so can be used to find the initial parent dataset here
+    (dataset) => scanreport.parent_dataset.name === dataset.name // parent's dataset is unique (set by the models.py) so can be used to find the initial parent dataset here
   )!;
 
-  const initialAuthor = users.find((user) => scanreport.author === user.id)!;
+  const initialAuthor = users.find((user) => scanreport.author.id === user.id)!;
   // Find and make initial data suitable for React select
   const initialDatasetFilter =
     FormDataFilter<DataSetSRList>(initialParentDataset);
@@ -71,7 +71,7 @@ export function ScanReportDetailsForm({
     const response = await updateScanReport(
       scanreport.id,
       submittingData,
-      true, // "true" for the value "needRedirect"
+      true // "true" for the value "needRedirect"
     );
     if (response) {
       toast.error(`Update Scan Report failed. Error: ${response.errorMessage}`);

--- a/app/next-client-app/types/scanreport.ts
+++ b/app/next-client-app/types/scanreport.ts
@@ -7,7 +7,7 @@ interface ScanReport {
   created_at: Date;
   hidden: boolean;
   visibility: string;
-  author: number;
+  author: User;
   viewers: number[];
   editors: number[];
 }


### PR DESCRIPTION
# Changes

This PR adds the Author column to the ScanReport list page and SR details line.

Also, the Alert box on the Download page is now moved to the same line with the Columns button.

Closes #715 

# Screenshots
![Screenshot 2024-09-02 at 16 08 29](https://github.com/user-attachments/assets/8acfb46d-ea63-42c2-a94f-5211f1aae59f)


# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
