### PR TITLE
Fix Empty state in lists

### DIFF
--- a/app/next-client-app/app/(protected)/datasets/[id]/page.tsx
+++ b/app/next-client-app/app/(protected)/datasets/[id]/page.tsx
@@ -65,7 +65,7 @@ export default async function DatasetSRList(props: DataSetListProps) {
           initialColumnVisibility={initialColumnVisibility}
           defaultPageSize={defaultPageSize}
           emptyStateMessage="No scan reports in this dataset"
-          emptyStateDescription="Run a scan on this dataset to generate scan reports and begin mapping your data."
+          emptyStateDescription="No scan reports found in this dataset yet."
           emptyStateIcon="filescan"
         />
       </TabsContent>

--- a/app/next-client-app/app/(protected)/datasets/[id]/page.tsx
+++ b/app/next-client-app/app/(protected)/datasets/[id]/page.tsx
@@ -6,6 +6,7 @@ import { objToQuery } from "@/lib/client-utils";
 import { ScanReportsTableFilter } from "@/components/scanreports/ScanReportsTableFilter";
 import { FilterParameters } from "@/types/filter";
 import { VisibilityState } from "@tanstack/react-table";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface DataSetListProps {
   params: Promise<{
@@ -35,7 +36,7 @@ export default async function DatasetSRList(props: DataSetListProps) {
   // Define which columns should be hidden by default
   const initialColumnVisibility: VisibilityState = {
     id: false,
-    Dataset: false,
+    Dataset: false
   };
 
   return (
@@ -57,30 +58,40 @@ export default async function DatasetSRList(props: DataSetListProps) {
         </a>
       </TabsList>
       <TabsContent value="active">
-        <DataTable
-          columns={columns}
-          data={scanReports.results}
-          count={scanReports.count}
-          Filter={filter}
-          initialColumnVisibility={initialColumnVisibility}
-          defaultPageSize={defaultPageSize}
-          emptyStateMessage="No scan reports in this dataset"
-          emptyStateDescription="No scan reports found in this dataset yet."
-          emptyStateIcon="filescan"
-        />
+        {scanReports.results.length > 0 ? (
+          <DataTable
+            columns={columns}
+            data={scanReports.results}
+            count={scanReports.count}
+            Filter={filter}
+            initialColumnVisibility={initialColumnVisibility}
+            defaultPageSize={defaultPageSize}
+          />
+        ) : (
+          <EmptyState
+            icon="filescan"
+            title="No scan reports in this dataset"
+            description="No scan reports found in this dataset yet."
+          />
+        )}
       </TabsContent>
       <TabsContent value="archived">
-        <DataTable
-          columns={columns}
-          data={scanReports.results}
-          count={scanReports.count}
-          Filter={filter}
-          initialColumnVisibility={initialColumnVisibility}
-          defaultPageSize={defaultPageSize}
-          emptyStateMessage="No archived reports"
-          emptyStateDescription="No archived scan reports found in this dataset. Active reports will appear here when archived."
-          emptyStateIcon="filescan"
-        />
+        {scanReports.results.length > 0 ? (
+          <DataTable
+            columns={columns}
+            data={scanReports.results}
+            count={scanReports.count}
+            Filter={filter}
+            initialColumnVisibility={initialColumnVisibility}
+            defaultPageSize={defaultPageSize}
+          />
+        ) : (
+          <EmptyState
+            icon="filescan"
+            title="No archived reports"
+            description="No archived scan reports found in this dataset. Active reports will appear here when archived."
+          />
+        )}
       </TabsContent>
     </Tabs>
   );

--- a/app/next-client-app/app/(protected)/datasets/[id]/page.tsx
+++ b/app/next-client-app/app/(protected)/datasets/[id]/page.tsx
@@ -64,6 +64,9 @@ export default async function DatasetSRList(props: DataSetListProps) {
           Filter={filter}
           initialColumnVisibility={initialColumnVisibility}
           defaultPageSize={defaultPageSize}
+          emptyStateMessage="No scan reports in this dataset"
+          emptyStateDescription="Run a scan on this dataset to generate scan reports and begin mapping your data."
+          emptyStateIcon="filescan"
         />
       </TabsContent>
       <TabsContent value="archived">
@@ -74,6 +77,9 @@ export default async function DatasetSRList(props: DataSetListProps) {
           Filter={filter}
           initialColumnVisibility={initialColumnVisibility}
           defaultPageSize={defaultPageSize}
+          emptyStateMessage="No archived reports"
+          emptyStateDescription="No archived scan reports found in this dataset. Active reports will appear here when archived."
+          emptyStateIcon="filescan"
         />
       </TabsContent>
     </Tabs>

--- a/app/next-client-app/app/(protected)/datasets/page.tsx
+++ b/app/next-client-app/app/(protected)/datasets/page.tsx
@@ -12,7 +12,7 @@ import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Datasets | Carrot Mapper",
-  description: "Datasets for the current user",
+  description: "Datasets for the current user"
 };
 
 interface DataSetListProps {
@@ -23,7 +23,7 @@ export default async function DataSets(props: DataSetListProps) {
   const searchParams = await props.searchParams;
   const defaultParams = {
     hidden: false,
-    page_size: 10,
+    page_size: 10
   };
   const combinedParams = { ...defaultParams, ...searchParams };
 

--- a/app/next-client-app/app/(protected)/datasets/page.tsx
+++ b/app/next-client-app/app/(protected)/datasets/page.tsx
@@ -72,9 +72,14 @@ export default async function DataSets(props: DataSetListProps) {
                 data={dataset.results}
                 count={dataset.count}
                 Filter={filter}
-                emptyStateMessage="No datasets yet"
-                emptyStateDescription="Create your first dataset to start organizing and mapping your data."
-                emptyStateIcon="database"
+                {...(dataset.results.length === 0
+                  ? {
+                      emptyStateMessage: "No datasets yet",
+                      emptyStateDescription:
+                        "Create your first dataset to start organizing and mapping your data.",
+                      emptyStateIcon: "database"
+                    }
+                  : {})}
               />
             </TabsContent>
             <TabsContent value="archived">
@@ -83,9 +88,14 @@ export default async function DataSets(props: DataSetListProps) {
                 data={dataset.results}
                 count={dataset.count}
                 Filter={filter}
-                emptyStateMessage="No archived datasets"
-                emptyStateDescription="No archived datasets found. Active datasets will appear here when archived."
-                emptyStateIcon="database"
+                {...(dataset.results.length === 0
+                  ? {
+                      emptyStateMessage: "No archived datasets",
+                      emptyStateDescription:
+                        "No archived datasets found. Active datasets will appear here when archived.",
+                      emptyStateIcon: "database"
+                    }
+                  : {})}
               />
             </TabsContent>
           </Tabs>

--- a/app/next-client-app/app/(protected)/datasets/page.tsx
+++ b/app/next-client-app/app/(protected)/datasets/page.tsx
@@ -9,6 +9,7 @@ import { CreateDatasetDialog } from "@/components/datasets/CreateDatasetDialog";
 import { Database } from "lucide-react";
 import { getAllProjects } from "@/api/projects";
 import { Metadata } from "next";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const metadata: Metadata = {
   title: "Datasets | Carrot Mapper",
@@ -67,36 +68,36 @@ export default async function DataSets(props: DataSetListProps) {
               </div>
             </div>
             <TabsContent value="active">
-              <DataTable
-                columns={columns}
-                data={dataset.results}
-                count={dataset.count}
-                Filter={filter}
-                {...(dataset.results.length === 0
-                  ? {
-                      emptyStateMessage: "No datasets yet",
-                      emptyStateDescription:
-                        "Create your first dataset to start organizing and mapping your data.",
-                      emptyStateIcon: "database"
-                    }
-                  : {})}
-              />
+              {dataset.results.length > 0 ? (
+                <DataTable
+                  columns={columns}
+                  data={dataset.results}
+                  count={dataset.count}
+                  Filter={filter}
+                />
+              ) : (
+                <EmptyState
+                  icon="database"
+                  title="No datasets yet"
+                  description="Create your first dataset to start organising and mapping your data."
+                />
+              )}
             </TabsContent>
             <TabsContent value="archived">
-              <DataTable
-                columns={columns}
-                data={dataset.results}
-                count={dataset.count}
-                Filter={filter}
-                {...(dataset.results.length === 0
-                  ? {
-                      emptyStateMessage: "No archived datasets",
-                      emptyStateDescription:
-                        "No archived datasets found. Active datasets will appear here when archived.",
-                      emptyStateIcon: "database"
-                    }
-                  : {})}
-              />
+              {dataset.results.length > 0 ? (
+                <DataTable
+                  columns={columns}
+                  data={dataset.results}
+                  count={dataset.count}
+                  Filter={filter}
+                />
+              ) : (
+                <EmptyState
+                  icon="database"
+                  title="No archived datasets"
+                  description="No archived datasets found. Active datasets will appear here when archived."
+                />
+              )}
             </TabsContent>
           </Tabs>
         </div>

--- a/app/next-client-app/app/(protected)/datasets/page.tsx
+++ b/app/next-client-app/app/(protected)/datasets/page.tsx
@@ -72,6 +72,9 @@ export default async function DataSets(props: DataSetListProps) {
                 data={dataset.results}
                 count={dataset.count}
                 Filter={filter}
+                emptyStateMessage="No datasets yet"
+                emptyStateDescription="Create your first dataset to start organizing and mapping your data."
+                emptyStateIcon="database"
               />
             </TabsContent>
             <TabsContent value="archived">
@@ -80,6 +83,9 @@ export default async function DataSets(props: DataSetListProps) {
                 data={dataset.results}
                 count={dataset.count}
                 Filter={filter}
+                emptyStateMessage="No archived datasets"
+                emptyStateDescription="No archived datasets found. Active datasets will appear here when archived."
+                emptyStateIcon="database"
               />
             </TabsContent>
           </Tabs>

--- a/app/next-client-app/app/(protected)/projects/[id]/page.tsx
+++ b/app/next-client-app/app/(protected)/projects/[id]/page.tsx
@@ -17,14 +17,12 @@ export default async function ProjectDetail(props: ProjectDetailProps) {
   const searchParams = await props.searchParams;
   const params = await props.params;
 
-  const {
-    id
-  } = params;
+  const { id } = params;
 
   const defaultParams = {
     hidden: false,
     page_size: 10,
-    project: id,
+    project: id
   };
   const combinedParams = { ...defaultParams, ...searchParams };
   const query = objToQuery(combinedParams);

--- a/app/next-client-app/app/(protected)/projects/[id]/page.tsx
+++ b/app/next-client-app/app/(protected)/projects/[id]/page.tsx
@@ -5,6 +5,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { DataTableFilter } from "@/components/data-table/DataTableFilter";
 import { getDataSets } from "@/api/datasets";
 import { columns } from "../../datasets/columns";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface ProjectDetailProps {
   params: Promise<{
@@ -50,36 +51,36 @@ export default async function ProjectDetail(props: ProjectDetailProps) {
         </TabsList>
       </div>
       <TabsContent value="active">
-        <DataTable
-          columns={columns}
-          data={datasets.results}
-          count={datasets.count}
-          Filter={filter}
-          {...(datasets.results.length === 0
-            ? {
-                emptyStateMessage: "No datasets in this project",
-                emptyStateDescription:
-                  "Create your first dataset in this project to start organizing and mapping your data.",
-                emptyStateIcon: "database"
-              }
-            : {})}
-        />
+        {datasets.results.length > 0 ? (
+          <DataTable
+            columns={columns}
+            data={datasets.results}
+            count={datasets.count}
+            Filter={filter}
+          />
+        ) : (
+          <EmptyState
+            icon="database"
+            title="No datasets in this project"
+            description="Create your first dataset in this project to start organizing and mapping your data."
+          />
+        )}
       </TabsContent>
       <TabsContent value="archived">
-        <DataTable
-          columns={columns}
-          data={datasets.results}
-          count={datasets.count}
-          Filter={filter}
-          {...(datasets.results.length === 0
-            ? {
-                emptyStateMessage: "No archived datasets",
-                emptyStateDescription:
-                  "No archived datasets found in this project. Active datasets will appear here when archived.",
-                emptyStateIcon: "database"
-              }
-            : {})}
-        />
+        {datasets.results.length > 0 ? (
+          <DataTable
+            columns={columns}
+            data={datasets.results}
+            count={datasets.count}
+            Filter={filter}
+          />
+        ) : (
+          <EmptyState
+            icon="database"
+            title="No archived datasets"
+            description="No archived datasets found in this project. Active datasets will appear here when archived."
+          />
+        )}
       </TabsContent>
     </Tabs>
   );

--- a/app/next-client-app/app/(protected)/projects/[id]/page.tsx
+++ b/app/next-client-app/app/(protected)/projects/[id]/page.tsx
@@ -55,9 +55,14 @@ export default async function ProjectDetail(props: ProjectDetailProps) {
           data={datasets.results}
           count={datasets.count}
           Filter={filter}
-          emptyStateMessage="No datasets in this project"
-          emptyStateDescription="Create your first dataset in this project to start organizing and mapping your data."
-          emptyStateIcon="database"
+          {...(datasets.results.length === 0
+            ? {
+                emptyStateMessage: "No datasets in this project",
+                emptyStateDescription:
+                  "Create your first dataset in this project to start organizing and mapping your data.",
+                emptyStateIcon: "database"
+              }
+            : {})}
         />
       </TabsContent>
       <TabsContent value="archived">
@@ -66,9 +71,14 @@ export default async function ProjectDetail(props: ProjectDetailProps) {
           data={datasets.results}
           count={datasets.count}
           Filter={filter}
-          emptyStateMessage="No archived datasets"
-          emptyStateDescription="No archived datasets found in this project. Active datasets will appear here when archived."
-          emptyStateIcon="database"
+          {...(datasets.results.length === 0
+            ? {
+                emptyStateMessage: "No archived datasets",
+                emptyStateDescription:
+                  "No archived datasets found in this project. Active datasets will appear here when archived.",
+                emptyStateIcon: "database"
+              }
+            : {})}
         />
       </TabsContent>
     </Tabs>

--- a/app/next-client-app/app/(protected)/projects/[id]/page.tsx
+++ b/app/next-client-app/app/(protected)/projects/[id]/page.tsx
@@ -57,6 +57,9 @@ export default async function ProjectDetail(props: ProjectDetailProps) {
           data={datasets.results}
           count={datasets.count}
           Filter={filter}
+          emptyStateMessage="No datasets in this project"
+          emptyStateDescription="Create your first dataset in this project to start organizing and mapping your data."
+          emptyStateIcon="database"
         />
       </TabsContent>
       <TabsContent value="archived">
@@ -65,6 +68,9 @@ export default async function ProjectDetail(props: ProjectDetailProps) {
           data={datasets.results}
           count={datasets.count}
           Filter={filter}
+          emptyStateMessage="No archived datasets"
+          emptyStateDescription="No archived datasets found in this project. Active datasets will appear here when archived."
+          emptyStateIcon="database"
         />
       </TabsContent>
     </Tabs>

--- a/app/next-client-app/app/(protected)/projects/page.tsx
+++ b/app/next-client-app/app/(protected)/projects/page.tsx
@@ -39,9 +39,14 @@ export default async function Projects(props: ProjectListProps) {
           data={projects.results}
           count={projects.count}
           Filter={filter}
-          emptyStateMessage="No projects yet"
-          emptyStateDescription="Contact your administrator to be added to a project."
-          emptyStateIcon="folders"
+          {...(projects.results.length === 0
+            ? {
+                emptyStateMessage: "No projects yet",
+                emptyStateDescription:
+                  "Contact your administrator to be added to a project.",
+                emptyStateIcon: "folders"
+              }
+            : {})}
         />
       </div>
     </div>

--- a/app/next-client-app/app/(protected)/projects/page.tsx
+++ b/app/next-client-app/app/(protected)/projects/page.tsx
@@ -39,6 +39,9 @@ export default async function Projects(props: ProjectListProps) {
           data={projects.results}
           count={projects.count}
           Filter={filter}
+          emptyStateMessage="No projects yet"
+          emptyStateDescription="Contact your administrator to be added to a project."
+          emptyStateIcon="folders"
         />
       </div>
     </div>

--- a/app/next-client-app/app/(protected)/projects/page.tsx
+++ b/app/next-client-app/app/(protected)/projects/page.tsx
@@ -6,6 +6,7 @@ import { FilterParameters } from "@/types/filter";
 import { Folders } from "lucide-react";
 import { getProjectsList } from "@/api/projects";
 import { Metadata } from "next";
+import { EmptyState } from "@/components/ui/empty-state";
 
 export const metadata: Metadata = {
   title: "Projects | Carrot Mapper",
@@ -34,20 +35,20 @@ export default async function Projects(props: ProjectListProps) {
         <h2>Projects</h2>
       </div>
       <div>
-        <DataTable
-          columns={columns}
-          data={projects.results}
-          count={projects.count}
-          Filter={filter}
-          {...(projects.results.length === 0
-            ? {
-                emptyStateMessage: "No projects yet",
-                emptyStateDescription:
-                  "Contact your administrator to be added to a project.",
-                emptyStateIcon: "folders"
-              }
-            : {})}
-        />
+        {projects.results.length > 0 ? (
+          <DataTable
+            columns={columns}
+            data={projects.results}
+            count={projects.count}
+            Filter={filter}
+          />
+        ) : (
+          <EmptyState
+            icon="folders"
+            title="No projects yet"
+            description="Contact your administrator to be added to a project."
+          />
+        )}
       </div>
     </div>
   );

--- a/app/next-client-app/app/(protected)/projects/page.tsx
+++ b/app/next-client-app/app/(protected)/projects/page.tsx
@@ -9,7 +9,7 @@ import { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Projects | Carrot Mapper",
-  description: "Projects for the current user",
+  description: "Projects for the current user"
 };
 
 interface ProjectListProps {
@@ -19,7 +19,7 @@ interface ProjectListProps {
 export default async function Projects(props: ProjectListProps) {
   const searchParams = await props.searchParams;
   const defaultParams = {
-    page_size: 10,
+    page_size: 10
   };
   const combinedParams = { ...defaultParams, ...searchParams };
   const query = objToQuery(combinedParams);

--- a/app/next-client-app/app/(protected)/scanreports/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/page.tsx
@@ -8,6 +8,7 @@ import { FilterParameters } from "@/types/filter";
 import { FileScan } from "lucide-react";
 import { VisibilityState } from "@tanstack/react-table";
 import { Metadata } from "next";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface ScanReportsProps {
   searchParams?: Promise<{ status__in: string } & FilterParameters>;
@@ -62,40 +63,40 @@ export default async function ScanReports(props: ScanReportsProps) {
             </a>
           </TabsList>
           <TabsContent value="active">
-            <DataTable
-              columns={columns}
-              data={scanReports.results}
-              count={scanReports.count}
-              Filter={filter}
-              defaultPageSize={defaultPageSize}
-              initialColumnVisibility={initialColumnVisibility}
-              {...(scanReports.results.length === 0
-                ? {
-                    emptyStateMessage: "No scan reports yet",
-                    emptyStateDescription:
-                      "Upload a scan report to begin mapping your data.",
-                    emptyStateIcon: "filescan"
-                  }
-                : {})}
-            />
+            {scanReports.results.length > 0 ? (
+              <DataTable
+                columns={columns}
+                data={scanReports.results}
+                count={scanReports.count}
+                Filter={filter}
+                defaultPageSize={defaultPageSize}
+                initialColumnVisibility={initialColumnVisibility}
+              />
+            ) : (
+              <EmptyState
+                icon="filescan"
+                title="No scan reports yet"
+                description="Upload a scan report to begin mapping your data."
+              />
+            )}
           </TabsContent>
           <TabsContent value="archived">
-            <DataTable
-              columns={columns}
-              data={scanReports.results}
-              count={scanReports.count}
-              Filter={filter}
-              defaultPageSize={defaultPageSize}
-              initialColumnVisibility={initialColumnVisibility}
-              {...(scanReports.results.length === 0
-                ? {
-                    emptyStateMessage: "No archived reports",
-                    emptyStateDescription:
-                      "No archived scan reports found. Active reports will appear here when archived.",
-                    emptyStateIcon: "filescan"
-                  }
-                : {})}
-            />
+            {scanReports.results.length > 0 ? (
+              <DataTable
+                columns={columns}
+                data={scanReports.results}
+                count={scanReports.count}
+                Filter={filter}
+                defaultPageSize={defaultPageSize}
+                initialColumnVisibility={initialColumnVisibility}
+              />
+            ) : (
+              <EmptyState
+                icon="filescan"
+                title="No archived reports"
+                description="No archived scan reports found. Active reports will appear here when archived."
+              />
+            )}
           </TabsContent>
         </Tabs>
       </div>

--- a/app/next-client-app/app/(protected)/scanreports/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/page.tsx
@@ -15,7 +15,7 @@ interface ScanReportsProps {
 
 export const metadata: Metadata = {
   title: "Scan Reports | Carrot Mapper",
-  description: "Scan reports for the current user",
+  description: "Scan reports for the current user"
 };
 
 export default async function ScanReports(props: ScanReportsProps) {
@@ -23,7 +23,7 @@ export default async function ScanReports(props: ScanReportsProps) {
   const defaultPageSize = 30;
   const defaultParams = {
     hidden: false,
-    page_size: defaultPageSize,
+    page_size: defaultPageSize
   };
   const combinedParams = { ...defaultParams, ...searchParams };
 
@@ -33,7 +33,7 @@ export default async function ScanReports(props: ScanReportsProps) {
 
   // Define which columns should be hidden by default
   const initialColumnVisibility: VisibilityState = {
-    id: false,
+    id: false
   };
 
   return (
@@ -70,7 +70,7 @@ export default async function ScanReports(props: ScanReportsProps) {
               defaultPageSize={defaultPageSize}
               initialColumnVisibility={initialColumnVisibility}
               emptyStateMessage="No scan reports yet"
-              emptyStateDescription="Create a dataset first to generate scan reports, or upload an existing scan report."
+              emptyStateDescription="Upload a scan report to begin mapping your data."
               emptyStateIcon="filescan"
             />
           </TabsContent>

--- a/app/next-client-app/app/(protected)/scanreports/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/page.tsx
@@ -69,9 +69,14 @@ export default async function ScanReports(props: ScanReportsProps) {
               Filter={filter}
               defaultPageSize={defaultPageSize}
               initialColumnVisibility={initialColumnVisibility}
-              emptyStateMessage="No scan reports yet"
-              emptyStateDescription="Upload a scan report to begin mapping your data."
-              emptyStateIcon="filescan"
+              {...(scanReports.results.length === 0
+                ? {
+                    emptyStateMessage: "No scan reports yet",
+                    emptyStateDescription:
+                      "Upload a scan report to begin mapping your data.",
+                    emptyStateIcon: "filescan"
+                  }
+                : {})}
             />
           </TabsContent>
           <TabsContent value="archived">
@@ -82,9 +87,14 @@ export default async function ScanReports(props: ScanReportsProps) {
               Filter={filter}
               defaultPageSize={defaultPageSize}
               initialColumnVisibility={initialColumnVisibility}
-              emptyStateMessage="No archived reports"
-              emptyStateDescription="No archived scan reports found. Active reports will appear here when archived."
-              emptyStateIcon="filescan"
+              {...(scanReports.results.length === 0
+                ? {
+                    emptyStateMessage: "No archived reports",
+                    emptyStateDescription:
+                      "No archived scan reports found. Active reports will appear here when archived.",
+                    emptyStateIcon: "filescan"
+                  }
+                : {})}
             />
           </TabsContent>
         </Tabs>

--- a/app/next-client-app/app/(protected)/scanreports/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/page.tsx
@@ -15,7 +15,7 @@ interface ScanReportsProps {
 
 export const metadata: Metadata = {
   title: "Scan Reports | Carrot Mapper",
-  description: "Scan reports for the current user"
+  description: "Scan reports for the current user",
 };
 
 export default async function ScanReports(props: ScanReportsProps) {
@@ -23,7 +23,7 @@ export default async function ScanReports(props: ScanReportsProps) {
   const defaultPageSize = 30;
   const defaultParams = {
     hidden: false,
-    page_size: defaultPageSize
+    page_size: defaultPageSize,
   };
   const combinedParams = { ...defaultParams, ...searchParams };
 
@@ -33,7 +33,7 @@ export default async function ScanReports(props: ScanReportsProps) {
 
   // Define which columns should be hidden by default
   const initialColumnVisibility: VisibilityState = {
-    id: false
+    id: false,
   };
 
   return (

--- a/app/next-client-app/app/(protected)/scanreports/page.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/page.tsx
@@ -15,7 +15,7 @@ interface ScanReportsProps {
 
 export const metadata: Metadata = {
   title: "Scan Reports | Carrot Mapper",
-  description: "Scan reports for the current user",
+  description: "Scan reports for the current user"
 };
 
 export default async function ScanReports(props: ScanReportsProps) {
@@ -23,7 +23,7 @@ export default async function ScanReports(props: ScanReportsProps) {
   const defaultPageSize = 30;
   const defaultParams = {
     hidden: false,
-    page_size: defaultPageSize,
+    page_size: defaultPageSize
   };
   const combinedParams = { ...defaultParams, ...searchParams };
 
@@ -33,7 +33,7 @@ export default async function ScanReports(props: ScanReportsProps) {
 
   // Define which columns should be hidden by default
   const initialColumnVisibility: VisibilityState = {
-    id: false,
+    id: false
   };
 
   return (
@@ -69,6 +69,9 @@ export default async function ScanReports(props: ScanReportsProps) {
               Filter={filter}
               defaultPageSize={defaultPageSize}
               initialColumnVisibility={initialColumnVisibility}
+              emptyStateMessage="No scan reports yet"
+              emptyStateDescription="Create a dataset first to generate scan reports, or upload an existing scan report."
+              emptyStateIcon="filescan"
             />
           </TabsContent>
           <TabsContent value="archived">
@@ -79,6 +82,9 @@ export default async function ScanReports(props: ScanReportsProps) {
               Filter={filter}
               defaultPageSize={defaultPageSize}
               initialColumnVisibility={initialColumnVisibility}
+              emptyStateMessage="No archived reports"
+              emptyStateDescription="No archived scan reports found. Active reports will appear here when archived."
+              emptyStateIcon="filescan"
             />
           </TabsContent>
         </Tabs>

--- a/app/next-client-app/components/data-table/index.tsx
+++ b/app/next-client-app/components/data-table/index.tsx
@@ -6,7 +6,7 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
-  useReactTable,
+  useReactTable
 } from "@tanstack/react-table";
 
 import {
@@ -15,7 +15,7 @@ import {
   TableCell,
   TableHead,
   TableHeader,
-  TableRow,
+  TableRow
 } from "@/components/ui/table";
 import React from "react";
 import { Button } from "@/components/ui/button";
@@ -25,11 +25,10 @@ import {
   DropdownMenuContent,
   DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuTrigger,
+  DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
 import { DataTablePagination } from "./DataTablePagination";
 import { Columns3 } from "lucide-react";
-import { EmptyState } from "@/components/ui/empty-state";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -42,9 +41,6 @@ interface DataTableProps<TData, TValue> {
   RefreshButton?: JSX.Element;
   defaultPageSize?: 10 | 20 | 30 | 40 | 50;
   initialColumnVisibility?: VisibilityState;
-  emptyStateMessage?: string;
-  emptyStateDescription?: string;
-  emptyStateIcon?: "folders" | "database" | "filescan" | "circle-slash";
 }
 
 function UrlBuilder(id: string, prefix: string = "") {
@@ -60,10 +56,7 @@ export function DataTable<TData, TValue>({
   paginated = true,
   RefreshButton,
   defaultPageSize,
-  initialColumnVisibility,
-  emptyStateMessage,
-  emptyStateDescription,
-  emptyStateIcon,
+  initialColumnVisibility
 }: DataTableProps<TData, TValue>) {
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>(initialColumnVisibility || {});
@@ -78,8 +71,8 @@ export function DataTable<TData, TValue>({
     manualSorting: true,
     onColumnVisibilityChange: setColumnVisibility,
     state: {
-      columnVisibility,
-    },
+      columnVisibility
+    }
   });
 
   return (
@@ -155,9 +148,7 @@ export function DataTable<TData, TValue>({
                   className="transition-colors"
                 >
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell
-                      key={cell.id}
-                    >
+                    <TableCell key={cell.id}>
                       <div>
                         {flexRender(
                           cell.column.columnDef.cell,
@@ -174,15 +165,7 @@ export function DataTable<TData, TValue>({
                   colSpan={columns.length}
                   className="h-24 text-center"
                 >
-                  {emptyStateMessage ? (
-                    <EmptyState
-                      icon={emptyStateIcon}
-                      title={emptyStateMessage}
-                      description={emptyStateDescription || "No results."}
-                    />
-                  ) : (
-                    "No results."
-                  )}
+                  {/* No results message is now handled by individual pages */}
                 </TableCell>
               </TableRow>
             )}

--- a/app/next-client-app/components/data-table/index.tsx
+++ b/app/next-client-app/components/data-table/index.tsx
@@ -58,7 +58,6 @@ export function DataTable<TData, TValue>({
   Filter,
   viewColumns = true,
   paginated = true,
-  overflow = true,
   RefreshButton,
   defaultPageSize,
   initialColumnVisibility,

--- a/app/next-client-app/components/data-table/index.tsx
+++ b/app/next-client-app/components/data-table/index.tsx
@@ -165,7 +165,7 @@ export function DataTable<TData, TValue>({
                   colSpan={columns.length}
                   className="h-24 text-center"
                 >
-                  {/* No results message is now handled by individual pages */}
+                  No results.
                 </TableCell>
               </TableRow>
             )}

--- a/app/next-client-app/components/data-table/index.tsx
+++ b/app/next-client-app/components/data-table/index.tsx
@@ -44,7 +44,7 @@ interface DataTableProps<TData, TValue> {
   initialColumnVisibility?: VisibilityState;
   emptyStateMessage?: string;
   emptyStateDescription?: string;
-  emptyStateIcon?: "folders" | "database" | "filescan" | "plus";
+  emptyStateIcon?: "folders" | "database" | "filescan" | "circle-slash";
 }
 
 function UrlBuilder(id: string, prefix: string = "") {
@@ -64,7 +64,7 @@ export function DataTable<TData, TValue>({
   initialColumnVisibility,
   emptyStateMessage,
   emptyStateDescription,
-  emptyStateIcon,
+  emptyStateIcon
 }: DataTableProps<TData, TValue>) {
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>(initialColumnVisibility || {});
@@ -179,7 +179,9 @@ export function DataTable<TData, TValue>({
                       title={emptyStateMessage}
                       description={emptyStateDescription || "No results."}
                     />
-                  ) : null}
+                  ) : (
+                    "No results."
+                  )}
                 </TableCell>
               </TableRow>
             )}

--- a/app/next-client-app/components/data-table/index.tsx
+++ b/app/next-client-app/components/data-table/index.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { DataTablePagination } from "./DataTablePagination";
 import { Columns3 } from "lucide-react";
+import { EmptyState } from "@/components/ui/empty-state";
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[];
@@ -41,6 +42,9 @@ interface DataTableProps<TData, TValue> {
   RefreshButton?: JSX.Element;
   defaultPageSize?: 10 | 20 | 30 | 40 | 50;
   initialColumnVisibility?: VisibilityState;
+  emptyStateMessage?: string;
+  emptyStateDescription?: string;
+  emptyStateIcon?: "folders" | "database" | "filescan" | "plus";
 }
 
 function UrlBuilder(id: string, prefix: string = "") {
@@ -57,7 +61,10 @@ export function DataTable<TData, TValue>({
   overflow = true,
   RefreshButton,
   defaultPageSize,
-  initialColumnVisibility
+  initialColumnVisibility,
+  emptyStateMessage,
+  emptyStateDescription,
+  emptyStateIcon,
 }: DataTableProps<TData, TValue>) {
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>(initialColumnVisibility || {});
@@ -166,7 +173,13 @@ export function DataTable<TData, TValue>({
                   colSpan={columns.length}
                   className="h-24 text-center"
                 >
-                  No results.
+                  {emptyStateMessage ? (
+                    <EmptyState
+                      icon={emptyStateIcon}
+                      title={emptyStateMessage}
+                      description={emptyStateDescription || "No results."}
+                    />
+                  ) : null}
                 </TableCell>
               </TableRow>
             )}

--- a/app/next-client-app/components/recommendations/ai-suggestions-dialog.tsx
+++ b/app/next-client-app/components/recommendations/ai-suggestions-dialog.tsx
@@ -40,7 +40,7 @@ export default function AISuggestionDialog({
 }: AISuggestionDialogProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-(--breakpoint-xl) overflow-auto max-h-[80vh]">
+      <DialogContent className="max-w-screen-xl overflow-auto max-h-[80vh]">
         <DialogHeader>
           <DialogTitle className="text-xl text-center">
             AI Mapping Suggestions

--- a/app/next-client-app/components/ui/empty-state.tsx
+++ b/app/next-client-app/components/ui/empty-state.tsx
@@ -1,0 +1,43 @@
+import { LucideIcon, Plus, Folders, Database, FileScan } from "lucide-react";
+
+interface EmptyStateProps {
+  icon?: "folders" | "database" | "filescan" | "plus";
+  title: string;
+  description: string;
+}
+
+export function EmptyState({
+  icon = "plus",
+  title,
+  description
+}: EmptyStateProps) {
+  const getIcon = (iconName: string): LucideIcon => {
+    switch (iconName) {
+      case "folders":
+        return Folders;
+      case "database":
+        return Database;
+      case "filescan":
+        return FileScan;
+      case "plus":
+      default:
+        return Plus;
+    }
+  };
+
+  const IconComponent = getIcon(icon);
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center w-full max-w-none">
+      <div className="mb-4 text-gray-400 flex justify-center">
+        <IconComponent className="h-16 w-16" />
+      </div>
+      <h3 className="mb-2 text-lg font-semibold text-gray-200 text-center w-full">
+        {title}
+      </h3>
+      <p className="mb-6 max-w-sm text-sm text-gray-400 text-center leading-relaxed mx-auto">
+        {description}
+      </p>
+    </div>
+  );
+}

--- a/app/next-client-app/components/ui/empty-state.tsx
+++ b/app/next-client-app/components/ui/empty-state.tsx
@@ -1,13 +1,19 @@
-import { LucideIcon, Plus, Folders, Database, FileScan } from "lucide-react";
+import {
+  LucideIcon,
+  CircleSlash,
+  Folders,
+  Database,
+  FileScan
+} from "lucide-react";
 
 interface EmptyStateProps {
-  icon?: "folders" | "database" | "filescan" | "plus";
+  icon?: "folders" | "database" | "filescan" | "circle-slash";
   title: string;
   description: string;
 }
 
 export function EmptyState({
-  icon = "plus",
+  icon = "circle-slash",
   title,
   description
 }: EmptyStateProps) {
@@ -19,9 +25,9 @@ export function EmptyState({
         return Database;
       case "filescan":
         return FileScan;
-      case "plus":
+      case "circle-slash":
       default:
-        return Plus;
+        return CircleSlash;
     }
   };
 
@@ -29,13 +35,13 @@ export function EmptyState({
 
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center w-full max-w-none">
-      <div className="mb-4 text-gray-400 flex justify-center">
+      <div className="mb-4 text-gray-600 dark:text-gray-400 flex justify-center">
         <IconComponent className="h-16 w-16" />
       </div>
-      <h3 className="mb-2 text-lg font-semibold text-gray-200 text-center w-full">
+      <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-gray-200 text-center w-full">
         {title}
       </h3>
-      <p className="mb-6 max-w-sm text-sm text-gray-400 text-center leading-relaxed mx-auto">
+      <p className="mb-6 text-sm text-gray-600 dark:text-gray-400 text-center leading-relaxed mx-auto">
         {description}
       </p>
     </div>

--- a/app/next-client-app/components/ui/empty-state.tsx
+++ b/app/next-client-app/components/ui/empty-state.tsx
@@ -34,7 +34,7 @@ export function EmptyState({
   const IconComponent = getIcon(icon);
 
   return (
-    <div className="flex flex-col items-center justify-center py-12 text-center w-full max-w-none">
+    <div className="flex flex-col items-center justify-center py-12 text-center w-full max-w-none border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900/50 transition-all duration-200 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800/50 hover:shadow-sm">
       <div className="mb-4 text-gray-600 dark:text-gray-400 flex justify-center">
         <IconComponent className="h-16 w-16" />
       </div>


### PR DESCRIPTION
⚡️ Optimization
## PR Description
Enhanced the DataTable component to show beautiful, contextual empty states instead of generic "No results" messages. Projects now display "Contact your administrator to be added to a project" with a folders icon, datasets show "Create your first dataset to start organizing and mapping your data" with a database icon, and scan reports guide users with "Create a dataset first to generate scan reports, or upload an existing scan report to begin mapping your data" with a filescan icon. Users now see helpful, contextual guidance instead of generic "No results" messages, creating a much better onboarding experience that directs them to the appropriate next steps with visually appealing and informative empty states.

## Related Issues or other material
Related #1171
Closes #1171

## Screenshots, example outputs/behaviour etc.
<img width="1911" height="960" alt="Screenshot 2025-08-11 at 15 13 43" src="https://github.com/user-attachments/assets/a7f83d55-3c28-41f8-acf6-57e4736e41c1" />
<img width="1911" height="960" alt="Screenshot 2025-08-11 at 15 13 50" src="https://github.com/user-attachments/assets/3e83dd7b-f793-4138-a5be-4ecb0d031c4f" />
<img width="1911" height="960" alt="Screenshot 2025-08-11 at 15 13 59" src="https://github.com/user-attachments/assets/0adf3fda-69d5-46c6-986b-6895c2ad8cfe" />
