### PR TITLE
fix: Remove npm build in entrypoint

### DIFF
--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -2,7 +2,6 @@
 
 # Run npm build
 export PATH=$PATH:/home/django/.nvm/versions/node/v12.18.3/bin
-npm run build
 
 # Wait until DB is available
 wait-for-it ${COCONNECT_DB_HOST}:${COCONNECT_DB_PORT} -- echo "Database is ready! Listening on ${COCONNECT_DB_HOST}:${COCONNECT_DB_PORT}"


### PR DESCRIPTION
# Changes

Removes the `npm run build` in the entrypoint.sh for running the webapp.

This is necessary to run the build for the legacy UI, but has begun to break in deployment.

So this is a hotfix, and maybe a temporary breaking change as it prevents running the CI. 

Relevant #761 
