### PR TITLE
Fix delete ScanReport dialog

### DIFF
--- a/app/next-client-app/app/(protected)/scanreports/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/columns.tsx
@@ -163,7 +163,10 @@ export const columns: ColumnDef<ScanReport>[] = [
                   <EyeNoneIcon className="ml-auto" />
                 )}
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => setOpen(true)}>
+              <DropdownMenuItem
+                onClick={() => setOpen(true)}
+                className="text-red-400"
+              >
                 Delete <TrashIcon className="ml-auto" />
               </DropdownMenuItem>
             </DropdownMenuContent>


### PR DESCRIPTION
# Changes

This PR fixes the delete ScanReport dialog in the route /scanreports/{id}/ which had the problem opening on the route's layout.

Closes #908 
