### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,36 +36,36 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Tag and build frontend
-      - name: Extract frontend Docker metadata
-        id: frontend_meta
-        uses:  docker/metadata-action@v5.5.1
-        with:
-          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend
+      # # Tag and build frontend
+      # - name: Extract frontend Docker metadata
+      #   id: frontend_meta
+      #   uses:  docker/metadata-action@v5.5.1
+      #   with:
+      #     images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend
 
-      - name: Build and push frontend image
-        uses: docker/build-push-action@v5.3.0
-        with:
-          context: ./app/next-client-app
-          file: ./app/next-client-app/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.frontend_meta.outputs.tags }}
+      # - name: Build and push frontend image
+      #   uses: docker/build-push-action@v5.3.0
+      #   with:
+      #     context: ./app/next-client-app
+      #     file: ./app/next-client-app/Dockerfile
+      #     push: true
+      #     platforms: linux/amd64,linux/arm64
+      #     tags: ${{ steps.frontend_meta.outputs.tags }}
 
-      # Tag and for backend
-      - name: Extract backend Docker metadata
-        id: backend_meta
-        uses:  docker/metadata-action@v5.5.1
-        with:
-          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend
+      # # Tag and for backend
+      # - name: Extract backend Docker metadata
+      #   id: backend_meta
+      #   uses:  docker/metadata-action@v5.5.1
+      #   with:
+      #     images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend
 
-      - name: Build and push backend image
-        uses: docker/build-push-action@v5.3.0
-        with:
-          file: ./app/Dockerfile.deploy
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.backend_meta.outputs.tags }}
+      # - name: Build and push backend image
+      #   uses: docker/build-push-action@v5.3.0
+      #   with:
+      #     file: ./app/Dockerfile.deploy
+      #     push: true
+      #     platforms: linux/amd64,linux/arm64
+      #     tags: ${{ steps.backend_meta.outputs.tags }}
 
       # Tag and for workers
       - name: Extract workers Docker metadata
@@ -77,7 +77,6 @@ jobs:
       - name: Build and push workers image
         uses: docker/build-push-action@v5.3.0
         with:
-          context: ./app/workers
           file: ./app/workers/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,35 +33,53 @@ jobs:
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.registry }}
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Tag and build frontend
+      - name: Extract frontend Docker metadata
+        id: frontend_meta
+        uses:  docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5.3.0
         with:
-          context: .app/next-client-app
+          context: ./app/next-client-app
           file: ./app/next-client-app/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend:${{ github.sha }}
+          tags: ${{ steps.frontend_meta.outputs.tags }}
+
+      # Tag and for backend
+      - name: Extract backend Docker metadata
+        id: backend_meta
+        uses:  docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5.3.0
         with:
           context: ./app
           file: ./app/Dockerfile.deploy
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend:${{ github.sha }}
+          tags: ${{ steps.backend_meta.outputs.tags }}
+
+      # Tag and for workers
+      - name: Extract workers Docker metadata
+        id: workers_meta
+        uses:  docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/workers
 
       - name: Build and push workers image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5.3.0
         with:
-          context: .app/workers
+          context: ./app/workers
           file: ./app/workers/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: |
-            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/workers:${{ github.sha }}
+          tags: ${{ steps.workers_meta.outputs.tags }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,13 @@
 name: Publish release images to Github Registry
 
+# on:
+#   release:
+#     types: [released]
 on:
-  release:
-    types: [released]
+  push:
+    branches:
+      - feat/863/add-release-workflow
+
 
 env:
   app-name: carrot
@@ -39,7 +44,6 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend:${{ github.event.release.tag_name }}
             ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend:${{ github.sha }}
 
       - name: Build and push backend image
@@ -50,7 +54,6 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend:${{ github.event.release.tag_name }}
             ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend:${{ github.sha }}
 
       - name: Build and push workers image
@@ -61,5 +64,4 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/workers:${{ github.event.release.tag_name }}
             ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/workers:${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish release images to Github Registry
+
+on:
+  release:
+    types: [released]
+
+env:
+  app-name: carrot
+  repo-owner: ${{ github.repository_owner }}
+  registry: ghcr.io
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      - name: Docker Login
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.registry }}
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v2
+        with:
+          context: .app/next-client-app
+          file: ./app/next-client-app/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend:${{ github.event.release.tag_name }}
+            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend:${{ github.sha }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./app
+          file: ./app/Dockerfile.deploy
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend:${{ github.event.release.tag_name }}
+            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend:${{ github.sha }}
+
+      - name: Build and push workers image
+        uses: docker/build-push-action@v2
+        with:
+          context: .app/workers
+          file: ./app/workers/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/workers:${{ github.event.release.tag_name }}
+            ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/workers:${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,8 @@
 name: Publish release images to Github Registry
 
-# on:
-#   release:
-#     types: [released]
 on:
-  push:
-    branches:
-      - feat/863/add-release-workflow
-
+  release:
+    types: [released]
 
 env:
   app-name: carrot
@@ -36,36 +31,47 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # # Tag and build frontend
-      # - name: Extract frontend Docker metadata
-      #   id: frontend_meta
-      #   uses:  docker/metadata-action@v5.5.1
-      #   with:
-      #     images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend
+      - name: Set timestamp env var
+        run: echo "RUN_TIMESTAMP=$(TZ="Etc/UTC" date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
 
-      # - name: Build and push frontend image
-      #   uses: docker/build-push-action@v5.3.0
-      #   with:
-      #     context: ./app/next-client-app
-      #     file: ./app/next-client-app/Dockerfile
-      #     push: true
-      #     platforms: linux/amd64,linux/arm64
-      #     tags: ${{ steps.frontend_meta.outputs.tags }}
+      # Tag and build frontend
+      - name: Extract frontend Docker metadata
+        id: frontend_meta
+        uses:  docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/frontend
+          tags: |
+            ${{ github.event.release.tag_name }}
+            ${{ github.sha }}
+            ${{ env.RUN_TIMESTAMP }}
 
-      # # Tag and for backend
-      # - name: Extract backend Docker metadata
-      #   id: backend_meta
-      #   uses:  docker/metadata-action@v5.5.1
-      #   with:
-      #     images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: ./app/next-client-app
+          file: ./app/next-client-app/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.frontend_meta.outputs.tags }}
 
-      # - name: Build and push backend image
-      #   uses: docker/build-push-action@v5.3.0
-      #   with:
-      #     file: ./app/Dockerfile.deploy
-      #     push: true
-      #     platforms: linux/amd64,linux/arm64
-      #     tags: ${{ steps.backend_meta.outputs.tags }}
+      # Tag and for backend
+      - name: Extract backend Docker metadata
+        id: backend_meta
+        uses:  docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/backend
+          tags: |
+            ${{ github.event.release.tag_name }}
+            ${{ github.sha }}
+            ${{ env.RUN_TIMESTAMP }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5.3.0
+        with:
+          file: ./app/Dockerfile.deploy
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.backend_meta.outputs.tags }}
 
       # Tag and for workers
       - name: Extract workers Docker metadata
@@ -73,6 +79,10 @@ jobs:
         uses:  docker/metadata-action@v5.5.1
         with:
           images: ${{ env.registry }}/${{ env.repo-owner }}/${{ env.app-name }}/workers
+          tags: |
+            ${{ github.event.release.tag_name }}
+            ${{ github.sha }}
+            ${{ env.RUN_TIMESTAMP }}
 
       - name: Build and push workers image
         uses: docker/build-push-action@v5.3.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Build and push workers image
         uses: docker/build-push-action@v5.3.0
         with:
+          context: ./app
           file: ./app/workers/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,6 @@ jobs:
       - name: Build and push backend image
         uses: docker/build-push-action@v5.3.0
         with:
-          context: ./app
           file: ./app/Dockerfile.deploy
           push: true
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
# Changes

Adds a workflow to publish the images of Carrot to Github registry on a new release.

This is the first step in improving our release process, and making it easier for others to deploy.

Closes #863 