### PR TITLE
Made Badge Clickable

### DIFF
--- a/app/next-client-app/app/(protected)/datasets/[id]/layout.tsx
+++ b/app/next-client-app/app/(protected)/datasets/[id]/layout.tsx
@@ -62,9 +62,14 @@ export default async function DatasetLayout({
           <div>Project(s): </div>
           <div className="flex space-x-1">
             {projects.map((project) => (
-              <Badge variant="outline" key={project.id}>
-                {project.name}
-              </Badge>
+              <Link key={project.id} href={`/projects/${project.id}`}>
+                <Badge
+                  variant="outline"
+                  className="cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors"
+                >
+                  {project.name}
+                </Badge>
+              </Link>
             ))}
           </div>
         </h3>


### PR DESCRIPTION
✨ Feature

## PR Description
This PR makes project badges clickable in the dataset layout, allowing users to navigate directly to project pages from the dataset view. The badges now include hover effects and smooth transitions to provide clear visual feedback that they are interactive elements.

NB: The cursor on the screenshot isn't visible, but we can see `http://localhost:3000/projects/1` at the bottom left on hover.

## Related Issues or other material
Related #1071
Closes #1071

## Screenshots, example outputs/behaviour etc.
<img width="1680" height="1050" alt="Screenshot 2025-08-01 at 14 22 30" src="https://github.com/user-attachments/assets/55904448-1deb-4c8b-bad5-32b25a2e85ee" />


