### PR TITLE
Fix undefined client request unavailable data

### DIFF
--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
@@ -2,7 +2,7 @@ import {
   getAllScanReportFields,
   getScanReportField,
   getScanReportPermissions,
-  getScanReportTable
+  getScanReportTable,
 } from "@/api/scanreports";
 import { objToQuery } from "@/lib/client-utils";
 import { AlertCircleIcon } from "lucide-react";
@@ -21,12 +21,15 @@ interface UpdateTableProps {
 export default async function UpdateTable(props: UpdateTableProps) {
   const params = await props.params;
 
-  const { id, tableId } = params;
+  const {
+    id,
+    tableId
+  } = params;
 
   const defaultPageSize = 50;
   const defaultParams = {
     fields: "name,id",
-    page_size: defaultPageSize
+    page_size: defaultPageSize,
   };
   const combinedParams = { ...defaultParams };
   const query = objToQuery(combinedParams);

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
@@ -2,7 +2,7 @@ import {
   getAllScanReportFields,
   getScanReportField,
   getScanReportPermissions,
-  getScanReportTable,
+  getScanReportTable
 } from "@/api/scanreports";
 import { objToQuery } from "@/lib/client-utils";
 import { AlertCircleIcon } from "lucide-react";
@@ -21,15 +21,12 @@ interface UpdateTableProps {
 export default async function UpdateTable(props: UpdateTableProps) {
   const params = await props.params;
 
-  const {
-    id,
-    tableId
-  } = params;
+  const { id, tableId } = params;
 
   const defaultPageSize = 50;
   const defaultParams = {
     fields: "name,id",
-    page_size: defaultPageSize,
+    page_size: defaultPageSize
   };
   const combinedParams = { ...defaultParams };
   const query = objToQuery(combinedParams);
@@ -39,7 +36,9 @@ export default async function UpdateTable(props: UpdateTableProps) {
   const table = await getScanReportTable(id, tableId);
 
   // Check if fields are available first before making the calls
-  const defaultField = {
+  // Note: We create a fallback field object because the component expects ScanReportField,
+  // not null. This is a temporary workaround until we improve the fetching pattern (#795)
+  const fallbackField = {
     id: 0,
     name: "",
     created_at: new Date(),
@@ -65,10 +64,10 @@ export default async function UpdateTable(props: UpdateTableProps) {
 
   const personId = table.person_id?.id
     ? await getScanReportField(id, tableId, table.person_id.id)
-    : defaultField;
+    : fallbackField;
   const dateEvent = table.date_event?.id
     ? await getScanReportField(id, tableId, table.date_event.id)
-    : defaultField;
+    : fallbackField;
   const permissions = await getScanReportPermissions(id);
 
   return (

--- a/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/tables/[tableId]/update/page.tsx
@@ -2,7 +2,7 @@ import {
   getAllScanReportFields,
   getScanReportField,
   getScanReportPermissions,
-  getScanReportTable,
+  getScanReportTable
 } from "@/api/scanreports";
 import { objToQuery } from "@/lib/client-utils";
 import { AlertCircleIcon } from "lucide-react";
@@ -21,15 +21,12 @@ interface UpdateTableProps {
 export default async function UpdateTable(props: UpdateTableProps) {
   const params = await props.params;
 
-  const {
-    id,
-    tableId
-  } = params;
+  const { id, tableId } = params;
 
   const defaultPageSize = 50;
   const defaultParams = {
     fields: "name,id",
-    page_size: defaultPageSize,
+    page_size: defaultPageSize
   };
   const combinedParams = { ...defaultParams };
   const query = objToQuery(combinedParams);
@@ -37,8 +34,38 @@ export default async function UpdateTable(props: UpdateTableProps) {
   const scanReportsFields = await getAllScanReportFields(id, tableId, query);
 
   const table = await getScanReportTable(id, tableId);
-  const personId = await getScanReportField(id, tableId, table.person_id?.id);
-  const dateEvent = await getScanReportField(id, tableId, table.date_event?.id);
+
+  // Check if fields are available first before making the calls
+  const defaultField = {
+    id: 0,
+    name: "",
+    created_at: new Date(),
+    updated_at: new Date(),
+    description_column: "",
+    type_column: "",
+    max_length: 0,
+    nrows: 0,
+    nrows_checked: 0,
+    fraction_empty: "",
+    nunique_values: 0,
+    fraction_unique: "",
+    ignore_column: null,
+    is_patient_id: false,
+    is_ignore: false,
+    classification_system: null,
+    pass_from_source: false,
+    concept_id: 0,
+    permissions: [],
+    field_description: null,
+    scan_report_table: 0
+  };
+
+  const personId = table.person_id?.id
+    ? await getScanReportField(id, tableId, table.person_id.id)
+    : defaultField;
+  const dateEvent = table.date_event?.id
+    ? await getScanReportField(id, tableId, table.date_event.id)
+    : defaultField;
   const permissions = await getScanReportPermissions(id);
 
   return (


### PR DESCRIPTION
🦋 Bug Fix


## PR Description
When users access the update table page for tables where Person ID and Date Event fields are not set, the Next.js client was making API calls with undefined field IDs, causing 404 errors and console warnings.

## Solution:
Added proper field existence checks before making API calls. Instead of blindly calling getScanReportField(id, tableId, table.person_id?.id), the code now checks if table.person_id?.id exists first. When fields don't exist, a default field object is used instead of making API calls with undefined values.


## Related Issues or other material
Related #1088
Closes #1088

## Screenshots, example outputs/behaviour etc.
<img width="1915" height="1033" alt="Screenshot 2025-07-30 at 12 15 45" src="https://github.com/user-attachments/assets/eb07118b-131c-4f80-bc3c-2a77846258d6" />
<img width="1029" height="835" alt="Screenshot 2025-07-30 at 12 16 35" src="https://github.com/user-attachments/assets/4b358ffb-81b9-4e79-a338-2f89dc5c80b0" />

