### PR TITLE
Refactored Queue Names

### DIFF
--- a/app/api/config/settings.py
+++ b/app/api/config/settings.py
@@ -213,9 +213,13 @@ FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:3000")
 WORKERS_URL = os.environ.get("WORKERS_URL", "http://localhost:7071")
 WORKERS_RULES_NAME = os.environ.get("WORKERS_RULES_NAME", "RulesOrchestrator")
 WORKERS_RULES_KEY = os.environ.get("WORKERS_RULES_KEY", "")
+
+# Queue Names
 WORKERS_RULES_EXPORT_NAME = os.environ.get(
-    "WORKERS_RULES_EXPORT_NAME", "rules-exports-local"
+    "WORKERS_RULES_EXPORT_NAME", "rules-exports-queue"
 )
+WORKERS_UPLOAD_NAME = os.environ.get("WORKERS_UPLOAD_NAME", "upload-reports-queue")
+RULES_QUEUE_NAME = os.environ.get("RULES_QUEUE_NAME", "rules-queue")
 
 # Auth
 

--- a/app/shared/shared/mapping/management/commands/automatic_queue_and_containers_creation.py
+++ b/app/shared/shared/mapping/management/commands/automatic_queue_and_containers_creation.py
@@ -20,7 +20,12 @@ class Command(BaseCommand):
     MINIO_SECRET_KEY = os.getenv("MINIO_SECRET_KEY")
 
     # Define the required queues and blob containers or buckets
-    QUEUES = ["rules-local", "rules-exports-local", "uploadreports-local"]
+    QUEUES = [
+        os.getenv("RULES_QUEUE_NAME"),
+        os.getenv("WORKERS_RULES_EXPORT_NAME"),
+        os.getenv("WORKERS_UPLOAD_NAME"),
+    ]
+
     CONTAINERS = ["scan-reports", "data-dictionaries", "rules-exports"]
 
     def _create_azure_queues(self, queue_service: str):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,12 +64,13 @@ services:
       - DB_USER=postgres
       - DB_PASSWORD=postgres
       - DEBUG=True
-      - WORKERS_UPLOAD_NAME=uploadreports-local
+      - RULES_QUEUE_NAME=rules-queue
+      - WORKERS_UPLOAD_NAME=upload-reports-queue
       - SECRET_KEY=secret
       - WORKERS_URL=http://workers:80
       - WORKERS_RULES_NAME=RulesOrchestrator
       - WORKERS_RULES_KEY=rules_key
-      - WORKERS_RULES_EXPORT_NAME=rules-exports-local
+      - WORKERS_RULES_EXPORT_NAME=rules-exports-queue
       - STORAGE_CONN_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;
       - SIGNING_KEY=secret
       - STORAGE_TYPE=${STORAGE_TYPE:-azure}
@@ -100,9 +101,9 @@ services:
       - STORAGE_CONN_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;
       - APP_URL=http://api:8000/
       # Three queues below need adding to Azure local storage
-      - WORKERS_UPLOAD_NAME=uploadreports-local
-      - RULES_QUEUE_NAME=rules-local
-      - RULES_FILE_QUEUE_NAME=rules-exports-local
+      - WORKERS_UPLOAD_NAME=upload-reports-queue
+      - RULES_QUEUE_NAME=rules-queue
+      - RULES_FILE_QUEUE_NAME=rules-exports-queue
       # The address that can be used to reach the function app from outside
       - WEBSITE_HOSTNAME=localhost:7071
       # Database setup

--- a/sample-env.txt
+++ b/sample-env.txt
@@ -6,7 +6,7 @@ DB_PASSWORD=postgres
 DB_PORT=5432
 DB_USER=postgres
 DEBUG=True
-WORKERS_UPLOAD_NAME=uploadreports-local
+WORKERS_UPLOAD_NAME=upload-reports-queue
 SECRET_KEY=secret
 STORAGE_CONN_STRING="DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://localhost:10000/devstoreaccount1;QueueEndpoint=http://localhost:10001/devstoreaccount1;"
 CCOM_APP_URL= http://localhost:8000

--- a/sample-local.settings.json
+++ b/sample-local.settings.json
@@ -6,8 +6,8 @@
     "STORAGE_CONN_STRING": "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;QueueEndpoint=http://localhost:10001/devstoreaccount1;BlobEndpoint=http://localhost:10000/devstoreaccount1;",
     "APP_URL": "http://localhost:8000/",
     "AZ_FUNCTION_KEY": "",
-    "WORKERS_UPLOAD_NAME": "uploadreports-local",
-    "RULES_QUEUE_NAME": "rules-local",
-    "RULES_FILE_QUEUE_NAME": "rules-exports-local"
+    "WORKERS_UPLOAD_NAME": "upload-reports-queue",
+    "RULES_QUEUE_NAME": "rules-queue",
+    "RULES_FILE_QUEUE_NAME": "rules-exports-queue"
   }
 }


### PR DESCRIPTION
♻️ Refactor - #1009 

## PR Description

This PR updates all queue name references in Carrot-Mapper to remove the "local" suffix in preparation for our upcoming cloud deployment. 

Additionally, I have added `-queue` in all the queue names for the following reason: 
  - To make the queue names more descriptive (easy to understand and interpret) 
  - We already have `rules-exports` as a container name, and if we remove `local` from `rules-exports-local` will be redundant and lead to potential errors. So, to make it more appropriate, I did the changes. 

**Test Cases**

I have already tested the code and it works well without any errors. 

## Feedback
Feel free to share any feedback or suggestions for further improvements. Your input is always welcome! 🚀

Closes #1009 