### PR TITLE
Fix NEXTAUTH_URL for Docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - BACKEND_URL=http://api:8000
       - BACKEND_ORIGIN=localhost:8000
-      - NEXTAUTH_URL=http://frontend:3000/
+      - NEXTAUTH_URL=http://localhost:3000/
       - NEXTAUTH_SECRET=verycomplexsecretkey
       - NEXTAUTH_BACKEND_URL=http://api:8000/api/
       - NODE_ENV=development


### PR DESCRIPTION
<!--
INSTRUCTIONS:

1. Please complete all sections detailing an ACTION
2. All tasks must be checked off before merging
-->

<!--
  PR Guidance:
  - 👷‍♀️ Create small PRs. In most cases this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

<!-- 
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->


## Pull Request Contents

<!--
ACTION: Delete any content types that don't apply to your pull request
-->

| |
|-|

🦋 Bug Fix

## Description

This PR fixed the NEXTAUTH_URL in Docker compose which should be http://localhost:3000/ 


