### PR TITLE
Fix downloads

### DIFF
--- a/app/next-client-app/api/files.ts
+++ b/app/next-client-app/api/files.ts
@@ -16,11 +16,11 @@ const fetchKeys = {
 
 export async function list(
   scan_report_id: number,
-  filter: string | undefined
+  filter: string | undefined,
 ): Promise<PaginatedResponse<FileDownload> | null> {
   try {
     return await request<PaginatedResponse<FileDownload>>(
-      fetchKeys.list(scan_report_id, filter)
+      fetchKeys.list(scan_report_id, filter),
     );
   } catch (error) {
     return null;
@@ -29,7 +29,7 @@ export async function list(
 
 export async function requestFile(
   scan_report_id: number,
-  file_type: FileTypeFormat
+  file_type: FileTypeFormat,
 ): Promise<{ success: boolean; errorMessage?: string }> {
   try {
     await request(fetchKeys.requestFile(scan_report_id), {
@@ -51,16 +51,17 @@ export async function requestFile(
 
 export async function downloadFile(
   scan_report_id: number,
-  file_id?: number
+  file_id?: number,
 ): Promise<{
   success: boolean;
   errorMessage?: string;
   data?: any;
   blob?: Blob;
+  downloadUrl?: string;
 }> {
   try {
     if (!file_id) {
-      // The case of SR exporting
+      // The case of SR exporting - keep existing logic for now
       const response = await request(fetchKeys.downloadFile(scan_report_id), {
         download: true,
       });
@@ -70,13 +71,9 @@ export async function downloadFile(
 
       return { success: true, data: base64String };
     } else {
-      // The case of mapping rules file downloading - use streaming for all file types
-      const response = await request(
-        fetchKeys.downloadFile(scan_report_id, file_id),
-        { download: true }
-      );
-      // Return the blob directly
-      return { success: true, blob: response as Blob };
+      // The case of mapping rules file downloading - use streaming API route
+      const downloadUrl = `/api/download/${scan_report_id}/${file_id}`;
+      return { success: true, downloadUrl };
     }
   } catch (error: any) {
     return { success: false, errorMessage: error.message };

--- a/app/next-client-app/app/(protected)/scanreports/[id]/downloads/columns.tsx
+++ b/app/next-client-app/app/(protected)/scanreports/[id]/downloads/columns.tsx
@@ -26,7 +26,7 @@ export const columns: ColumnDef<FileDownload>[] = [
       return format(created_at, "d MMM HH:mm");
     },
     enableHiding: true,
-    enableSorting: true
+    enableSorting: true,
   },
   {
     id: "User",
@@ -43,7 +43,7 @@ export const columns: ColumnDef<FileDownload>[] = [
       return <>{user.username}</>;
     },
     enableHiding: true,
-    enableSorting: false
+    enableSorting: false,
   },
   {
     id: "Type",
@@ -60,7 +60,7 @@ export const columns: ColumnDef<FileDownload>[] = [
       return <Badge variant="outline">{file_type.display_name}</Badge>;
     },
     enableHiding: true,
-    enableSorting: false
+    enableSorting: false,
   },
   {
     id: "Download",
@@ -69,12 +69,15 @@ export const columns: ColumnDef<FileDownload>[] = [
       const { id, scan_report, name } = row.original;
       const handleDownload = async () => {
         const response = await downloadFile(scan_report, id);
-        if (response.success && response.blob) {
-          // Use the blob directly
+        if (response.success && response.downloadUrl) {
+          // Use the streaming download URL
+          window.open(response.downloadUrl, "_blank");
+        } else if (response.success && response.blob) {
+          // Fallback for SR exporting (blob approach)
           saveAs(response.blob, name);
         } else {
           toast.error(
-            `Error downloading file: ${(response.errorMessage as any).message}`
+            `Error downloading file: ${response.errorMessage || "Unknown error"}`,
           );
         }
       };
@@ -85,6 +88,6 @@ export const columns: ColumnDef<FileDownload>[] = [
       );
     },
     enableHiding: true,
-    enableSorting: false
-  }
+    enableSorting: false,
+  },
 ];

--- a/app/next-client-app/app/api/download/[scan_report_id]/[file_id]/route.ts
+++ b/app/next-client-app/app/api/download/[scan_report_id]/[file_id]/route.ts
@@ -1,0 +1,82 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { options as authOptions } from "@/auth/options";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { scan_report_id: string; file_id: string } },
+) {
+  try {
+    const { scan_report_id, file_id } = params;
+
+    // Get the session for authentication
+    const session = await getServerSession(authOptions);
+    const token = session?.access_token;
+
+    if (!token) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Construct the Django backend URL
+    const backendUrl = `${process.env.BACKEND_URL}/api/v2/scanreports/${scan_report_id}/rules/downloads/${file_id}/`;
+
+    // Forward the request to Django backend
+    const backendResponse = await fetch(backendUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `JWT ${token}`,
+        // Forward any relevant headers from the original request
+        ...(request.headers.get("user-agent") && {
+          "User-Agent": request.headers.get("user-agent")!,
+        }),
+      },
+    });
+
+    // If the backend request failed, return the same status
+    if (!backendResponse.ok) {
+      return new NextResponse(backendResponse.body, {
+        status: backendResponse.status,
+        statusText: backendResponse.statusText,
+      });
+    }
+
+    // Get the content type and disposition from the backend response
+    const contentType = backendResponse.headers.get("content-type");
+    const contentDisposition = backendResponse.headers.get(
+      "content-disposition",
+    );
+    const contentLength = backendResponse.headers.get("content-length");
+
+    // Create headers for the Next.js response
+    const responseHeaders = new Headers();
+
+    if (contentType) {
+      responseHeaders.set("content-type", contentType);
+    }
+
+    if (contentDisposition) {
+      responseHeaders.set("content-disposition", contentDisposition);
+    }
+
+    if (contentLength) {
+      responseHeaders.set("content-length", contentLength);
+    }
+
+    // Set cache headers to prevent caching of file downloads
+    responseHeaders.set("cache-control", "no-cache, no-store, must-revalidate");
+    responseHeaders.set("pragma", "no-cache");
+    responseHeaders.set("expires", "0");
+
+    // Stream the response body directly to the client
+    return new NextResponse(backendResponse.body, {
+      status: 200,
+      headers: responseHeaders,
+    });
+  } catch (error) {
+    console.error("Error in download proxy:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
- Add streaming API route at /api/download/[scan_report_id]/[file_id] that proxies Django backend
- Update downloadFile function to return downloadUrl for mapping rules files
- Modify download button to use window.open() for streaming downloads
- Preserve existing blob-based approach for SR exports
- Include proper authentication, error handling, and cache headers
- Fixes large file download failures caused by memory buffering

| <!-- # Delete content types that don't apply to your pull request -->|
|-|
🦋 Bug Fix

## PR Description


## Related Issues or other material
Related #
Closes #

## Screenshots, example outputs/behaviour etc.

## ✅ Added/updated tests?
- [] This PR contains relevant tests / Or doesn't need to per the below explanation

## [optional] What gif best describes this PR or how it makes you feel?
![alt_text](gif_link)
