### PR TITLE
Adding validator for Allowed Domains in RCA

### DIFF
--- a/app/workers/RulesConceptsActivity/__init__.py
+++ b/app/workers/RulesConceptsActivity/__init__.py
@@ -70,7 +70,7 @@ def _create_concepts(
         if value["concept_id"] == -1:
             continue
 
-        # Making all concept_ids as a list
+        # Making all concept_ids as a lists
         concept_ids = (
             value["concept_id"]
             if isinstance(value["concept_id"], list)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,6 @@ services:
     ports:
       - 8000:8000
     environment:
-      - DATA_UPLOAD_MAX_MEMORY_SIZE=10485760
       - FRONTEND_URL=http://frontend:3000
       - ALLOWED_HOSTS=['localhost', '127.0.0.1','api', 'workers']
       - DB_ENGINE=django.db.backends.postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
     ports:
       - 8000:8000
     environment:
+      - DATA_UPLOAD_MAX_MEMORY_SIZE=10485760
       - FRONTEND_URL=http://frontend:3000
       - ALLOWED_HOSTS=['localhost', '127.0.0.1','api', 'workers']
       - DB_ENGINE=django.db.backends.postgresql


### PR DESCRIPTION
🦋 Bug Fix - #1039 

## PR Description

This PR  fixes a bug that caused Carrot-Mapper's workers' function to crash in production. It prevents the creation of concepts with unsupported domains that would later fail in `RulesGenerationActivity`.

As a solution, we added an explicit **ALLOWED_DOMAINS** list check during concept creation and only created concepts from supported domains. I have added the screenshots and please find them below. 

<img width="1470" alt="Screenshot 2025-05-12 at 7 29 17 pm" src="https://github.com/user-attachments/assets/dc6fedd9-f5e9-4d46-903c-db99ffa50a68" />

## ✅ Added/updated tests?

I have already tested the scripts using the client's Data Dictionary & Scan Report (From Whales), which work well as expected. 

## Feedback
Feel free to share any feedback or suggestions for further improvements. Your input is always welcome! 🚀

Closes #1039 