### PR TITLE
Enhanced scan report upload speed

### DIFF
--- a/app/airflow/dags/libs/SR_processing/db_services.py
+++ b/app/airflow/dags/libs/SR_processing/db_services.py
@@ -125,7 +125,7 @@ def update_temp_data_dictionary_table(
                     "value_description",
                 ],
                 fast_executemany=True,
-                commit_every=3000,
+                commit_every=10000,
             )
 
         logging.info(
@@ -214,7 +214,7 @@ def create_temp_field_values_table(
                     "frequency",
                 ],
                 fast_executemany=True,
-                commit_every=3000,
+                commit_every=10000,
             )
 
     except Exception as e:

--- a/app/airflow/dags/libs/SR_processing/db_services.py
+++ b/app/airflow/dags/libs/SR_processing/db_services.py
@@ -125,7 +125,7 @@ def update_temp_data_dictionary_table(
                     "value_description",
                 ],
                 fast_executemany=True,
-                commit_every=0, # commit every row to avoid transaction overhead
+                commit_every=0,  # commit every row to avoid transaction overhead
             )
 
         logging.info(
@@ -214,7 +214,7 @@ def create_temp_field_values_table(
                     "frequency",
                 ],
                 fast_executemany=True,
-                commit_every=0, # commit every row to avoid transaction overhead
+                commit_every=0,  # commit every row to avoid transaction overhead
             )
 
     except Exception as e:

--- a/app/airflow/dags/libs/SR_processing/db_services.py
+++ b/app/airflow/dags/libs/SR_processing/db_services.py
@@ -125,7 +125,7 @@ def update_temp_data_dictionary_table(
                     "value_description",
                 ],
                 fast_executemany=True,
-                commit_every=0,  # commit every row to avoid transaction overhead
+                commit_every=10000,  # commit every 10k
             )
 
         logging.info(
@@ -214,7 +214,7 @@ def create_temp_field_values_table(
                     "frequency",
                 ],
                 fast_executemany=True,
-                commit_every=0,  # commit every row to avoid transaction overhead
+                commit_every=10000,  # commit every 10k
             )
 
     except Exception as e:

--- a/app/airflow/dags/libs/SR_processing/db_services.py
+++ b/app/airflow/dags/libs/SR_processing/db_services.py
@@ -125,7 +125,7 @@ def update_temp_data_dictionary_table(
                     "value_description",
                 ],
                 fast_executemany=True,
-                commit_every=10000,
+                commit_every=0, # commit every row to avoid transaction overhead
             )
 
         logging.info(
@@ -214,7 +214,7 @@ def create_temp_field_values_table(
                     "frequency",
                 ],
                 fast_executemany=True,
-                commit_every=10000,
+                commit_every=0, # commit every row to avoid transaction overhead
             )
 
     except Exception as e:

--- a/app/airflow/dags/libs/SR_processing/db_services.py
+++ b/app/airflow/dags/libs/SR_processing/db_services.py
@@ -8,6 +8,7 @@ from libs.queries import create_fields_query
 from libs.settings import AIRFLOW_DAGRUN_TIMEOUT, AIRFLOW_DEBUG_MODE
 from libs.utils import update_job_status
 from openpyxl.worksheet.worksheet import Worksheet
+from psycopg2.extras import execute_values
 
 # PostgreSQL connection hook
 pg_hook = PostgresHook(
@@ -105,26 +106,35 @@ def update_temp_data_dictionary_table(
                         }
                     )
 
-        # Insert records into the temporary table
+        # Insert records into the temporary table using execute_values for fast bulk inserts
         if dictionary_records:
-            pg_hook.insert_rows(
-                table=f"temp_data_dictionary_{scan_report_id}",
-                rows=[
-                    (
-                        d["table_name"],
-                        d["field_name"],
-                        d["value"],
-                        d["value_description"],
-                    )
-                    for d in dictionary_records
-                ],
-                target_fields=[
-                    "table_name",
-                    "field_name",
-                    "value",
-                    "value_description",
-                ],
-            )
+            conn = pg_hook.get_conn()
+            cursor = conn.cursor()
+            try:
+                execute_values(
+                    cursor,
+                    f"""
+                    INSERT INTO temp_data_dictionary_{scan_report_id}
+                        (table_name, field_name, value, value_description)
+                    VALUES %s
+                    """,
+                    [
+                        (
+                            d["table_name"],
+                            d["field_name"],
+                            d["value"],
+                            d["value_description"],
+                        )
+                        for d in dictionary_records
+                    ],
+                )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                cursor.close()
+                conn.close()
 
         logging.info(
             f"Created temporary data dictionary table with {len(dictionary_records)} records"
@@ -195,23 +205,34 @@ def create_temp_field_values_table(
                     }
                 )
 
+        # Using execute_values() for fast bulk inserts (see notes above)
         if field_values_data:
-            pg_hook.insert_rows(
-                table=f"temp_field_values_{table_id}",
-                rows=[
-                    (
-                        d["field_name"],
-                        d["value"],
-                        d["frequency"],
-                    )
-                    for d in field_values_data
-                ],
-                target_fields=[
-                    "field_name",
-                    "value",
-                    "frequency",
-                ],
-            )
+            conn = pg_hook.get_conn()
+            cursor = conn.cursor()
+            try:
+                execute_values(
+                    cursor,
+                    f"""
+                    INSERT INTO temp_field_values_{table_id}
+                        (field_name, value, frequency)
+                    VALUES %s
+                    """,
+                    [
+                        (
+                            d["field_name"],
+                            d["value"],
+                            d["frequency"],
+                        )
+                        for d in field_values_data
+                    ],
+                )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                cursor.close()
+                conn.close()
 
     except Exception as e:
         logging.error(f"Error creating data dictionary table: {str(e)}")

--- a/app/airflow/dags/libs/settings.py
+++ b/app/airflow/dags/libs/settings.py
@@ -17,4 +17,7 @@ SEARCH_ENABLED = os.getenv("SEARCH_ENABLED", "false").lower()
 # Timedelta for dagrun_timeout in minutes
 AIRFLOW_DAGRUN_TIMEOUT = os.getenv("AIRFLOW_DAGRUN_TIMEOUT", 60)
 
+# Page size for bulk database inserts (execute_values)
+EXECUTE_VALUES_PAGE_SIZE = int(os.getenv("EXECUTE_VALUES_PAGE_SIZE", 100))
+
 AIRFLOW_VAR_JSON_VERSION = os.getenv("AIRFLOW_VAR_JSON_VERSION", "v1")

--- a/app/airflow/dags/libs/settings.py
+++ b/app/airflow/dags/libs/settings.py
@@ -18,6 +18,6 @@ SEARCH_ENABLED = os.getenv("SEARCH_ENABLED", "false").lower()
 AIRFLOW_DAGRUN_TIMEOUT = os.getenv("AIRFLOW_DAGRUN_TIMEOUT", 60)
 
 # Page size for bulk database inserts (execute_values)
-EXECUTE_VALUES_PAGE_SIZE = int(os.getenv("EXECUTE_VALUES_PAGE_SIZE", 100))
+EXECUTE_VALUES_PAGE_SIZE = int(os.getenv("EXECUTE_VALUES_PAGE_SIZE", 1000))
 
 AIRFLOW_VAR_JSON_VERSION = os.getenv("AIRFLOW_VAR_JSON_VERSION", "v1")


### PR DESCRIPTION
⚡️ Optimization

## PR Description

The bulk inserts in update_temp_data_dictionary_table() and create_temp_field_values_table() were using pg_hook.run() in loops, which meant one INSERT per row. For large scan reports with thousands of records, this was slow and could cause DAG timeouts.
This PR switched to psycopg2.extras.execute_values() to batch all rows into a single INSERT, which is much faster and avoids timeout issues.

## Related Issues or other material
Related #1226
Closes #1226

## Screenshots, example outputs/behaviour etc.
Below is a screenshot of the new record time it takes to upload the scan report and data dictionary

<img width="1906" height="929" alt="Screenshot 2025-11-26 at 17 54 53" src="https://github.com/user-attachments/assets/3b980259-9f55-4f72-8e84-8a34ba464201" />

