### PR TITLE
Support other datatypes of INT

### DIFF
--- a/app/airflow/dags/libs/queries.py
+++ b/app/airflow/dags/libs/queries.py
@@ -91,18 +91,21 @@ find_source_field_id_query = """
     UPDATE temp_existing_concepts_%(table_id)s AS temp_table
     SET source_field_data_type = 
         CASE
-            WHEN sr_field.type_column = 'INT' OR
-                sr_field.type_column = 'REAL' OR
-                sr_field.type_column = 'FLOAT' OR
-                sr_field.type_column = 'NUMERIC' OR
-                sr_field.type_column = 'DECIMAL' OR
-                sr_field.type_column = 'DOUBLE'
+            WHEN UPPER(sr_field.type_column) = 'INT' OR
+                UPPER(sr_field.type_column) = 'TINYINT' OR
+                UPPER(sr_field.type_column) = 'SMALLINT' OR
+                UPPER(sr_field.type_column) = 'BIGINT' OR
+                UPPER(sr_field.type_column) = 'REAL' OR
+                UPPER(sr_field.type_column) = 'FLOAT' OR
+                UPPER(sr_field.type_column) = 'NUMERIC' OR
+                UPPER(sr_field.type_column) = 'DECIMAL' OR
+                UPPER(sr_field.type_column) = 'DOUBLE'
             THEN 'numeric'
-            WHEN sr_field.type_column = 'VARCHAR' OR
-                sr_field.type_column = 'NVARCHAR' OR
-                sr_field.type_column = 'TEXT' OR
-                sr_field.type_column = 'STRING' OR
-                sr_field.type_column = 'CHAR'
+            WHEN UPPER(sr_field.type_column) = 'VARCHAR' OR
+                UPPER(sr_field.type_column) = 'NVARCHAR' OR
+                UPPER(sr_field.type_column) = 'TEXT' OR
+                UPPER(sr_field.type_column) = 'STRING' OR
+                UPPER(sr_field.type_column) = 'CHAR'
             THEN 'string'
             ELSE sr_field.type_column
         END

--- a/app/api/api/views.py
+++ b/app/api/api/views.py
@@ -1001,6 +1001,9 @@ class ScanReportConceptListV2(
         if domain == "observation" and field_datatype.lower() not in [
             "real",
             "int",
+            "tinyint",
+            "smallint",
+            "bigint",
             "varchar",
             "nvarchar",
             "float",

--- a/app/shared/shared/services/rules.py
+++ b/app/shared/shared/services/rules.py
@@ -423,7 +423,12 @@ def save_mapping_rules(
     # When the concept has the domain "Observation", one more mapping rule to the OMOP field
     # "value_as_number"/"value_as_string" will be added based on the field's datatype
     if domain == "observation" and (
-        type_column == "int" or type_column == "real" or type_column == "float"
+        type_column == "int"
+        or type_column == "real"
+        or type_column == "float"
+        or type_column == "tinyint"
+        or type_column == "smallint"
+        or type_column == "bigint"
     ):
         # create/update a model for the domain value_as_number
         #  - for this destination_field and source_field

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ x-airflow-common:
     AIRFLOW__CORE__LOAD_EXAMPLES: "false"
     AIRFLOW__WEBSERVER__EXPOSE_CONFIG: "False"
     AIRFLOW__WEBSERVER__WEB_SERVER_PORT: 8080
+    AIRFLOW__WEBSERVER__SECRET_KEY: secret
     AIRFLOW__API__AUTH_BACKEND: airflow.api.auth.backend.basic_auth
     # This connection can be in separate variables (then don't need to do URL encoding), but it can reuse the same connection string with SQL_ALCHEMY_CONN (without extras)
     AIRFLOW_CONN_POSTGRES_DB_CONN: postgresql+psycopg2://postgres:postgres@db:5432/postgres


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description
This PR added support for other data types of INT (e.g., tinyint, bigint). Also, it added back the Webserver secret key of the Airflow app, and made the datatype recognition in auto mapping (airflow) case-sensitive.

## Related Issues or other material
Closes #1109 

