### PR TITLE
Dev Deployment uv compatible configurations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,16 +24,15 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: "Install Poetry"
-        uses: snok/install-poetry@v1
-        with:
-          plugins: poetry-plugin-export
+      - name: "Install UV and Pip"
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv
 
-      - name: "Resolve Project Dependencies Using Poetry"
+      - name: "Resolve Project Dependencies Using UV"
         run: |
           pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
-          poetry config virtualenvs.create false
-          poetry export --format requirements.txt --output requirements.txt --without-hashes
+          uv pip compile pyproject.toml --output-file requirements.txt
           popd
         shell: bash
 
@@ -41,7 +40,6 @@ jobs:
         shell: bash
         run: |
           pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
-          python -m pip install --upgrade pip
           pip install -r requirements.txt --target=".python_packages/lib/site-packages"
           popd
 

--- a/app/api/pyproject.toml
+++ b/app/api/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "drf-dynamic-fields>=0.4.0,<0.5",
     "django-cors-headers>=4.4.0,<5",
     "python-dotenv>=1.0.1,<2",
-    "shared",
+    "carrot-shared",
     "azure-monitor-opentelemetry>=1.6.0,<2",
     "djangorestframework-simplejwt>=5.3.1,<6",
     "django-allauth==0.61.1",
@@ -52,7 +52,7 @@ default-groups = [
 ]
 
 [tool.uv.sources]
-shared = { path = "../shared", editable = true }
+carrot-shared = { path = "../shared", editable = true }
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/app/shared/pyproject.toml
+++ b/app/shared/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "shared"
+name = "carrot-shared"
 version = "0.3.2"
 description = "Carrot shared library"
 authors = [
@@ -34,8 +34,9 @@ default-groups = [
     "test",
 ]
 
-[tool.setuptools]
-packages = ["shared"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["shared*"]
 
 [tool.setuptools.package-data]
 shared = ["py.typed"]

--- a/app/workers/pyproject.toml
+++ b/app/workers/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "openpyxl==3.1.3",
     "Resource>=0.2.1,<0.3",
     "httpx==0.27",
-    "shared",
+    "carrot-shared",
     "python-dotenv>=1.0.1,<2",
     "azure-functions-durable>=1.2.9,<2",
     "minio>=7.2.15,<8",
@@ -30,7 +30,7 @@ dev = [
     "django-stubs>=5.0.0,<6",
     "types-openpyxl>=3.1.0.20240428,<4",
     "types-requests>=2.31.0.20240406,<3",
-    "shared",
+    "carrot-shared",
 ]
 test = [
     "pytest>=8.0.2,<9",
@@ -45,7 +45,7 @@ default-groups = [
 ]
 
 [tool.uv.sources]
-shared = { path = "../shared" }
+carrot-shared = { path = "../shared" }
 
 [build-system]
 requires = ["setuptools>=64.0.0"]


### PR DESCRIPTION
♻️ Refactor -  #1049 

## PR Description

This PR updates our GitHub Actions workflow to use UV package manager instead of Poetry, aligning with our recent project-wide migration to UV. 

## Changes made

- Updated CI/CD workflow to use UV instead of Poetry for dependency resolution.
- Modified `pyproject.toml` files in shared as **carrot-shared** and made all the scripts available as shared.
- Modified `pyproject.toml` files in **API & workers** packages to use **carrot-shared**.
- Fixed package naming consistency between project files to resolve dependency resolution issues. 

Closes #1049 
