### PR TITLE
add specimen table support

### DIFF
--- a/app/workers/shared_code/helpers.py
+++ b/app/workers/shared_code/helpers.py
@@ -17,6 +17,8 @@ ALLOWED_DOMAINS = [
     "drug",
     "procedure",
     "device",
+    "specimen",
+    "specanatomic site",
 ]
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,7 +255,7 @@ services:
     environment:
       <<: *airflow-common-env
       AIRFLOW__CORE__EXECUTE_TASKS_NEW_PYTHON_INTERPRETER: True
-      AIRFLOW_DEBUG_MODE: True
+      AIRFLOW_DEBUG_MODE: False
 
 volumes:
   db_data:


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🛠️ Repo maintenance

## PR Description
This PR added support for rules generation for the table Specimen in OMOP CDM, when a concept is added to Carrot manually.

## Related Issues or other material
Closes #406 
