### PR TITLE
Fix Carrot's reuse function

### DIFF
--- a/app/next-client-app/components/concepts/concept-tags.tsx
+++ b/app/next-client-app/components/concepts/concept-tags.tsx
@@ -60,7 +60,7 @@ export const ConceptTags = React.memo(function ConceptTags({
                 : concept.creation_type === "R"
                 ? "bg-carrot-reuse hover:bg-carrot-reuse dark:bg-carrot-reuse dark:text-white"
                 : ""
-            }`}
+            } ${concepts.length > 1 && "my-[1px]"}`}
             key={concept.concept_code}
           >
             <p className="pl-2 pr-1 py-1">{`${concept.concept_id} ${concept.concept_name} (${concept.creation_type})`}</p>

--- a/app/workers/RulesConceptsActivity/reuse.py
+++ b/app/workers/RulesConceptsActivity/reuse.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Tuple, Union
-
+from collections import defaultdict
 from shared.mapping.models import ScanReportConcept, ScanReportField, ScanReportValue
 from shared_code import db
 from shared_code.logger import logger
@@ -178,19 +178,22 @@ def reuse_existing_field_concepts(new_fields_map: List[ScanReportFieldDict]) -> 
 
     existing_field_concepts = db.get_scan_report_active_concepts(content_type)
 
-    # create dictionary that maps existing field ids to scan report concepts
-    # from the list of existing scan report concepts from active SRs
-    existing_field_id_to_concept_map = {
-        str(element.object_id): str(element.concept.pk)
-        for element in existing_field_concepts
-    }
+    # Create a defaultdict that maps existing field ids to scan report concepts
+    existing_field_id_to_concept_map = defaultdict(list)
+
+    for element in existing_field_concepts:
+        existing_field_id_to_concept_map[str(element.object_id)].append(
+            str(element.concept.pk)
+        )
+
+    # Convert defaultdict to a regular dictionary if needed
+    existing_field_id_to_concept_map = dict(existing_field_id_to_concept_map)
     logger.debug(
         f"field_id:concept_id for all existing fields in active SRs with concepts: "
         f"{existing_field_id_to_concept_map}"
     )
 
-    # get details of existing selected fields, for the purpose of matching against
-    # new fields
+    # Get details of existing selected fields, for the purpose of matching against new fields
     existing_field_ids = {item.object_id for item in existing_field_concepts}
     existing_fields = ScanReportField.objects.filter(id__in=existing_field_ids).all()
     logger.debug(
@@ -222,8 +225,7 @@ def reuse_existing_field_concepts(new_fields_map: List[ScanReportFieldDict]) -> 
     #
     # [{"id":, "name":}]
 
-    # Now we simply look for unique matches on "name" across
-    # the two.
+    # Now we simply look for unique matches on "name" across the two.
 
     # existing_field_name_to_field_and_concept_id_map will contain
     # (field_name) -> (field_id, concept_id)
@@ -238,17 +240,20 @@ def reuse_existing_field_concepts(new_fields_map: List[ScanReportFieldDict]) -> 
             )
         )
 
+        # Flatten the list of concept IDs
         target_concept_ids = {
-            mapping["concept"] for mapping in mappings_matching_field_name
+            concept_id
+            for mapping in mappings_matching_field_name
+            for concept_id in mapping["concept"]
         }
 
-        if len(target_concept_ids) == 1:
-            target_field_id = (
+        if len(target_concept_ids) != 0:
+            target_field_id = next(
                 mapping["id"] for mapping in mappings_matching_field_name
             )
             existing_field_name_to_field_and_concept_id_map[str(name)] = (
-                str(next(target_field_id)),
-                str(target_concept_ids.pop()),
+                str(target_field_id),
+                list(map(str, target_concept_ids)),  # Store all concept IDs as a list
             )
 
     # Use the new_fields_full_details as keys into
@@ -261,19 +266,17 @@ def reuse_existing_field_concepts(new_fields_map: List[ScanReportFieldDict]) -> 
     ):
         ScanReportConcept.objects.bulk_create(concepts_to_post)
         logger.info("POST concepts all finished in reuse_existing_field_concepts")
+    else:
+        logger.info("No concepts to post")
 
 
 def select_concepts_to_post(
     new_content_details: List[Dict[str, str]],
-    details_to_id_and_concept_id_map: Union[
-        Dict[str, Tuple[str, str]],
+    details_to_id_and_concept_ids_map: Union[
+        Dict[str, Tuple[str, List[str]]],
         Dict[
-            Tuple[
-                str,
-                str,
-                str,
-            ],
-            Tuple[str, str],
+            Tuple[str, str, str],
+            Tuple[str, List[str]],
         ],
     ],
     content_type: ScanReportConceptContentType,
@@ -290,7 +293,7 @@ def select_concepts_to_post(
           or "id", "name", "description", and "field_name" keys (for values).
 
         details_to_id_and_concept_id_map (List[Dict[str, str]]): keys "name" (for fields) or ("name",
-          "description", "field_name") keys (for values), with entries (field_id, concept_id)
+          "description", "field_name") keys (for values), with a list of entries (field_id, concept_id)
           or (value_id, concept_id) respectively.
 
         content_type (Literal["scanreportfield", "scanreportvalue"]): Controls whether to handle ScanReportFields, or ScanReportValues.
@@ -317,15 +320,16 @@ def select_concepts_to_post(
             raise ValueError(f"Unsupported content_type: {content_type}")
 
         try:
-            existing_content_id, concept_id = details_to_id_and_concept_id_map[key]  # type: ignore
-            logger.info(
-                f"Found existing {'field' if content_type == ScanReportConceptContentType.FIELD else 'value'} with id: {existing_content_id} "
-                f"with existing concept mapping: {concept_id} which matches new {'field' if content_type == ScanReportConceptContentType.FIELD else 'value'} id: {new_content_detail['id']}"
-            )
-            if concept_entry := db.create_concept(
-                concept_id, str(new_content_detail["id"]), content_type, "R"
-            ):
-                concepts_to_post.append(concept_entry)
+            existing_content_id, concept_ids = details_to_id_and_concept_ids_map[key]  # type: ignore
+            for concept_id in concept_ids:
+                logger.info(
+                    f"Found existing {'field' if content_type == ScanReportConceptContentType.FIELD else 'value'} with id: {existing_content_id} "
+                    f"with existing concept mapping: {concept_id} which matches new {'field' if content_type == ScanReportConceptContentType.FIELD else 'value'} id: {new_content_detail['id']}"
+                )
+                if concept_entry := db.create_concept(
+                    concept_id, str(new_content_detail["id"]), content_type, "R"
+                ):
+                    concepts_to_post.append(concept_entry)
         except KeyError:
             continue
 

--- a/app/workers/RulesConceptsActivity/reuse.py
+++ b/app/workers/RulesConceptsActivity/reuse.py
@@ -181,7 +181,7 @@ def reuse_existing_field_concepts(new_fields_map: List[ScanReportFieldDict]) -> 
     # create dictionary that maps existing field ids to scan report concepts
     # from the list of existing scan report concepts from active SRs
     existing_field_id_to_concept_map = {
-        str(element.object_id): str(element.concept)
+        str(element.object_id): str(element.concept.pk)
         for element in existing_field_concepts
     }
     logger.debug(

--- a/app/workers/shared_code/db.py
+++ b/app/workers/shared_code/db.py
@@ -139,16 +139,26 @@ def get_scan_report_active_concepts(
     Returns:
         - QuerySet[ScanReportConcept]: The list of Scan Report Concepts.
     """
+
     content_type_model = ContentType.objects.get(model=content_type.value)
 
-    value_ids = ScanReportValue.objects.filter(
-        scan_report_field__scan_report_table__scan_report__hidden=False,
-        scan_report_field__scan_report_table__scan_report__parent_dataset__hidden=False,
-        scan_report_field__scan_report_table__scan_report__status="COMPLET",
-    ).values_list("id", flat=True)
+    if content_type == ScanReportConceptContentType.FIELD:
+        object_ids = ScanReportField.objects.filter(
+            scan_report_table__scan_report__hidden=False,
+            scan_report_table__scan_report__parent_dataset__hidden=False,
+            scan_report_table__scan_report__status="COMPLET",
+        ).values_list("id", flat=True)
+    elif content_type == ScanReportConceptContentType.VALUE:
+        object_ids = ScanReportValue.objects.filter(
+            scan_report_field__scan_report_table__scan_report__hidden=False,
+            scan_report_field__scan_report_table__scan_report__parent_dataset__hidden=False,
+            scan_report_field__scan_report_table__scan_report__status="COMPLET",
+        ).values_list("id", flat=True)
+    else:
+        raise ValueError(f"Unsupported content type: {content_type}")
 
     return ScanReportConcept.objects.filter(
-        content_type=content_type_model, object_id__in=value_ids
+        content_type=content_type_model, object_id__in=object_ids
     ).all()
 
 


### PR DESCRIPTION
# Changes

This PR added a fix for the Carrot reuse vocabulary function which couldn't reuse multiple concepts added at the same Scan report field or value.

The fix focused on enabling Carrot to handle multiple existing concepts at both the field and value level of an SR.

This PR also added small gaps between concept tags

Closes #626 

# Screenshots

<img width="1214" alt="Screenshot 2024-09-30 at 12 44 50" src="https://github.com/user-attachments/assets/dba9f2aa-79a4-483c-8051-f11314a0e072">


<screenshot.jpg>

# Checks

**Important:** please complete these **before** merging.
- [ ] Run migrations, if any.
- [ ] Update `changelog.md`, including migration instructions if any.
- [ ] Run unit tests.
