### PR TITLE
Added validator for dd & sr

### DIFF
--- a/app/api/api/logger.py
+++ b/app/api/api/logger.py
@@ -1,0 +1,12 @@
+import logging
+
+logger = logging.getLogger("api_test_logger")
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(
+    logging.Formatter(
+        fmt="%(asctime)s - %(levelname)s - %(message)s", datefmt="%d/%m/%Y " "%H:%M:%S"
+    )
+)
+logger.addHandler(stream_handler)
+logger.setLevel(logging.INFO)  # Set to logging.DEBUG to show the debug output

--- a/app/api/api/serializers.py
+++ b/app/api/api/serializers.py
@@ -249,10 +249,6 @@ class ScanReportFilesSerializer(DynamicFieldsMixin, serializers.ModelSerializer)
             if line and len(line) > 0:
                 csv_file_names.add(line[0].strip())
 
-        # Log the collected csv_file_names and sr_table_names
-        logger.info(f"CSV file names: {csv_file_names}")
-        logger.info(f"Scan Report table names: {self.sr_table_names}")
-
         # Checking for mismatches between csv_file_name entries and expected table names:
         logger.info("Checking for matching table names of DD and SR.")
 
@@ -270,8 +266,8 @@ class ScanReportFilesSerializer(DynamicFieldsMixin, serializers.ModelSerializer)
             if csv_name not in self.sr_table_names:
                 errors.append(
                     ParseError(
-                        f"CSV name in Data Dictionary '{csv_name}' is not matching any table in Scan Report. "
-                        f"Available tables: {', '.join(sorted(self.sr_table_names))}"
+                        f"'{csv_name}' in the column 'csv_file_name' in the Data Dictionary does not match any table name in the Scan Report. Hint: Make sure the extension '.csv' is included"
+                        f"Available table names/CSV file names: {', '.join(sorted(self.sr_table_names))}"
                     )
                 )
 
@@ -559,7 +555,7 @@ class ScanReportFilesSerializer(DynamicFieldsMixin, serializers.ModelSerializer)
         try:
             # Store table names in the serializer
             logger.info("Collecting table names from the scan report...")
-            self.sr_table_names = self.run_fast_consistency_checks(wb)
+            _, self.sr_table_names = self.run_fast_consistency_checks(wb)
         except ParseError as e:
             raise e
 


### PR DESCRIPTION
⚡️ Optimization #1003 

## PR Description

This PR implements **validation to check the Data Dictionaries' `csv_file_name` entries exactly match `Scan Report table names` (including file extensions)**. The changes prevent processing errors by catching mismatches during upload

## Key Changes

- Added validation in ScanReportFilesSerializer to:
    - Extract table names from Scan Report's "Table" column (including .csv extensions)
    - Compare against Data Dictionary's `csv_file_name entries`
    - Reject uploads with mismatched names

- Enhanced error messages that clearly show:
    - Which table names are invalid
    - Expected table names from the Scan Report

## Feedback
Feel free to share any feedback or suggestions for further improvements. Your input is always welcome! 🚀

Closes #1003 