### PR TITLE
Fix error when add concept at value level

### DIFF
--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -553,7 +553,16 @@ class ScanReportConceptListV2(
 
         # Get the domain and data type of the field for the check below
         domain = concept.domain_id.lower()
-        field_datatype = ScanReportField.objects.get(pk=body["object_id"]).type_column
+        # If users add the concept at "SR_Field" level
+        try:
+            field_datatype = ScanReportField.objects.get(
+                pk=body["object_id"]
+            ).type_column
+        # If users add the concept at "SR_Value" level
+        except:
+            field_datatype = ScanReportValue.objects.get(
+                pk=body["object_id"]
+            ).scan_report_field.type_column
 
         # Checking field's datatype for concept with domain Observation
         if domain == "observation" and field_datatype not in ["REAL", "INT", "VARCHAR"]:

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -565,7 +565,13 @@ class ScanReportConceptListV2(
             ).scan_report_field.type_column
 
         # Checking field's datatype for concept with domain Observation
-        if domain == "observation" and field_datatype not in ["REAL", "INT", "VARCHAR"]:
+        if domain == "observation" and field_datatype.lower() not in [
+            "real",
+            "int",
+            "varchar",
+            "nvarchar",
+            "float",
+        ]:
             return Response(
                 {
                     "detail": "Concept having 'Observation' domain should be only added to fields having REAL, INT, or VARCHAR data type."

--- a/app/next-client-app/app/(protected)/scanreports/[id]/layout.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/layout.tsx
@@ -68,15 +68,19 @@ export default async function ScanReportLayout({
     <div className="space-y-2">
       {/* Details line */}
       <div className="flex font-semibold text-xl items-center space-x-2">
-        <Folders className="text-gray-500" />
         <Link href={`/datasets/${scanreport.parent_dataset.id}`}>
-          <h2 className="text-gray-500 dark:text-gray-400">
+          <h2 className="text-gray-500 dark:text-gray-400 flex items-center">
+            <Folders className="text-gray-500 mr-2" />
             {scanreport.parent_dataset.name}
           </h2>
         </Link>
         <h2 className="text-gray-500 dark:text-gray-400">{"/"}</h2>
-        <FileScan className=" text-green-700" />
-        <h2>{scanreport.dataset}</h2>
+        <Link href={`/scanreports/${scanreport.id}`}>
+          <h2 className="flex items-center">
+            <FileScan className="text-green-700 mr-2" />
+            {scanreport.dataset}
+          </h2>
+        </Link>
       </div>
 
       <div className="flex flex-col md:flex-row md:items-center h-7 text-sm space-y-2 md:space-y-0 divide-y md:divide-y-0 md:divide-x divide-gray-300">

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -313,7 +313,7 @@ def _save_mapping_rules(scan_report_concept: ScanReportConcept) -> bool:
 
     concept = scan_report_concept.concept
 
-    type_column = source_field.type_column
+    type_column = source_field.type_column.lower()
     # get the omop field for the source_concept_id for this domain
     domain = concept.domain_id.lower()
 
@@ -400,7 +400,9 @@ def _save_mapping_rules(scan_report_concept: ScanReportConcept) -> bool:
 
     # When the concept has the domain "Observation", one more mapping rule to the OMOP field
     # "value_as_number"/"value_as_string" will be added based on the field's datatype
-    if domain == "observation" and (type_column == "INT" or type_column == "REAL"):
+    if domain == "observation" and (
+        type_column == "int" or type_column == "real" or type_column == "float"
+    ):
         # create/update a model for the domain value_as_number
         #  - for this destination_field and source_field
         #  - do_term_mapping is set to false
@@ -413,7 +415,9 @@ def _save_mapping_rules(scan_report_concept: ScanReportConcept) -> bool:
         )
         rules.append(rule_domain_value_as_number)
 
-    if domain == "observation" and (type_column == "VARCHAR"):
+    if domain == "observation" and (
+        type_column == "varchar" or type_column == "nvarchar"
+    ):
         # create/update a model for the domain value_as_string
         #  - for this destination_field and source_field
         #  - do_term_mapping is set to false


### PR DESCRIPTION
# Changes

This PR added a fix to the error when users can't add the new concept at the value level, which was caused by field datatype check in #881 

The supported data types of the SR field for the Observation table are updated in this PR as well.

Also, added a link to the breadcrumb section for SR.


# Checks

**Important:** please complete these **before** merging.
- [x] Run migrations, if any.
- [x] Update `changelog.md`, including migration instructions if any.
- [x] Run unit tests.
