### PR TITLE
Add airflow-logs to automatic containers creation

### DIFF
--- a/app/shared/shared/mapping/management/commands/automatic_queue_and_containers_creation.py
+++ b/app/shared/shared/mapping/management/commands/automatic_queue_and_containers_creation.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
         os.getenv("WORKERS_UPLOAD_NAME"),
     ]
 
-    CONTAINERS = ["scan-reports", "data-dictionaries", "rules-exports"]
+    CONTAINERS = ["scan-reports", "data-dictionaries", "rules-exports", "airflow-logs"]
 
     def _create_azure_queues(self, queue_service: str):
         """


### PR DESCRIPTION
| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description
Currently, the `airflow-logs` container, which holds Airflow DAGs' logs on cloud deployment, needs to be created manually. This can be automatic, along with other containers. 

