### PR TITLE
Hot fix for rules generation

### DIFF
--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -323,11 +323,6 @@ def save_mapping_rules(
         source_field = scan_report_value.scan_report_field
     else:
         source_field = content_object
-    if scan_report_concept.creation_type == "R" and (
-        scan_report_concept.concept.domain_id == "Specimen"
-        or scan_report_concept.concept.domain_id == "Visit"
-    ):
-        return []
 
     scan_report = source_field.scan_report_table.scan_report
     concept = scan_report_concept.concept

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -323,6 +323,11 @@ def save_mapping_rules(
         source_field = scan_report_value.scan_report_field
     else:
         source_field = content_object
+    if scan_report_concept.creation_type == "R" and (
+        scan_report_concept.concept.domain_id == "Specimen"
+        or scan_report_concept.concept.domain_id == "Visit"
+    ):
+        return []
 
     scan_report = source_field.scan_report_table.scan_report
     concept = scan_report_concept.concept

--- a/app/workers/RulesConceptsActivity/reuse.py
+++ b/app/workers/RulesConceptsActivity/reuse.py
@@ -5,6 +5,7 @@ from shared.mapping.models import (
     ScanReportField,
     ScanReportValue,
     ScanReportTable,
+    Concept,
 )
 from shared_code import db
 from shared_code.logger import logger
@@ -355,6 +356,13 @@ def select_concepts_to_post(
         try:
             existing_content_id, concept_ids = details_to_id_and_concept_ids_map[key]
             for concept_id in concept_ids:
+                if content_type == ScanReportConceptContentType.VALUE:
+                    try:
+                        concept_obj = Concept.objects.get(pk=concept_id)
+                        if concept_obj.domain_id in ("Visit", "Specimen"):
+                            continue  # Skip this concept if it has Visit or Specimen domain
+                    except Concept.DoesNotExist:
+                        continue  # If concept doesn't exist, skip
                 logger.info(
                     f"Found existing {'field' if content_type == ScanReportConceptContentType.FIELD else 'value'} with id: {existing_content_id} "
                     f"with existing concept mapping: {concept_id} which matches new {'field' if content_type == ScanReportConceptContentType.FIELD else 'value'} id: {new_content_detail['id']}"


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix


## PR Description
This PR add a small and hot fix for RulesConceptAct which keeps reusing the concepts that have the unsupported domains, ie., Visit or Specimen.

## Related Issues or other material
Related #1039 


